### PR TITLE
Remove unnecessary exec bash from watch commands

### DIFF
--- a/src/contexts/WorktreeContext.tsx
+++ b/src/contexts/WorktreeContext.tsx
@@ -635,7 +635,7 @@ export function WorktreeProvider({
           runCommand(['tmux', 'send-keys', '-t', `${sessionName}:0.0`, `exec ${config.command}`, 'C-m']);
         } else {
           // For watch commands (servers, dev), keep session alive after command exits
-          runCommand(['tmux', 'send-keys', '-t', `${sessionName}:0.0`, `${config.command}; exec bash`, 'C-m']);
+          runCommand(['tmux', 'send-keys', '-t', `${sessionName}:0.0`, config.command, 'C-m']);
         }
       }
     } catch (error) {


### PR DESCRIPTION
## Summary

- Remove redundant `; exec bash` from watch command execution
- When `watch: true`, the tmux session naturally remains in the original bash shell after command completion
- This simplifies the command execution and removes unnecessary shell replacement

## Test plan

- [x] All tests pass (277 tests)
- [x] Build and typecheck successful
- [x] No breaking changes to existing functionality

🤖 Generated with [Claude Code](https://claude.ai/code)