### PR TITLE
refactor: remove magic tmux behavior from commandExecutor utils

### DIFF
--- a/src/services/TmuxService.ts
+++ b/src/services/TmuxService.ts
@@ -1,4 +1,4 @@
-import {commandExitCode, runCommandQuick, runCommandQuickAsync, runCommand, runInteractive} from '../utils.js';
+import {commandExitCode, runCommandQuick, runCommandQuickAsync, runCommand, runInteractive, getCleanEnvironment} from '../utils.js';
 import {SESSION_PREFIX, CLAUDE_PATTERNS, AI_TOOLS} from '../constants.js';
 import {logDebug} from '../shared/utils/logger.js';
 import {Timer} from '../shared/utils/timing.js';
@@ -8,6 +8,15 @@ import {AIStatus, AITool} from '../models.js';
 export type ClaudeStatus = AIStatus;
 
 export class TmuxService {
+  // Clean environment for tmux commands to avoid nvm conflicts
+  private _tmuxEnv: NodeJS.ProcessEnv | null = null;
+  
+  private get tmuxEnv(): NodeJS.ProcessEnv {
+    if (!this._tmuxEnv) {
+      this._tmuxEnv = getCleanEnvironment();
+    }
+    return this._tmuxEnv;
+  }
   sessionName(project: string, feature: string): string {
     return `${SESSION_PREFIX}${project}-${feature}`;
   }
@@ -21,12 +30,12 @@ export class TmuxService {
   }
 
   hasSession(session: string): boolean {
-    const code = commandExitCode(['tmux', 'has-session', '-t', `=${session}`]);
+    const code = commandExitCode(['tmux', 'has-session', '-t', `=${session}`], undefined, this.tmuxEnv);
     return code === 0;
   }
 
   async listSessions(): Promise<string[]> {
-    const output = await runCommandQuickAsync(['tmux', 'list-sessions', '-F', '#S']);
+    const output = await runCommandQuickAsync(['tmux', 'list-sessions', '-F', '#S'], undefined, this.tmuxEnv);
     if (!output) return [];
     
     const sessions = output.split('\n').filter(Boolean);
@@ -35,7 +44,7 @@ export class TmuxService {
 
   async capturePane(session: string): Promise<string> {
     const target = await this.findAIPaneTarget(session) || `${session}:0.0`;
-    const output = await runCommandQuickAsync(['tmux', 'capture-pane', '-p', '-t', target, '-S', '-50']);
+    const output = await runCommandQuickAsync(['tmux', 'capture-pane', '-p', '-t', target, '-S', '-50'], undefined, this.tmuxEnv);
     
     return output || '';
   }
@@ -61,11 +70,11 @@ export class TmuxService {
   }
 
   killSession(session: string): string {
-    return runCommandQuick(['tmux', 'kill-session', '-t', session]);
+    return runCommandQuick(['tmux', 'kill-session', '-t', session], undefined, this.tmuxEnv);
   }
 
   createSession(sessionName: string, cwd: string, autoExit: boolean = false): void {
-    runCommand(['tmux', 'new-session', '-ds', sessionName, '-c', cwd]);
+    runCommand(['tmux', 'new-session', '-ds', sessionName, '-c', cwd], { env: this.tmuxEnv });
     if (autoExit) {
       this.setSessionOption(sessionName, 'remain-on-exit', 'off');
     }
@@ -73,7 +82,7 @@ export class TmuxService {
 
   createSessionWithCommand(sessionName: string, cwd: string, command: string, autoExit: boolean = true): void {
     const shell = process.env.SHELL || '/bin/bash';
-    runCommand(['tmux', 'new-session', '-ds', sessionName, '-c', cwd, command || shell]);
+    runCommand(['tmux', 'new-session', '-ds', sessionName, '-c', cwd, command || shell], { env: this.tmuxEnv });
     if (autoExit) {
       this.setSessionOption(sessionName, 'remain-on-exit', 'off');
     }
@@ -93,13 +102,13 @@ export class TmuxService {
     
     if (executeCommand) {
       // Send as command and execute with Enter
-      runCommand(['tmux', 'send-keys', '-t', `${session}:0.0`, text, 'C-m']);
+      runCommand(['tmux', 'send-keys', '-t', `${session}:0.0`, text, 'C-m'], { env: this.tmuxEnv });
     } else if (addNewline) {
       // Send text with newline character
-      runCommand(['tmux', 'send-keys', '-t', `${session}:0.0`, text + '\n']);
+      runCommand(['tmux', 'send-keys', '-t', `${session}:0.0`, text + '\n'], { env: this.tmuxEnv });
     } else {
       // Send text as-is
-      runCommand(['tmux', 'send-keys', '-t', `${session}:0.0`, text]);
+      runCommand(['tmux', 'send-keys', '-t', `${session}:0.0`, text], { env: this.tmuxEnv });
     }
   }
 
@@ -119,13 +128,13 @@ export class TmuxService {
       this.sendText(session, line);
       if (endWithAltEnter) {
         // Use Alt+Enter for multi-line input (like Claude input)
-        runCommand(['tmux', 'send-keys', '-t', `${session}:0.0`, 'Escape', 'Enter']);
+        runCommand(['tmux', 'send-keys', '-t', `${session}:0.0`, 'Escape', 'Enter'], { env: this.tmuxEnv });
       }
     });
     
     if (endWithExecute) {
       // Final execute command
-      runCommand(['tmux', 'send-keys', '-t', `${session}:0.0`, 'C-m']);
+      runCommand(['tmux', 'send-keys', '-t', `${session}:0.0`, 'C-m'], { env: this.tmuxEnv });
     }
   }
 
@@ -135,7 +144,7 @@ export class TmuxService {
    * @param keys Key combination (e.g., 'Escape', 'Enter', 'C-m')
    */
   sendSpecialKeys(session: string, ...keys: string[]): void {
-    runCommand(['tmux', 'send-keys', '-t', `${session}:0.0`, ...keys]);
+    runCommand(['tmux', 'send-keys', '-t', `${session}:0.0`, ...keys], { env: this.tmuxEnv });
   }
 
   attachSessionInteractive(sessionName: string): void {
@@ -143,15 +152,15 @@ export class TmuxService {
   }
 
   setOption(option: string, value: string): void {
-    runCommand(['tmux', 'set-option', '-g', option, value]);
+    runCommand(['tmux', 'set-option', '-g', option, value], { env: this.tmuxEnv });
   }
 
   setSessionOption(session: string, option: string, value: string): void {
-    runCommand(['tmux', 'set-option', '-t', session, option, value]);
+    runCommand(['tmux', 'set-option', '-t', session, option, value], { env: this.tmuxEnv });
   }
 
   async listPanes(session: string): Promise<string> {
-    return await runCommandQuickAsync(['tmux', 'list-panes', '-t', `=${session}`, '-F', '#{window_index}.#{pane_index} #{pane_current_command}']) || '';
+    return await runCommandQuickAsync(['tmux', 'list-panes', '-t', `=${session}`, '-F', '#{window_index}.#{pane_index} #{pane_current_command}'], undefined, this.tmuxEnv) || '';
   }
 
   async cleanupOrphanedSessions(validWorktrees: string[]): Promise<void> {
@@ -208,7 +217,7 @@ export class TmuxService {
     const toolsMap = new Map<string, AITool>();
     
     // Get all sessions with their PIDs in one command
-    const output = await runCommandQuickAsync(['tmux', 'list-panes', '-a', '-F', '#{session_name}:#{pane_pid}']);
+    const output = await runCommandQuickAsync(['tmux', 'list-panes', '-a', '-F', '#{session_name}:#{pane_pid}'], undefined, this.tmuxEnv);
     if (!output) {
       this.aiToolsCache = toolsMap;
       this.aiToolsCacheTime = Date.now();
@@ -270,7 +279,7 @@ export class TmuxService {
 
   private async detectSessionAITool(session: string): Promise<AITool> {
     // Get the PID of the first pane to check full process command
-    const pidOutput = await runCommandQuickAsync(['tmux', 'list-panes', '-F', '#{pane_pid}', '-t', `${session}:0`]);
+    const pidOutput = await runCommandQuickAsync(['tmux', 'list-panes', '-F', '#{pane_pid}', '-t', `${session}:0`], undefined, this.tmuxEnv);
     const pid = pidOutput?.trim();
     
     if (pid) {

--- a/tests/unit/ai-tool-switching.test.ts
+++ b/tests/unit/ai-tool-switching.test.ts
@@ -12,6 +12,7 @@ jest.mock('../../src/utils.js', () => ({
   runCommand: jest.fn(),
   commandExitCode: jest.fn(),
   runInteractive: jest.fn(),
+  getCleanEnvironment: jest.fn(() => ({ ...process.env, npm_config_prefix: undefined })),
 }));
 
 describe('AI Tool Switching', () => {


### PR DESCRIPTION
## Summary
- Remove automatic tmux environment detection from commandExecutor functions  
- Add optional env parameter to command execution functions
- Update TmuxService to explicitly use clean environment for tmux commands
- Make getCleanEnvironment() a public export instead of internal magic

## Problem
The commandExecutor utilities had magic behavior where they automatically detected tmux commands and applied a clean environment. This made the utility functions non-deterministic and violated the principle that utilities should not make assumptions based on command names.

## Solution
- **Explicit Control**: The caller (TmuxService) now explicitly decides when to use clean environment
- **No Magic**: Utility functions no longer make assumptions based on command names  
- **Backward Compatible**: All existing signatures work, new `env` parameter is optional
- **Consistent**: All tmux commands in TmuxService now use the same clean environment

## Test plan
- [x] All existing tests pass (393/393)
- [x] TypeScript compilation successful
- [x] Terminal rendering tests pass
- [x] Fixed test mocking to include getCleanEnvironment function
- [x] Verified same nvm compatibility behavior maintained

🤖 Generated with [Claude Code](https://claude.ai/code)