### PR TITLE
fix: truncate help bar in diff view instead of wrapping

### DIFF
--- a/src/components/views/DiffView.ts
+++ b/src/components/views/DiffView.ts
@@ -1518,6 +1518,6 @@ export default function DiffView({worktreePath, title = 'Diff Viewer', onClose, 
         h(Text, {key: idx, color: 'gray'}, `${comment.fileName}:${comment.lineIndex} - ${comment.commentText}`)
       )
     ) : null,
-    h(Text, {color: 'gray'}, `j/k move  v toggle view (${viewMode})  w toggle wrap (${wrapMode})  c comment  C show all  d delete  S send to Claude  q close`)
+    h(Text, {color: 'gray'}, truncateDisplay(`j/k move  v toggle view (${viewMode})  w toggle wrap (${wrapMode})  c comment  C show all  d delete  S send to Claude  q close`, terminalWidth))
   );
 }


### PR DESCRIPTION
## Summary
- Fixed the bottom help bar in the diff view to truncate instead of wrap when terminal width is too small
- Prevents text wrapping that could push content off screen

## Test plan
- [x] Build and typecheck pass
- [ ] Open diff view with narrow terminal width
- [ ] Verify help bar truncates with ellipsis instead of wrapping to next line
- [ ] Test with various terminal widths to ensure proper truncation

🤖 Generated with [Claude Code](https://claude.ai/code)