### PR TITLE
Fix TypeScript build configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "scripts": {
     "build": "tsc -p .",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsc -p tsconfig.test.json",
     "start": "node dist/index.js",
     "cli": "node dist/bin/dev-sessions.js",
     "test": "jest",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,8 +12,8 @@
     "jsx": "react-jsx",
     "isolatedModules": true,
     "outDir": "dist",
-    "rootDir": "."
+    "rootDir": "src"
   },
-  "include": ["src/**/*", "tests/**/*"],
+  "include": ["src/**/*"],
   "exclude": ["src/**/*_old.ts", "src/**/*_old.tsx", "dist/**/*"]
 }

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "noEmit": true
+  },
+  "include": ["src/**/*", "tests/**/*"],
+  "exclude": ["src/**/*_old.ts", "src/**/*_old.tsx", "dist/**/*"]
+}


### PR DESCRIPTION
## Summary
- Fixed broken build by correcting TypeScript configuration
- Resolved issue where test files were being compiled into dist folder
- Separated build and test type checking configurations

## Changes Made
1. **Updated tsconfig.json**
   - Changed `rootDir` from `"."` to `"src"` to prevent test files appearing in dist
   - Removed `"tests/**/*"` from include array (only source files should be compiled)

2. **Created tsconfig.test.json** 
   - Separate config for type checking both source and test files
   - Uses `noEmit: true` since it's only for type checking

3. **Updated package.json**
   - Modified `typecheck` script to use `tsconfig.test.json`
   - This ensures tests are still type-checked without polluting the build

## Test Plan
- [x] Run `npm run build` - builds successfully
- [x] Run `npm run typecheck` - type checking passes
- [x] Run `npm test` - all tests pass (61 passing)
- [x] Run `npm run cli` - CLI command works correctly
- [x] Verify dist folder contains only production code (no test files)

## Before/After
**Before:** `dist/` folder contained both source and test files
**After:** `dist/` folder contains only production code

🤖 Generated with [Claude Code](https://claude.ai/code)