### PR TITLE
Remove integration tests; ensure e2e tests are truly e2e

### DIFF
--- a/jest.unit.config.js
+++ b/jest.unit.config.js
@@ -25,7 +25,7 @@ export default {
   testEnvironment: 'node',
   setupFilesAfterEnv: ['<rootDir>/tests/setup.ts'],
   testMatch: [
-    '<rootDir>/tests/{unit,integration}/**/*.test.{ts,tsx}',
+    '<rootDir>/tests/unit/**/*.test.{ts,tsx}',
   ],
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
   collectCoverageFrom: [

--- a/tests/unit/app-services.test.tsx
+++ b/tests/unit/app-services.test.tsx
@@ -443,3 +443,4 @@ describe('App Services E2E', () => {
   });
 
 });
+

--- a/tests/unit/comment-formatting.test.tsx
+++ b/tests/unit/comment-formatting.test.tsx
@@ -11,11 +11,11 @@ describe('Comment formatting for Claude prompts', () => {
         commentText: 'Good constant naming'
       }];
 
-      let prompt = "Please address the following code review comments:\\n\\n";
-      prompt += `File: src/test.ts\\n`;
-      prompt += `  Line 3: const value = 42;\\n`;
-      prompt += `  Comment: Good constant naming\\n`;
-      prompt += "\\n";
+      let prompt = "Please address the following code review comments:\n\n";
+      prompt += `File: src/test.ts\n`;
+      prompt += `  Line 3: const value = 42;\n`;
+      prompt += `  Comment: Good constant naming\n`;
+      prompt += "\n";
 
       expect(prompt).toContain('Line 3: const value = 42;');
       expect(prompt).toContain('Comment: Good constant naming');
@@ -29,11 +29,11 @@ describe('Comment formatting for Claude prompts', () => {
         commentText: 'Why was this removed?'
       }];
 
-      let prompt = "Please address the following code review comments:\\n\\n";
-      prompt += `File: src/test.ts\\n`;
-      prompt += `  Line content: const removed = 1;\\n`;
-      prompt += `  Comment: Why was this removed?\\n`;
-      prompt += "\\n";
+      let prompt = "Please address the following code review comments:\n\n";
+      prompt += `File: src/test.ts\n`;
+      prompt += `  Line content: const removed = 1;\n`;
+      prompt += `  Comment: Why was this removed?\n`;
+      prompt += "\n";
 
       expect(prompt).toContain('Line content: const removed = 1;');
       expect(prompt).toContain('Comment: Why was this removed?');
@@ -48,10 +48,10 @@ describe('Comment formatting for Claude prompts', () => {
         commentText: 'Review this new file structure'
       }];
 
-      let prompt = "Please address the following code review comments:\\n\\n";
-      prompt += `File: src/newfile.ts\\n`;
-      prompt += `  Comment: Review this new file structure\\n`;
-      prompt += "\\n";
+      let prompt = "Please address the following code review comments:\n\n";
+      prompt += `File: src/newfile.ts\n`;
+      prompt += `  Comment: Review this new file structure\n`;
+      prompt += "\n";
 
       expect(prompt).not.toContain('Line content:');
       expect(prompt).not.toContain('Line 1:');
@@ -80,7 +80,7 @@ describe('Comment formatting for Claude prompts', () => {
         }
       ];
 
-      let prompt = "Please address the following code review comments:\\n\\n";
+      let prompt = "Please address the following code review comments:\n\n";
       
       const commentsByFile: {[key: string]: typeof comments} = {};
       comments.forEach(comment => {
@@ -91,19 +91,19 @@ describe('Comment formatting for Claude prompts', () => {
       });
 
       Object.entries(commentsByFile).forEach(([fileName, fileComments]) => {
-        prompt += `File: ${fileName}\\n`;
+        prompt += `File: ${fileName}\n`;
         fileComments.forEach(comment => {
           if (comment.lineIndex !== undefined) {
             // Normal line with line number
-            prompt += `  Line ${comment.lineIndex + 1}: ${comment.lineText}\\n`;
+            prompt += `  Line ${comment.lineIndex + 1}: ${comment.lineText}\n`;
           } else if (comment.lineText && comment.lineText.trim().length > 0 && comment.lineText !== fileName) {
             // Removed line or other content - show line content without line number
-            prompt += `  Line content: ${comment.lineText}\\n`;
+            prompt += `  Line content: ${comment.lineText}\n`;
           }
           // For file headers (lineText == fileName), just show the comment
-          prompt += `  Comment: ${comment.commentText}\\n`;
+          prompt += `  Comment: ${comment.commentText}\n`;
         });
-        prompt += "\\n";
+        prompt += "\n";
       });
 
       // Verify different formatting for each comment type
@@ -168,3 +168,4 @@ describe('Comment formatting for Claude prompts', () => {
     });
   });
 });
+

--- a/tests/unit/comment-line-mapping.test.tsx
+++ b/tests/unit/comment-line-mapping.test.tsx
@@ -109,3 +109,4 @@ describe('Comment line mapping and indexing', () => {
     });
   });
 });
+

--- a/tests/unit/diffWidthIssue.test.tsx
+++ b/tests/unit/diffWidthIssue.test.tsx
@@ -42,7 +42,7 @@ describe('DiffView Width Calculation Issue', () => {
     
     const newApproachOutput = leadingSpace + syntaxHighlightedText + padding;
     
-    console.log(`\\nNew approach (our branch):`);
+    console.log(`\nNew approach (our branch):`);
     console.log(`  Truncated text: "${truncatedText}" (${truncatedText.length} chars, ${stringDisplayWidth(truncatedText)} display width)`);
     console.log(`  Leading space: 1 char`);
     console.log(`  Padding: ${paddingChars} chars`);
@@ -53,7 +53,7 @@ describe('DiffView Width Calculation Issue', () => {
     const oldWidth = stringDisplayWidth(oldApproachOutput);
     const newWidth = stringDisplayWidth(newApproachOutput);
     
-    console.log(`\\nComparison:`);
+    console.log(`\nComparison:`);
     console.log(`  Old width: ${oldWidth} (${oldWidth === paneWidth ? 'CORRECT' : 'WRONG'})`);
     console.log(`  New width: ${newWidth} (${newWidth === paneWidth ? 'CORRECT' : 'WRONG'})`);
     
@@ -70,7 +70,7 @@ describe('DiffView Width Calculation Issue', () => {
     const widePaddingChars = Math.max(0, paneWidth - stringDisplayWidth(wideTruncated) - 1);
     const wideNewOutput = ' ' + wideTruncated + ' '.repeat(widePaddingChars);
     
-    console.log(`\\nWide character test:`);
+    console.log(`\nWide character test:`);
     console.log(`  Wide text: "${wideText}"`);
     console.log(`  Old approach width: ${stringDisplayWidth(wideOldOutput)} (${stringDisplayWidth(wideOldOutput) === paneWidth ? 'CORRECT' : 'WRONG'})`);
     console.log(`  New approach width: ${stringDisplayWidth(wideNewOutput)} (${stringDisplayWidth(wideNewOutput) === paneWidth ? 'CORRECT' : 'WRONG'})`);
@@ -95,7 +95,7 @@ describe('DiffView Width Calculation Issue', () => {
     // Line 1213 in DiffView.ts for syntax highlighting:
     const truncatedText = truncateDisplay(rightFullText, paneWidth - 1); // 38 chars for syntax
     
-    console.log(`\\nInconsistency in current code:`);
+    console.log(`\nInconsistency in current code:`);
     console.log(`  Original text: "${rightFullText}"`);
     console.log(`  Non-syntax truncation (paneWidth - 2): "${rightText}" (${stringDisplayWidth(rightText)} display chars)`);
     console.log(`  Syntax truncation (paneWidth - 1): "${truncatedText}" (${stringDisplayWidth(truncatedText)} display chars)`);
@@ -110,7 +110,7 @@ describe('DiffView Width Calculation Issue', () => {
     const padding = ' '.repeat(Math.max(0, paneWidth - stringDisplayWidth(truncatedText) - 1));
     const syntaxOutput = leadingSpace + syntaxText + padding;
     
-    console.log(`\\nFinal outputs:`);
+    console.log(`\nFinal outputs:`);
     console.log(`  Non-syntax: "${nonSyntaxOutput}" (${stringDisplayWidth(nonSyntaxOutput)} chars)`);
     console.log(`  Syntax:     "${syntaxOutput}" (${stringDisplayWidth(syntaxOutput)} chars)`);
     
@@ -119,7 +119,7 @@ describe('DiffView Width Calculation Issue', () => {
     const syntaxWidth = stringDisplayWidth(syntaxOutput);
     
     if (nonSyntaxWidth !== syntaxWidth) {
-      console.log(`\\nPROBLEM CONFIRMED: Width difference of ${syntaxWidth - nonSyntaxWidth} characters!`);
+      console.log(`\nPROBLEM CONFIRMED: Width difference of ${syntaxWidth - nonSyntaxWidth} characters!`);
       console.log(`This is the off-by-one error mentioned by the user.`);
     }
     
@@ -128,3 +128,4 @@ describe('DiffView Width Calculation Issue', () => {
     expect(syntaxWidth).toBe(paneWidth);
   });
 });
+

--- a/tests/unit/input-focus.test.tsx
+++ b/tests/unit/input-focus.test.tsx
@@ -384,3 +384,4 @@ describe('InputFocus Context E2E', () => {
     });
   });
 });
+


### PR DESCRIPTION
- Remove tests/integration folder\n- Move non-e2e tests from tests/e2e to tests/unit\n- Update jest.unit.config.js to drop integration glob\n- Verified all tests pass (43 suites, 398 tests)\n\nPer CLAUDE.md: keep tests as unit or e2e only.