### PR TITLE
Use symlinks for .claude directory instead of copying files

### DIFF
--- a/src/ops.ts
+++ b/src/ops.ts
@@ -231,11 +231,16 @@ export function createFeature(projectName: string, featureName: string) {
     ensureDirectory(path.dirname(envDst));
     fs.copyFileSync(envSrc, envDst);
   }
-  const claudeSrc = path.join(projectPath, CLAUDE_SETTINGS_FILE);
-  const claudeDst = path.join(worktreePath, CLAUDE_SETTINGS_FILE);
-  if (fs.existsSync(claudeSrc)) {
-    ensureDirectory(path.dirname(claudeDst));
-    fs.copyFileSync(claudeSrc, claudeDst);
+  // Create symlink to .claude directory instead of copying
+  const claudeDirSrc = path.join(projectPath, '.claude');
+  const claudeDirDst = path.join(worktreePath, '.claude');
+  if (fs.existsSync(claudeDirSrc)) {
+    // Remove existing .claude if it exists (in case it was previously copied)
+    if (fs.existsSync(claudeDirDst)) {
+      fs.rmSync(claudeDirDst, { recursive: true, force: true });
+    }
+    // Create symlink to the original .claude directory
+    fs.symlinkSync(claudeDirSrc, claudeDirDst, 'dir');
   }
   // Copy common Claude config files if present
   const claudeDoc = path.join(projectPath, 'CLAUDE.md');
@@ -253,11 +258,16 @@ export function setupWorktreeEnvironment(projectName: string, worktreePath: stri
     ensureDirectory(path.dirname(envDst));
     fs.copyFileSync(envSrc, envDst);
   }
-  const claudeSrc = path.join(projectPath, CLAUDE_SETTINGS_FILE);
-  const claudeDst = path.join(worktreePath, CLAUDE_SETTINGS_FILE);
-  if (fs.existsSync(claudeSrc)) {
-    ensureDirectory(path.dirname(claudeDst));
-    fs.copyFileSync(claudeSrc, claudeDst);
+  // Create symlink to .claude directory instead of copying
+  const claudeDirSrc = path.join(projectPath, '.claude');
+  const claudeDirDst = path.join(worktreePath, '.claude');
+  if (fs.existsSync(claudeDirSrc)) {
+    // Remove existing .claude if it exists (in case it was previously copied)
+    if (fs.existsSync(claudeDirDst)) {
+      fs.rmSync(claudeDirDst, { recursive: true, force: true });
+    }
+    // Create symlink to the original .claude directory
+    fs.symlinkSync(claudeDirSrc, claudeDirDst, 'dir');
   }
   const claudeDoc = path.join(projectPath, 'CLAUDE.md');
   if (fs.existsSync(claudeDoc)) fs.copyFileSync(claudeDoc, path.join(worktreePath, 'CLAUDE.md'));

--- a/src/screens/ArchiveConfirmScreen.tsx
+++ b/src/screens/ArchiveConfirmScreen.tsx
@@ -1,4 +1,4 @@
-import React, {useState, useEffect} from 'react';
+import React from 'react';
 import {Box, Text, useInput, useStdin} from 'ink';
 import FullScreen from '../components/common/FullScreen.js';
 import {useServices} from '../contexts/ServicesContext.js';
@@ -24,25 +24,9 @@ export default function ArchiveConfirmScreen({
 }: ArchiveConfirmScreenProps) {
   const {worktreeService} = useServices();
   const {isRawModeSupported} = useStdin();
-  const [mergeSettings, setMergeSettings] = useState(true);
-  const [newPermissions, setNewPermissions] = useState<string[] | null>(null);
-  
-  // Check for Claude settings on mount
-  useEffect(() => {
-    const permissions = worktreeService.getClaudeSettingsToMerge(
-      featureInfo.project,
-      featureInfo.path
-    );
-    setNewPermissions(permissions);
-  }, [featureInfo, worktreeService]);
 
   const handleConfirm = () => {
     try {
-      // Merge Claude settings if requested and available
-      if (mergeSettings && newPermissions) {
-        worktreeService.mergeClaudeSettings(featureInfo.project, featureInfo.path);
-      }
-      
       // Archive the feature
       worktreeService.archiveFeature(
         featureInfo.project,
@@ -63,8 +47,6 @@ export default function ArchiveConfirmScreen({
       onCancel();
     } else if (key.return || input === 'y') {
       handleConfirm();
-    } else if (input === 'm' && newPermissions) {
-      setMergeSettings(!mergeSettings);
     }
   });
 
@@ -75,21 +57,6 @@ export default function ArchiveConfirmScreen({
         h(Box, {marginTop: 1},
           h(Text, null, `Archive ${featureInfo.project}/${featureInfo.feature}?`)
         ),
-        
-        newPermissions && newPermissions.length > 0 && h(Box, {flexDirection: 'column', marginTop: 1},
-          h(Text, {color: 'yellow'}, `Found ${newPermissions.length} Claude permission${newPermissions.length > 1 ? 's' : ''} to merge:`),
-          h(Box, {flexDirection: 'column', marginLeft: 2},
-            ...newPermissions.slice(0, 5).map((perm, i) => 
-              h(Text, {key: i, color: 'green'}, `+ ${perm}`)
-            ),
-            newPermissions.length > 5 && h(Text, {color: 'gray'}, `  ... and ${newPermissions.length - 5} more`)
-          ),
-          h(Box, {marginTop: 1},
-            h(Text, {color: mergeSettings ? 'green' : 'gray'}, 
-              `[${mergeSettings ? '✓' : ' '}] Merge permissions (press 'm' to toggle)`)
-          )
-        ),
-        
         h(Box, {marginTop: 1},
           h(Text, {color: 'gray'}, 'Press y to confirm, n to cancel')
         )


### PR DESCRIPTION
## Summary
- Replace file copying with directory symlinks for .claude settings
- Remove settings merge functionality on archive since symlinks share the same settings
- Simplify ArchiveConfirmScreen by removing merge UI and logic

## Changes
- Updated `ops.ts` and `WorktreeService.ts` to create symlinks to `.claude` directory instead of copying individual files
- Removed `getClaudeSettingsToMerge` and `mergeClaudeSettings` methods from WorktreeService
- Simplified ArchiveConfirmScreen by removing merge-related state and UI components

## Benefits
- Settings are now shared across all worktrees via symlinks
- No need to merge settings on archive since they're already synchronized
- Cleaner, simpler codebase with fewer moving parts

## Test plan
- [x] Build passes without errors
- [x] All existing tests pass
- [x] TypeScript compilation succeeds

🤖 Generated with [Claude Code](https://claude.ai/code)