### PR TITLE
feat(highlighting): map .mjs to JavaScript

### DIFF
--- a/src/shared/utils/languageMapping.ts
+++ b/src/shared/utils/languageMapping.ts
@@ -2,6 +2,7 @@
 
 export const LANGUAGE_MAP: Record<string, string> = {
   js: 'javascript',
+  mjs: 'javascript',
   jsx: 'javascript',
   ts: 'typescript',
   tsx: 'typescript',
@@ -106,4 +107,3 @@ export function getLanguageFromFileName(fileName: string | undefined): string {
 
   return LANGUAGE_MAP[ext || ''] || 'plaintext';
 }
-


### PR DESCRIPTION
- Change: add mjs -> javascript in language mapping\n- File: src/shared/utils/languageMapping.ts\n\nThis makes .mjs files use JS syntax highlighting in diffs.\n\nOptional follow-up: map .cjs -> JavaScript and .mts/.cts -> TypeScript for consistency.