### PR TITLE
Add npm install to typecheck script

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "scripts": {
     "build": "tsc -p .",
-    "typecheck": "tsc -p tsconfig.test.json",
+    "typecheck": "npm install && tsc -p tsconfig.test.json",
     "start": "node dist/index.js",
     "cli": "node dist/bin/dev-sessions.js",
     "test": "jest",


### PR DESCRIPTION
## Summary
• Add npm install to typecheck script to ensure dependencies are available before type checking

## Test plan
- [x] Verify typecheck script runs successfully with npm install
- [x] Confirm dependencies are installed before tsc runs
- [x] Test that type checking completes without errors

🤖 Generated with [Claude Code](https://claude.ai/code)