### PR TITLE
fix: show untracked files in diff view when main diff is empty

### DIFF
--- a/src/components/views/DiffView.tsx
+++ b/src/components/views/DiffView.tsx
@@ -150,26 +150,28 @@ async function loadDiff(worktreePath: string, diffType: 'full' | 'uncommitted' =
     diff = await runCommandAsync(['git', '-C', worktreePath, 'diff', '--no-color', '--no-ext-diff', target]);
   }
   
-  if (!diff) return lines;
-  const raw = diff.split('\n');
-  let currentFileName = '';
-  for (const line of raw) {
-    if (line.startsWith('diff --git')) {
-      const parts = line.split(' ');
-      const fp = parts[3]?.slice(2) || parts[2]?.slice(2) || '';
-      currentFileName = fp;
-      lines.push({type: 'header', text: `📁 ${fp}`, fileName: fp, headerType: 'file'});
-    } else if (line.startsWith('@@')) {
-      const ctx = line.replace(/^@@.*@@ ?/, '');
-      if (ctx) lines.push({type: 'header', text: `  ▼ ${ctx}`, fileName: currentFileName, headerType: 'hunk'});
-    } else if (line.startsWith('+') && !line.startsWith('+++')) {
-      lines.push({type: 'added', text: line.slice(1), fileName: currentFileName});
-    } else if (line.startsWith('-') && !line.startsWith('---')) {
-      lines.push({type: 'removed', text: line.slice(1), fileName: currentFileName});
-    } else if (line.startsWith(' ')) {
-      lines.push({type: 'context', text: line.slice(1), fileName: currentFileName});
-    } else if (line === '') {
-      lines.push({type: 'context', text: ' ', fileName: currentFileName}); // Empty line gets a space so cursor is visible
+  // Process main diff if it exists
+  if (diff && diff.trim()) {
+    const raw = diff.split('\n');
+    let currentFileName = '';
+    for (const line of raw) {
+      if (line.startsWith('diff --git')) {
+        const parts = line.split(' ');
+        const fp = parts[3]?.slice(2) || parts[2]?.slice(2) || '';
+        currentFileName = fp;
+        lines.push({type: 'header', text: `📁 ${fp}`, fileName: fp, headerType: 'file'});
+      } else if (line.startsWith('@@')) {
+        const ctx = line.replace(/^@@.*@@ ?/, '');
+        if (ctx) lines.push({type: 'header', text: `  ▼ ${ctx}`, fileName: currentFileName, headerType: 'hunk'});
+      } else if (line.startsWith('+') && !line.startsWith('+++')) {
+        lines.push({type: 'added', text: line.slice(1), fileName: currentFileName});
+      } else if (line.startsWith('-') && !line.startsWith('---')) {
+        lines.push({type: 'removed', text: line.slice(1), fileName: currentFileName});
+      } else if (line.startsWith(' ')) {
+        lines.push({type: 'context', text: line.slice(1), fileName: currentFileName});
+      } else if (line === '') {
+        lines.push({type: 'context', text: ' ', fileName: currentFileName}); // Empty line gets a space so cursor is visible
+      }
     }
   }
   // Append untracked files


### PR DESCRIPTION
## Summary
- Fixed diff viewer not showing content when worktree has only untracked files
- Resolved issue where file counts were shown but no actual diff content displayed

## Problem
The diff viewer was showing file counts but no content for worktrees that had:
- No committed changes (branch up to date with base)
- Only untracked files

This was happening because the `loadDiff` function would return early when the main git diff was empty, before processing untracked files.

## Solution
Modified the `loadDiff` function in `src/components/views/DiffView.tsx` to:
- Only skip main diff processing when diff is empty, instead of returning early
- Always process untracked files section, even when main diff is empty
- Ensure untracked files are displayed with proper content

## Test plan
- [x] Tested with `coding-agent-team-branches/diff-tests` worktree (4 untracked files, no committed changes)
- [x] Verified untracked files now display correctly in diff viewer
- [x] Ran full test suite to ensure no regressions
- [x] Confirmed fix works for both cases: worktrees with only untracked files, and worktrees with both committed changes + untracked files

🤖 Generated with [Claude Code](https://claude.ai/code)