### PR TITLE
Make R key refresh only visible PR statuses

### DIFF
--- a/src/contexts/WorktreeContext.tsx
+++ b/src/contexts/WorktreeContext.tsx
@@ -43,7 +43,7 @@ interface WorktreeContextType {
   getSelectedWorktree: () => WorktreeInfo | null;
   
   // Data operations
-  refresh: () => Promise<void>;
+  refresh: (refreshPRs?: 'all' | 'visible' | 'none') => Promise<void>;
   refreshSelected: () => void;
   refreshPRSelective: () => Promise<void>;
   
@@ -143,7 +143,7 @@ export function WorktreeProvider({
     });
   }, [gitService, tmuxService]);
 
-  const refresh = useCallback(async () => {
+  const refresh = useCallback(async (refreshPRs: 'all' | 'visible' | 'none' = 'all') => {
     if (loading) return;
     setLoading(true);
     
@@ -159,9 +159,10 @@ export function WorktreeProvider({
         setVisibleWorktrees(visiblePaths);
       }
       
-      // Refresh PR status for all worktrees (will use cache if available)
-      if (refreshPRStatus) {
-        await refreshPRStatus(enrichedList, false);
+      // Refresh PR status based on parameter
+      if (refreshPRStatus && refreshPRs !== 'none') {
+        const visibleOnly = refreshPRs === 'visible';
+        await refreshPRStatus(enrichedList, visibleOnly);
         
         // Update worktrees with fresh PR data after refresh completes
         const updatedWorktrees = enrichedList.map(wt => new WorktreeInfo({

--- a/src/screens/WorktreeListScreen.tsx
+++ b/src/screens/WorktreeListScreen.tsx
@@ -29,7 +29,7 @@ export default function WorktreeListScreen({
   onExecuteRun,
   onConfigureRun
 }: WorktreeListScreenProps) {
-  const {worktrees, selectedIndex, selectWorktree, refresh, refreshPRSelective, attachSession, attachShellSession} = useWorktreeContext();
+  const {worktrees, selectedIndex, selectWorktree, refresh, attachSession, attachShellSession} = useWorktreeContext();
 
   const handleMove = (delta: number) => {
     const nextIndex = Math.max(0, Math.min(worktrees.length - 1, selectedIndex + delta));
@@ -83,10 +83,8 @@ export default function WorktreeListScreen({
   };
 
   const handleRefresh = async () => {
-    // Full refresh: both worktrees and PR status
-    await refresh();
-    // Then selective PR refresh for visible items
-    await refreshPRSelective();
+    // Full refresh: worktrees and PR status for visible items only
+    await refresh('visible');
   };
 
   useKeyboardShortcuts({


### PR DESCRIPTION
## Summary
- Enhanced refresh functionality to support selective PR refresh modes
- R key now refreshes worktrees and visible PR statuses only (not all PRs) 
- Maintains backward compatibility with existing refresh() calls

## Changes
- Added optional `refreshPRs` parameter to `refresh()` function with modes: 'all' (default), 'visible', 'none'
- Updated R key handler to call `refresh('visible')` instead of redundant dual refresh calls
- Updated TypeScript interface to reflect new function signature

## Benefits
- Improves performance by avoiding unnecessary API calls for non-visible items
- Cleaner implementation that eliminates redundant refresh calls
- Better user experience with faster refresh for large worktree lists

## Test plan
- [x] Verify R key refreshes visible worktrees and their PR statuses
- [x] Verify existing refresh calls continue to work (backward compatibility)
- [x] Verify TypeScript compilation passes
- [x] Verify no regression in other refresh functionality

🤖 Generated with [Claude Code](https://claude.ai/code)