### PR TITLE
Fix Shift+Left navigation to properly go to previous file

### DIFF
--- a/src/components/views/DiffView.ts
+++ b/src/components/views/DiffView.ts
@@ -535,7 +535,18 @@ export default function DiffView({worktreePath, title = 'Diff Viewer', onClose, 
     
     // Previous file: Shift+Left
     if (key.leftArrow && key.shift) {
-      for (let i = selectedLine - 1; i >= 0; i--) {
+      // First, find the current file header
+      let currentFileHeaderIndex = -1;
+      for (let i = selectedLine; i >= 0; i--) {
+        if (isFileHeader(i)) {
+          currentFileHeaderIndex = i;
+          break;
+        }
+      }
+      
+      // Now search for the previous file header (before the current one)
+      const searchStart = currentFileHeaderIndex > 0 ? currentFileHeaderIndex - 1 : selectedLine - 1;
+      for (let i = searchStart; i >= 0; i--) {
         if (isFileHeader(i)) {
           // Find the first content line after this file header
           const contentLineIndex = findFirstContentLineAfterHeader(i);


### PR DESCRIPTION
## Summary
- Fixed an issue where pressing Shift+Left to navigate to the previous file would sometimes stay in the current file
- The navigation now properly identifies the current file and skips to the actual previous file

## Problem
When pressing Shift+Left, the code was searching backwards from `selectedLine - 1`, which could find the current file's header if the user was near the top of their current file. This caused the navigation to appear to do nothing or stay in the same file.

## Solution
Modified the Shift+Left handler to:
1. First find the current file's header by searching backwards from the selected line
2. Then search backwards from before that header (or from selectedLine - 1 if no current header found)
3. This ensures we always skip the current file and navigate to the truly previous file

## Test plan
- [x] Built the project successfully with `npm run build`
- [ ] Test navigating between files with Shift+Left and Shift+Right
- [ ] Verify that Shift+Left always goes to the previous file, not the current file
- [ ] Test from various positions within a file (top, middle, bottom)

🤖 Generated with [Claude Code](https://claude.ai/code)