### PR TITLE
Fix: per-file line numbers for diff comments (unified + sxs)

### DIFF
--- a/src/shared/utils/diffLineIndex.ts
+++ b/src/shared/utils/diffLineIndex.ts
@@ -1,0 +1,44 @@
+export type UnifiedDiffLine = { type: 'added' | 'removed' | 'context' | 'header'; text: string; fileName?: string; headerType?: 'file' | 'hunk' };
+
+export type SideBySideCell = { type: 'added' | 'removed' | 'context' | 'header' | 'empty'; text: string; fileName?: string; headerType?: 'file' | 'hunk' } | null;
+export type SideBySideRow = { left: SideBySideCell; right: SideBySideCell; lineIndex: number };
+
+// Returns array mapping each unified line index -> per-file 0-based line index, or undefined for lines without a file
+export function computeUnifiedPerFileIndices(lines: UnifiedDiffLine[]): Array<number | undefined> {
+  const map: Array<number | undefined> = new Array(lines.length);
+  const counters = new Map<string, number>();
+  for (let i = 0; i < lines.length; i++) {
+    const l = lines[i];
+    const file = l.fileName || '';
+    if (!file) { map[i] = undefined; continue; }
+    if (l.type === 'header') {
+      map[i] = counters.get(file);
+      continue;
+    }
+    const prev = counters.get(file) || 0;
+    map[i] = prev;
+    counters.set(file, prev + 1);
+  }
+  return map;
+}
+
+// Returns array mapping each side-by-side row index -> per-file 0-based line index, or undefined for rows without a file
+export function computeSideBySidePerFileIndices(rows: SideBySideRow[]): Array<number | undefined> {
+  const map: Array<number | undefined> = new Array(rows.length);
+  const counters = new Map<string, number>();
+  for (let i = 0; i < rows.length; i++) {
+    const r = rows[i];
+    const file = r.left?.fileName || r.right?.fileName || '';
+    if (!file) { map[i] = undefined; continue; }
+    const isHeader = (r.left?.type === 'header') || (r.right?.type === 'header');
+    if (isHeader) {
+      map[i] = counters.get(file);
+      continue;
+    }
+    const prev = counters.get(file) || 0;
+    map[i] = prev;
+    counters.set(file, prev + 1);
+  }
+  return map;
+}
+

--- a/tests/unit/diffLineIndex.test.ts
+++ b/tests/unit/diffLineIndex.test.ts
@@ -1,0 +1,48 @@
+import {describe, test, expect} from '@jest/globals';
+import {computeUnifiedPerFileIndices, computeSideBySidePerFileIndices} from '../../src/shared/utils/diffLineIndex.js';
+
+describe('diffLineIndex utilities', () => {
+  test('computeUnifiedPerFileIndices maps per file and skips headers', () => {
+    const lines = [
+      {type: 'header', text: '📁 a.ts', fileName: 'a.ts', headerType: 'file'},
+      {type: 'header', text: '  ▼ hunk', fileName: 'a.ts', headerType: 'hunk'},
+      {type: 'context', text: 'line1', fileName: 'a.ts'},
+      {type: 'added', text: 'line2', fileName: 'a.ts'},
+      {type: 'removed', text: 'line3', fileName: 'a.ts'},
+      {type: 'header', text: '📁 b.ts', fileName: 'b.ts', headerType: 'file'},
+      {type: 'context', text: 'b1', fileName: 'b.ts'},
+      {type: 'added', text: 'b2', fileName: 'b.ts'},
+    ] as any;
+
+    const map = computeUnifiedPerFileIndices(lines);
+    // Headers: undefined or previous counter; content increments per file
+    expect(map[0]).toBeUndefined(); // file header
+    expect(map[1]).toBeUndefined(); // hunk header
+    expect(map[2]).toBe(0);
+    expect(map[3]).toBe(1);
+    expect(map[4]).toBe(2);
+    expect(map[5]).toBeUndefined(); // file header for b.ts
+    expect(map[6]).toBe(0);
+    expect(map[7]).toBe(1);
+  });
+
+  test('computeSideBySidePerFileIndices maps per file and skips headers', () => {
+    const rows = [
+      {left: {type: 'header', text: '📁 a.ts', fileName: 'a.ts', headerType: 'file'}, right: {type: 'header', text: '📁 a.ts', fileName: 'a.ts', headerType: 'file'}, lineIndex: 0},
+      {left: {type: 'context', text: 'a1', fileName: 'a.ts'}, right: {type: 'context', text: 'a1', fileName: 'a.ts'}, lineIndex: 1},
+      {left: {type: 'removed', text: 'a2', fileName: 'a.ts'}, right: {type: 'added', text: 'a2', fileName: 'a.ts'}, lineIndex: 2},
+      {left: {type: 'header', text: '📁 b.ts', fileName: 'b.ts', headerType: 'file'}, right: {type: 'header', text: '📁 b.ts', fileName: 'b.ts', headerType: 'file'}, lineIndex: 3},
+      {left: {type: 'context', text: 'b1', fileName: 'b.ts'}, right: {type: 'context', text: 'b1', fileName: 'b.ts'}, lineIndex: 4},
+      {left: {type: 'empty', text: '', fileName: 'b.ts'}, right: {type: 'added', text: 'b2', fileName: 'b.ts'}, lineIndex: 5},
+    ] as any;
+
+    const map = computeSideBySidePerFileIndices(rows);
+    expect(map[0]).toBeUndefined(); // header
+    expect(map[1]).toBe(0);
+    expect(map[2]).toBe(1);
+    expect(map[3]).toBeUndefined(); // header for b.ts
+    expect(map[4]).toBe(0);
+    expect(map[5]).toBe(1);
+  });
+});
+


### PR DESCRIPTION
This PR fixes incorrect line numbers in comments created from the Diff View. Previously we stored global diff indices; now we map to per-file indices in both unified and side-by-side modes.\n\nChanges:\n- Add unified and side-by-side per-file index mapping.\n- Use per-file indices for save/delete/indicator/initialComment.\n- Accept lowercase 's' to send comments.\n- Tests left green (375 passing).\n\nValidated by running `npx jest --runInBand`.