### PR TITLE
feat: make side-by-side diff view the default

### DIFF
--- a/src/components/views/DiffView.tsx
+++ b/src/components/views/DiffView.tsx
@@ -274,7 +274,7 @@ export default function DiffView({worktreePath, title = 'Diff Viewer', onClose, 
   const [isFileNavigation, setIsFileNavigation] = useState(false);
   const [currentFileHeader, setCurrentFileHeader] = useState<string>('');
   const [currentHunkHeader, setCurrentHunkHeader] = useState<string>('');
-  const [viewMode, setViewMode] = useState<ViewMode>('unified');
+  const [viewMode, setViewMode] = useState<ViewMode>('sidebyside');
   const [wrapMode, setWrapMode] = useState<WrapMode>('truncate');
   const commentStore = useMemo(() => commentStoreManager.getStore(worktreePath), [worktreePath]);
   const [tmuxService] = useState(() => new TmuxService());


### PR DESCRIPTION
## Summary
- Changed default view mode from 'unified' to 'sidebyside' in DiffView component
- Users can still toggle between view modes using the 'v' key
- No other functionality changed

## Test plan
- [x] TypeScript compilation passes
- [x] Build completes successfully  
- [x] Existing functionality preserved (view mode toggle still works)

🤖 Generated with [Claude Code](https://claude.ai/code)