### PR TITLE
Fix: Remove backticks from review comments to prevent bash errors

### DIFF
--- a/src/components/views/DiffView.ts
+++ b/src/components/views/DiffView.ts
@@ -720,7 +720,7 @@ export default function DiffView({worktreePath, title = 'Diff Viewer', onClose, 
     Object.entries(commentsByFile).forEach(([fileName, fileComments]) => {
       prompt += `File: ${fileName}\\n`;
       fileComments.forEach(comment => {
-        prompt += `  Line ${comment.lineIndex + 1}: \`${comment.lineText}\`\\n`;
+        prompt += `  Line ${comment.lineIndex + 1}: ${comment.lineText}\\n`;
         prompt += `  Comment: ${comment.commentText}\\n`;
       });
       prompt += "\\n";
@@ -796,7 +796,7 @@ export default function DiffView({worktreePath, title = 'Diff Viewer', onClose, 
     Object.entries(commentsByFile).forEach(([fileName, fileComments]) => {
       messageLines.push(`File: ${fileName}`);
       fileComments.forEach(comment => {
-        messageLines.push(`  Line ${comment.lineIndex + 1}: \`${comment.lineText}\``);
+        messageLines.push(`  Line ${comment.lineIndex + 1}: ${comment.lineText}`);
         messageLines.push(`  Comment: ${comment.commentText}`);
       });
       messageLines.push("");

--- a/tests/e2e/comment-send.test.tsx
+++ b/tests/e2e/comment-send.test.tsx
@@ -302,18 +302,18 @@ describe('Comment Send to Claude E2E', () => {
     Object.entries(commentsByFile).forEach(([fileName, fileComments]) => {
       prompt += `File: ${fileName}\\n`;
       fileComments.forEach(comment => {
-        prompt += `  Line ${comment.lineIndex + 1}: \`${comment.lineText}\`\\n`;
+        prompt += `  Line ${comment.lineIndex + 1}: ${comment.lineText}\\n`;
         prompt += `  Comment: ${comment.commentText}\\n`;
       });
       prompt += "\\n";
     });
     
     // Verify the prompt includes line text with proper formatting
-    expect(prompt).toContain("Line 16: `let unchangedValue = 5;`");
+    expect(prompt).toContain("Line 16: let unchangedValue = 5;");
     expect(prompt).toContain("Comment: This variable should be const");
-    expect(prompt).toContain("Line 43: `await fetchData();`");
+    expect(prompt).toContain("Line 43: await fetchData();");
     expect(prompt).toContain("Comment: Add error handling here");
-    expect(prompt).toContain("Line 9: `const API_URL = \"\";`");
+    expect(prompt).toContain("Line 9: const API_URL = \"\";");
     expect(prompt).toContain("Comment: URL should not be empty");
     
     // Test sendCommentsViaAltEnter format (used when Claude is already running)


### PR DESCRIPTION
## Summary
- Fixed bash command substitution errors when launching Claude with review comments
- Removed backticks from comment format strings that were causing shell interpretation issues

## Problem
When sending code review comments to Claude, backticks in the format string were causing bash to interpret them as command substitution markers, resulting in syntax errors like:
```
-bash: command substitution: line 2: syntax error: unexpected end of file
```

## Solution
Changed the comment format from:
```
Line 78: `constructor() {`
```
to:
```
Line 78: constructor() {
```

This prevents the shell from attempting to execute code within backticks when the prompt is passed to the Claude command via `JSON.stringify()`.

## Test plan
- [x] Updated tests to match new format without backticks
- [x] All tests pass (`npm test tests/e2e/comment-send.test.tsx`)
- [x] Build successful (`npm run build`)
- [x] Type checking passes (`npm run typecheck`)

🤖 Generated with [Claude Code](https://claude.ai/code)