### PR TITLE
Disable highlighting when agent is working or thinking

### DIFF
--- a/src/components/views/MainView.ts
+++ b/src/components/views/MainView.ts
@@ -221,8 +221,12 @@ export default function MainView(props: Props) {
       let highlightIndex = -1;
       let highlightColor: any = undefined;
       
+      // Skip all highlighting if agent is working or thinking
+      if (cs.includes('working') || cs.includes('thinking')) {
+        // Agent is busy - nothing is actionable, so no highlighting
+      }
       // PRIORITY 1: Claude waiting for input (highest priority - blocks all work)
-      if (cs.includes('waiting')) {
+      else if (cs.includes('waiting')) {
         highlightIndex = COLUMNS.AI;
         highlightColor = COLORS.YELLOW;
         // claude-waiting


### PR DESCRIPTION
## Summary
- Prevents cells from appearing actionable while the agent is actively processing tasks
- Ensures UI accurately reflects when user actions are actually possible
- Fixes visual inconsistency where highlighted items suggested available actions during agent busy states

## Test plan
- [ ] Verify no cells are highlighted when agent status is 'working'
- [ ] Verify no cells are highlighted when agent status is 'thinking' 
- [ ] Confirm normal highlighting still works for other states (waiting, idle, etc.)

🤖 Generated with [Claude Code](https://claude.ai/code)