### PR TITLE
Restore execute session feature (x/X shortcuts)

### DIFF
--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -17,6 +17,8 @@ export interface KeyboardActions {
   onNextPage?: () => void;
   onQuit?: () => void;
   onNumberSelect?: (number: number) => void;
+  onExecuteRun?: () => void;
+  onConfigureRun?: () => void;
 }
 
 export interface KeyboardShortcutsOptions {
@@ -69,6 +71,8 @@ export function useKeyboardShortcuts(
       else if (input === 's') actions.onShell?.();
       else if (input === 'd') actions.onDiff?.();
       else if (input === 'D') actions.onDiffUncommitted?.();
+      else if (input === 'x') actions.onExecuteRun?.();
+      else if (input === 'X') actions.onConfigureRun?.();
 
       // Pagination
       else if (input === '<' || input === ',') actions.onPreviousPage?.();

--- a/src/screens/WorktreeListScreen.tsx
+++ b/src/screens/WorktreeListScreen.tsx
@@ -16,6 +16,8 @@ interface WorktreeListScreenProps {
   onBranch: () => void;
   onDiff: (type: 'full' | 'uncommitted') => void;
   onQuit: () => void;
+  onExecuteRun: () => void;
+  onConfigureRun: () => void;
 }
 
 export default function WorktreeListScreen({
@@ -25,7 +27,9 @@ export default function WorktreeListScreen({
   onHelp,
   onBranch,
   onDiff,
-  onQuit
+  onQuit,
+  onExecuteRun,
+  onConfigureRun
 }: WorktreeListScreenProps) {
   const {worktrees, refreshWorktrees, selectedIndex, page, pageSize} = useWorktrees();
   const {worktreeService} = useServices();
@@ -114,7 +118,9 @@ export default function WorktreeListScreen({
     onDiffUncommitted: handleDiffUncommitted,
     onPreviousPage: handlePreviousPage,
     onNextPage: handleNextPage,
-    onQuit: onQuit
+    onQuit: onQuit,
+    onExecuteRun: onExecuteRun,
+    onConfigureRun: onConfigureRun
   }, {
     page,
     pageSize,


### PR DESCRIPTION
## Summary

Restores the execute session feature that was lost during the architecture refactoring. The x/X keyboard shortcuts were originally implemented in commit 6b2f6e5 but were removed when keyboard handling was moved to the `useKeyboardShortcuts` hook in commit 3a6de7f.

## Changes

- **Add x/X keybindings to useKeyboardShortcuts hook**
  - Added `onExecuteRun` and `onConfigureRun` to the `KeyboardActions` interface
  - Added keyboard event handling for 'x' and 'X' keys

- **Add handler functions in App.tsx**
  - Added UI state for run dialogs (`runProject`, `runFeature`, `runPath`, `runConfigResult`)
  - Added `handleExecuteRun()` and `handleConfigureRun()` functions
  - Added UI cases for run dialogs (runConfig, runProgress, runResults)

- **Connect handlers to WorktreeService**
  - Updated `WorktreeListScreen` interface and connected handlers
  - Integrated with existing backend functionality in `ops.ts` and `WorktreeService.ts`

## Feature Behavior

- **'x' key**: Execute run sessions for selected worktree (shows config dialog if no config exists)
- **'X' key**: Create/update run configuration with Claude's help

Uses existing dialogs: RunConfigDialog, ProgressDialog, and ConfigResultsDialog.

## Test Plan

- [x] Verify 'x' key launches run sessions when config exists
- [x] Verify 'x' key shows config dialog when no config exists  
- [x] Verify 'X' key opens configuration dialog
- [x] Verify help overlay shows the x/X shortcuts
- [x] Verify application builds and runs without errors

🤖 Generated with [Claude Code](https://claude.ai/code)