### PR TITLE
Fix error logs not appearing in log dump on exit

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -1,10 +1,15 @@
 import {render} from 'ink';
 import React from 'react';
 import App from './App.js';
+import {reinitializeMemoryLogging} from './shared/utils/logger.js';
 
 const h = React.createElement;
 
 export function run() {
   const {waitUntilExit} = render(h(App));
+  
+  // Re-initialize logging after Ink's render() to ensure our overrides work
+  reinitializeMemoryLogging();
+  
   return waitUntilExit();
 }

--- a/src/shared/utils/logger.ts
+++ b/src/shared/utils/logger.ts
@@ -51,6 +51,16 @@ export function logDebug(message: string, data?: any): void {
 
 // Initialize memory logging by overriding console methods
 export function initializeMemoryLogging(): void {
+  applyConsoleOverrides();
+}
+
+// Re-initialize logging after other libraries may have overridden console methods
+export function reinitializeMemoryLogging(): void {
+  applyConsoleOverrides();
+}
+
+// Apply console method overrides to capture logs in memory
+function applyConsoleOverrides(): void {
   console.log = (...args: any[]) => {
     const message = args.map(arg => 
       typeof arg === 'object' ? JSON.stringify(arg, null, 2) : String(arg)


### PR DESCRIPTION
## Summary
- Fixed error logs not being captured in the log dump when the program exits
- Root cause: Ink's render() function overrides console methods after logger initialization
- Solution: Re-initialize logger after Ink's render() to restore error capturing

## Test plan
- [x] Build and typecheck passes
- [x] Created test script to verify error capture before/after Ink override
- [x] Confirmed all console.error calls are now captured in log dump
- [x] Verified console.log calls are also properly captured

🤖 Generated with [Claude Code](https://claude.ai/code)