### PR TITLE
fix: remove JSX comment causing crash in BranchPickerDialog

### DIFF
--- a/src/components/dialogs/BranchPickerDialog.tsx
+++ b/src/components/dialogs/BranchPickerDialog.tsx
@@ -154,7 +154,7 @@ export default function BranchPickerDialog({branches, onSubmit, onCancel, onRefr
   // Add header row for column labels
   const header = (
     <Box marginBottom={0} flexDirection="row">
-      <Text color="gray">  </Text> {/* Space for selection indicator */}
+      <Text color="gray">  </Text>
       <Box width={columnWidths[0]} marginRight={1}>
         <Text color="gray" bold>BRANCH</Text>
       </Box>


### PR DESCRIPTION
## Summary
- Fixed crash in BranchPickerDialog when showing branches view
- Removed JSX comment that was incorrectly placed as direct child of Box component
- Ink/React for CLI doesn't allow text nodes (including comments) as direct children of Box components

## Test plan
- [x] Build project successfully 
- [x] Run app without crashes
- [x] Verify no similar issues exist in other dialog components
- [x] Branch picker dialog should now work without throwing "Text string must be rendered inside <Text> component" error

🤖 Generated with [Claude Code](https://claude.ai/code)