### PR TITLE
Remove conditional raw mode support and exit immediately when unsupported

### DIFF
--- a/.claude
+++ b/.claude
@@ -1,0 +1,1 @@
+/home/mserv/projects/coding-agent-team/.claude

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -49,11 +49,10 @@ function AppContent() {
   const [runPath, setRunPath] = useState<string | null>(null);
   const [runConfigResult, setRunConfigResult] = useState<any | null>(null);
 
-  // Auto-exit for non-interactive environments
+  // Exit immediately if raw mode isn't supported
   useEffect(() => {
     if (!isRawModeSupported) {
-      const id = setTimeout(() => exit(), 800);
-      return () => clearTimeout(id);
+      exit();
     }
   }, [isRawModeSupported, exit]);
 

--- a/src/components/dialogs/BranchPickerDialog.ts
+++ b/src/components/dialogs/BranchPickerDialog.ts
@@ -31,7 +31,6 @@ export default function BranchPickerDialog({branches, onSubmit, onCancel, onRefr
   const [selected, setSelected] = useState(0);
   const [page, setPage] = useState(0);
   const [pageSize, setPageSize] = useState(Math.max(1, (process.stdout.rows || 24) - 6));
-  const {isRawModeSupported} = useStdin();
   const filtered = useMemo(() => {
     const f = filterInput.value.toLowerCase();
     const arr = branches.filter(b => (b.name + ' ' + b.local_name + ' ' + (b.pr_title || '')).toLowerCase().includes(f));
@@ -45,7 +44,6 @@ export default function BranchPickerDialog({branches, onSubmit, onCancel, onRefr
   }, []);
 
   useInput((input, key) => {
-    if (!isRawModeSupported) return;
     if (key.escape) return onCancel();
     
     // Handle control keys first

--- a/src/components/dialogs/ConfigResultsDialog.ts
+++ b/src/components/dialogs/ConfigResultsDialog.ts
@@ -11,10 +11,7 @@ type Props = {
 };
 
 export default function ConfigResultsDialog({success, content, configPath, error, onClose}: Props) {
-  const {isRawModeSupported} = useStdin();
-  
   useInput((input, key) => {
-    if (!isRawModeSupported) return;
     // Any key closes the dialog
     onClose();
   });

--- a/src/components/dialogs/ConfirmDialog.ts
+++ b/src/components/dialogs/ConfirmDialog.ts
@@ -12,9 +12,7 @@ type Props = {
 };
 
 export default function ConfirmDialog({title, message, confirmKey = 'y', cancelKey = 'n', onConfirm, onCancel}: Props) {
-  const {isRawModeSupported} = useStdin();
   useInput((input, key) => {
-    if (!isRawModeSupported) return;
     if (key.escape || input === cancelKey) onCancel();
     if (key.return || input === confirmKey) onConfirm();
   });

--- a/src/components/dialogs/CreateFeatureDialog.ts
+++ b/src/components/dialogs/CreateFeatureDialog.ts
@@ -16,7 +16,6 @@ export default function CreateFeatureDialog({projects, defaultProject, onSubmit,
   const [mode, setMode] = useState<'select'|'input'|'creating'>('select');
   const [filter, setFilter] = useState('');
   const [selected, setSelected] = useState(() => Math.max(0, projects.findIndex(p => p.name === defaultProject)));
-  const {isRawModeSupported} = useStdin();
   const featureInput = useTextInput();
 
   const filtered = useMemo(() => {
@@ -25,7 +24,6 @@ export default function CreateFeatureDialog({projects, defaultProject, onSubmit,
   }, [projects, filter]);
 
   useInput((input, key) => {
-    if (!isRawModeSupported) return;
     if (mode === 'creating') return; // Disable input during creation
     if (key.escape) {
       if (mode === 'input') setMode('select');

--- a/src/components/dialogs/HelpOverlay.ts
+++ b/src/components/dialogs/HelpOverlay.ts
@@ -6,9 +6,7 @@ const h = React.createElement;
 type Props = { onClose: () => void };
 
 export default function HelpOverlay({onClose}: Props) {
-  const {isRawModeSupported} = useStdin();
   useInput((input, key) => {
-    if (!isRawModeSupported) return;
     if (key.escape || input === '?' || input === 'q' || key.return) onClose();
   });
   return h(

--- a/src/components/dialogs/ProjectPickerDialog.ts
+++ b/src/components/dialogs/ProjectPickerDialog.ts
@@ -14,14 +14,12 @@ type Props = {
 export default function ProjectPickerDialog({projects, defaultProject, onSubmit, onCancel}: Props) {
   const filterInput = useTextInput();
   const [selected, setSelected] = useState(() => Math.max(0, projects.findIndex(p => p.name === defaultProject)));
-  const {isRawModeSupported} = useStdin();
   const filtered = useMemo(() => {
     const f = filterInput.value.toLowerCase();
     return projects.filter(p => p.name.toLowerCase().includes(f));
   }, [projects, filterInput.value]);
 
   useInput((input, key) => {
-    if (!isRawModeSupported) return;
     if (key.escape) return onCancel();
     
     // Handle control keys first before text input

--- a/src/components/dialogs/RunConfigDialog.ts
+++ b/src/components/dialogs/RunConfigDialog.ts
@@ -11,10 +11,7 @@ type Props = {
 };
 
 export default function RunConfigDialog({project, configPath, claudePrompt, onCancel, onCreateConfig}: Props) {
-  const {isRawModeSupported} = useStdin();
-  
   useInput((input, key) => {
-    if (!isRawModeSupported) return;
     if (key.escape || input === 'q') onCancel();
     else if (input === 'y' || input === 'Y' || key.return) onCreateConfig();
     else if (input === 'n' || input === 'N') onCancel();

--- a/src/components/views/ArchivedView.ts
+++ b/src/components/views/ArchivedView.ts
@@ -21,15 +21,12 @@ type Props = {
 };
 
 export default function ArchivedView({items, selectedIndex, onMove, onDelete, onBack}: Props) {
-  const {isRawModeSupported} = useStdin();
-  if (isRawModeSupported) {
-    useInput((input, key) => {
-      if (key.escape || input === 'v') onBack?.();
-      if (input === 'j' || key.downArrow) onMove?.(1);
-      if (input === 'k' || key.upArrow) onMove?.(-1);
-      if (input === 'd') onDelete?.(selectedIndex);
-    });
-  }
+  useInput((input, key) => {
+    if (key.escape || input === 'v') onBack?.();
+    if (input === 'j' || key.downArrow) onMove?.(1);
+    if (input === 'k' || key.upArrow) onMove?.(-1);
+    if (input === 'd') onDelete?.(selectedIndex);
+  });
 
   const rows = useMemo(() => items.map((it, i) => {
     const sel = i === selectedIndex;

--- a/src/components/views/DiffView.ts
+++ b/src/components/views/DiffView.ts
@@ -69,7 +69,6 @@ async function loadDiff(worktreePath: string, diffType: 'full' | 'uncommitted' =
 type Props = {worktreePath: string; title?: string; onClose: () => void; diffType?: 'full' | 'uncommitted'};
 
 export default function DiffView({worktreePath, title = 'Diff Viewer', onClose, diffType = 'full'}: Props) {
-  const {isRawModeSupported} = useStdin();
   const [lines, setLines] = useState<DiffLine[]>([]);
   const [pos, setPos] = useState(0);
   const [offset, setOffset] = useState(0);
@@ -179,8 +178,6 @@ export default function DiffView({worktreePath, title = 'Diff Viewer', onClose, 
   }, [animationId]);
 
   useInput((input, key) => {
-    if (!isRawModeSupported) return;
-    
     // Don't handle inputs when comment dialog is open
     if (showCommentDialog) return;
     

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -33,7 +33,7 @@ export function useKeyboardShortcuts(
   actions: KeyboardActions,
   options: KeyboardShortcutsOptions = {}
 ) {
-  const {stdin, setRawMode, isRawModeSupported} = useStdin();
+  const {stdin, setRawMode} = useStdin();
   const {
     enabled = true,
     page = 0,
@@ -43,7 +43,7 @@ export function useKeyboardShortcuts(
   } = options;
 
   useEffect(() => {
-    if (!isRawModeSupported || !enabled) return;
+    if (!enabled) return;
 
     setRawMode(true);
 
@@ -103,7 +103,6 @@ export function useKeyboardShortcuts(
       setRawMode(false);
     };
   }, [
-    isRawModeSupported,
     enabled,
     actions,
     page,
@@ -115,7 +114,6 @@ export function useKeyboardShortcuts(
   ]);
 
   return {
-    isRawModeSupported,
-    enabled: enabled && isRawModeSupported
+    enabled
   };
 }

--- a/src/screens/ArchiveConfirmScreen.tsx
+++ b/src/screens/ArchiveConfirmScreen.tsx
@@ -23,7 +23,6 @@ export default function ArchiveConfirmScreen({
   onSuccess
 }: ArchiveConfirmScreenProps) {
   const {worktreeService} = useServices();
-  const {isRawModeSupported} = useStdin();
 
   const handleConfirm = () => {
     try {
@@ -41,8 +40,6 @@ export default function ArchiveConfirmScreen({
   };
   
   useInput((input, key) => {
-    if (!isRawModeSupported) return;
-    
     if (key.escape || input === 'n') {
       onCancel();
     } else if (key.return || input === 'y') {

--- a/tests/__mocks__/ink.js
+++ b/tests/__mocks__/ink.js
@@ -10,7 +10,6 @@ function useApp() {
 
 function useStdin() {
   return {
-    isRawModeSupported: true,
     stdin: {
       setEncoding: jest.fn(),
       resume: jest.fn(),


### PR DESCRIPTION
## Summary

- Exit immediately when raw mode is not supported instead of showing degraded UI
- Remove all conditional `isRawModeSupported` checks from components and dialogs  
- Simplify useKeyboardShortcuts hook to always assume raw mode is available
- Update test mocks to remove `isRawModeSupported` property

## Changes Made

### Core App Logic
- **App.tsx**: Modified to exit immediately when `isRawModeSupported` is false (removed 800ms delay)
- **useKeyboardShortcuts.ts**: Removed conditional raw mode checks, now always enables raw mode

### Component Updates
- **All Dialog Components**: Removed conditional `isRawModeSupported` checks from:
  - BranchPickerDialog.ts
  - HelpOverlay.ts  
  - ConfirmDialog.ts
  - ConfigResultsDialog.ts
  - CreateFeatureDialog.ts
  - ProjectPickerDialog.ts
  - RunConfigDialog.ts

- **View Components**: Removed conditional checks from:
  - DiffView.ts
  - ArchivedView.ts

- **Screen Components**: Removed conditional checks from:
  - ArchiveConfirmScreen.tsx

### Test Infrastructure
- **test mocks**: Updated ink.js mock to remove `isRawModeSupported` property

## Behavior Changes

**Before**: App would show degraded functionality when raw mode wasn't supported, with conditional UI behavior
**After**: App exits immediately if raw mode isn't supported, ensuring consistent behavior

This ensures users get a clean experience - either the app works fully with raw mode, or it exits gracefully when raw mode is unavailable.

## Test plan

- [x] Verify app starts normally in environments with raw mode support
- [x] Verify no conditional raw mode checks remain in codebase
- [x] Verify keyboard shortcuts work as expected
- [x] Verify all dialog interactions function normally

🤖 Generated with [Claude Code](https://claude.ai/code)