### PR TITLE
Show comments box by default when comments exist

### DIFF
--- a/src/components/views/DiffView.ts
+++ b/src/components/views/DiffView.ts
@@ -80,7 +80,7 @@ export default function DiffView({worktreePath, title = 'Diff Viewer', onClose, 
   const commentStore = useMemo(() => commentStoreManager.getStore(worktreePath), [worktreePath]);
   const [tmuxService] = useState(() => new TmuxService());
   const [showCommentDialog, setShowCommentDialog] = useState(false);
-  const [showAllComments, setShowAllComments] = useState(false);
+  const [showAllComments, setShowAllComments] = useState(true);
   const [showSessionWaitingDialog, setShowSessionWaitingDialog] = useState(false);
   const [sessionWaitingInfo, setSessionWaitingInfo] = useState<{sessionName: string}>({sessionName: ''});
 


### PR DESCRIPTION
## Summary
- Change initial state of `showAllComments` from `false` to `true` in DiffView component
- Comments box now appears automatically when comments exist
- Users can still press 'C' to toggle visibility
- Empty comments box never shows (requires `commentStore.count > 0`)

## Test plan
- [x] Verify comments box appears when comments are added
- [x] Verify empty comments box doesn't appear when no comments exist
- [x] Verify 'C' toggle still works to hide/show comments
- [x] Check that existing functionality remains unchanged

🤖 Generated with [Claude Code](https://claude.ai/code)