### PR TITLE
Make debug logs conditional on DEBUG_LOGS environment variable

### DIFF
--- a/src/contexts/GitHubContext.tsx
+++ b/src/contexts/GitHubContext.tsx
@@ -4,7 +4,7 @@ import {GitHubService} from '../services/GitHubService.js';
 import {GitService} from '../services/GitService.js';
 import {PRStatusCacheService} from '../services/PRStatusCacheService.js';
 import {PR_REFRESH_DURATION} from '../constants.js';
-import {logError, logInfo} from '../shared/utils/logger.js';
+import {logError, logDebug} from '../shared/utils/logger.js';
 
 const h = React.createElement;
 
@@ -131,7 +131,7 @@ export function GitHubProvider({children}: GitHubProviderProps) {
         }
       }
       
-      logInfo(`PR refresh: ${worktrees.length} worktrees requested, 0 need refresh (${worktrees.length} cached)`);
+      logDebug(`PR refresh: ${worktrees.length} worktrees requested, 0 need refresh (${worktrees.length} cached)`);
       
       if (Object.keys(cached).length > 0) {
         setPullRequests(prev => ({...prev, ...cached}));
@@ -141,7 +141,7 @@ export function GitHubProvider({children}: GitHubProviderProps) {
     }
     
     const cachedCount = worktrees.length - worktreesToRefresh.length;
-    logInfo(`PR refresh: ${worktrees.length} worktrees requested, ${worktreesToRefresh.length} need refresh (${cachedCount} cached)`);
+    logDebug(`PR refresh: ${worktrees.length} worktrees requested, ${worktreesToRefresh.length} need refresh (${cachedCount} cached)`);
     
     setLoading(true);
     try {
@@ -231,7 +231,7 @@ export function GitHubProvider({children}: GitHubProviderProps) {
         // Invalidate cache for any PRs found to be merged
         for (const wt of openPassingPRs) {
           if (wt.pr?.number && mergedPRNumbers.includes(wt.pr.number)) {
-            logInfo(`Found merged PR #${wt.pr.number} via git history, invalidating cache`);
+            logDebug(`Found merged PR #${wt.pr.number} via git history, invalidating cache`);
             cacheService.invalidateByPRNumber(wt.pr.number);
           }
         }

--- a/src/contexts/WorktreeContext.tsx
+++ b/src/contexts/WorktreeContext.tsx
@@ -29,7 +29,7 @@ import {
 } from '../utils.js';
 import {useInputFocus} from './InputFocusContext.js';
 import {useGitHubContext} from './GitHubContext.js';
-import {logInfo, logDebug} from '../shared/utils/logger.js';
+import {logDebug} from '../shared/utils/logger.js';
 import {Timer} from '../shared/utils/timing.js';
 
 const h = React.createElement;
@@ -209,7 +209,7 @@ export function WorktreeProvider({
     setLoading(true);
     
     try {
-      logInfo(`[Refresh.Full] Starting complete refresh`);
+      logDebug(`[Refresh.Full] Starting complete refresh`);
       
       const rawList = await collectWorktrees();
       const enrichedList = await attachRuntimeData(rawList, getPRStatus);
@@ -236,11 +236,11 @@ export function WorktreeProvider({
       }
       
       const timing = timer.elapsed();
-      logInfo(`[Refresh.Full] Complete: ${enrichedList.length} worktrees in ${timing.formatted}`);
+      logDebug(`[Refresh.Full] Complete: ${enrichedList.length} worktrees in ${timing.formatted}`);
       
     } catch (error) {
       const timing = timer.elapsed();
-      logInfo(`[Refresh.Full] Failed in ${timing.formatted}: ${error instanceof Error ? error.message : String(error)}`);
+      logDebug(`[Refresh.Full] Failed in ${timing.formatted}: ${error instanceof Error ? error.message : String(error)}`);
       console.error('Failed to refresh worktrees:', error);
     } finally {
       setLoading(false);
@@ -270,7 +270,7 @@ export function WorktreeProvider({
         // A push occurred - invalidate PR cache and refresh
         const pr = getPRStatus(selected.path);
         if (pr && pr.state === 'OPEN' && refreshPRForWorktree) {
-          logInfo(`Detected push for ${selected.feature}, invalidating PR cache and refreshing`);
+          logDebug(`Detected push for ${selected.feature}, invalidating PR cache and refreshing`);
           // The GitHubContext will handle cache invalidation in refreshPRForWorktree
           await refreshPRForWorktree(selected.path);
         }

--- a/src/services/GitHubService.ts
+++ b/src/services/GitHubService.ts
@@ -1,6 +1,6 @@
 import {PRStatus} from '../models.js';
 import {runCommand, runCommandAsync, runCommandQuick, runCommandQuickAsync} from '../utils.js';
-import {logInfo, logDebug} from '../shared/utils/logger.js';
+import {logDebug} from '../shared/utils/logger.js';
 import {Timer} from '../shared/utils/timing.js';
 
 export class GitHubService {
@@ -50,7 +50,7 @@ export class GitHubService {
       const timing = timer.elapsed();
       const branchCount = branches?.length || 'all';
       const totalPRs = Object.keys(prByBranch).length;
-      logInfo(`[GitHub.PR.Fetch] ${branchCount} branches -> ${totalPRs} PRs (Open: ${stateCounts.open}, Closed: ${stateCounts.closed}, Merged: ${stateCounts.merged}) in ${timing.formatted}`);
+      logDebug(`[GitHub.PR.Fetch] ${branchCount} branches -> ${totalPRs} PRs (Open: ${stateCounts.open}, Closed: ${stateCounts.closed}, Merged: ${stateCounts.merged}) in ${timing.formatted}`);
       
     } catch {}
     

--- a/src/services/GitService.ts
+++ b/src/services/GitService.ts
@@ -17,7 +17,7 @@ import {
   ensureDirectory,
   formatTimeAgo,
 } from '../utils.js';
-import {logInfo, logDebug} from '../shared/utils/logger.js';
+import {logDebug} from '../shared/utils/logger.js';
 import {Timer} from '../shared/utils/timing.js';
 
 export class GitService {
@@ -48,7 +48,7 @@ export class GitService {
       .sort((a, b) => a.name.localeCompare(b.name));
     
     const timing = timer.elapsed();
-    logInfo(`[Project.Discovery] Found ${projects.length} projects in ${timing.formatted}`);
+    logDebug(`[Project.Discovery] Found ${projects.length} projects in ${timing.formatted}`);
     
     return projects;
   }
@@ -107,7 +107,7 @@ export class GitService {
     worktrees.sort((a, b) => b.mtime - a.mtime);
     
     const timing = timer.elapsed();
-    logInfo(`[Worktree.Collection] ${project.name}: ${worktrees.length} worktrees in ${timing.formatted}`);
+    logDebug(`[Worktree.Collection] ${project.name}: ${worktrees.length} worktrees in ${timing.formatted}`);
     
     return worktrees;
   }

--- a/src/services/TmuxService.ts
+++ b/src/services/TmuxService.ts
@@ -1,6 +1,6 @@
 import {commandExitCode, runCommandQuick, runCommandQuickAsync} from '../utils.js';
 import {SESSION_PREFIX, CLAUDE_PATTERNS} from '../constants.js';
-import {logInfo, logDebug} from '../shared/utils/logger.js';
+import {logDebug} from '../shared/utils/logger.js';
 import {Timer} from '../shared/utils/timing.js';
 
 export type ClaudeStatus = 'not_running' | 'working' | 'waiting' | 'idle' | 'active';

--- a/src/shared/utils/logger.ts
+++ b/src/shared/utils/logger.ts
@@ -43,8 +43,11 @@ export function logWarn(message: string, data?: any): void {
   storeLogEntry(false, entry);
 }
 
-// Log debug function
+// Log debug function - only logs when DEBUG_LOGS environment variable is set
 export function logDebug(message: string, data?: any): void {
+  if (!process.env.DEBUG_LOGS) {
+    return; // Skip logging if DEBUG_LOGS is not set
+  }
   const entry = formatLogEntry('DEBUG', message, data);
   storeLogEntry(false, entry);
 }
@@ -94,6 +97,9 @@ function applyConsoleOverrides(): void {
   };
 
   console.debug = (...args: any[]) => {
+    if (!process.env.DEBUG_LOGS) {
+      return; // Skip logging if DEBUG_LOGS is not set
+    }
     const message = args.map(arg => 
       typeof arg === 'object' ? JSON.stringify(arg, null, 2) : String(arg)
     ).join(' ');


### PR DESCRIPTION
## Summary
- Convert all `logInfo` calls to `logDebug` for better log level organization
- Make debug logs conditional on `DEBUG_LOGS` environment variable
- Preserve all logging statements but make them conditional on env var
- Clean output by default, debug output available when needed for troubleshooting
- Remove unused `logInfo` imports from all service files

## Implementation Details
- Updated `logger.ts` to check `process.env.DEBUG_LOGS` before logging debug messages
- Converted all `logInfo()` calls to `logDebug()` calls (no info logs in the program)
- Both `logDebug()` function and `console.debug()` override respect the environment variable
- Error and warning logs continue to work normally for production debugging

## Files Changed
- `src/shared/utils/logger.ts` - Added environment variable check for debug logs
- `src/contexts/GitHubContext.tsx` - Converted 3 logInfo → logDebug calls
- `src/contexts/WorktreeContext.tsx` - Converted 4 logInfo → logDebug calls  
- `src/services/GitHubService.ts` - Converted 1 logInfo → logDebug call
- `src/services/GitService.ts` - Converted 2 logInfo → logDebug calls
- `src/services/TmuxService.ts` - Cleaned up unused imports

## Usage
- **Normal usage**: `npm run dev` - Clean output, no debug logs
- **Debug mode**: `DEBUG_LOGS=true npm run dev` - Shows all debug logs for troubleshooting
- **Error/warnings**: Always visible regardless of DEBUG_LOGS setting

## Test plan
- [x] TypeScript compilation passes
- [x] No debug output without DEBUG_LOGS environment variable
- [x] Debug logs appear when DEBUG_LOGS=true is set
- [x] Error and warning logs still work normally
- [x] No `logInfo` calls remain in application code
- [x] Merged latest from main without conflicts

🤖 Generated with [Claude Code](https://claude.ai/code)