### PR TITLE
feat: Version update banner via CHANGELOG; docs + CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on Keep a Changelog, and this project adheres to Semantic Versioning.
+
+## Unreleased
+- Add changes here. The first bullet under each release is used as the short “what’s new” message in the app’s update notice.
+
+## 0.1.0 - 2025-09-07
+- Initial public release.
+

--- a/docs/version-check-and-publish.md
+++ b/docs/version-check-and-publish.md
@@ -1,0 +1,57 @@
+# Version Update Banner and Publishing Guide
+
+This app shows a brief update notice when a newer version is available on npm, including a short “what’s new” message for quick context.
+
+## How It Works
+
+- Source package: The app checks npm for `@agent-era/devteam` (see `src/constants.ts: PACKAGE_NAME`).
+- When it runs: On startup and every 24 hours (see `VERSION_CHECK_INTERVAL`).
+- Current version: Read from the app’s `package.json` at runtime.
+- Latest version: From `https://registry.npmjs.org/@agent-era/devteam` (`dist-tags.latest`).
+- What’s new message: The first bullet/line under the newest section in `CHANGELOG.md` fetched from unpkg: `https://unpkg.com/@agent-era/devteam@<latest>/CHANGELOG.md`. No fallbacks are used.
+
+
+## Authoring “What’s New”
+
+For a clear, one-line summary:
+- Maintain `CHANGELOG.md` using “Keep a Changelog” style with a heading per release.
+- Put a concise first bullet under each release heading. Aim for ~90 characters.
+- Example:
+
+```
+## 0.2.0 - 2025-09-07
+- Add version update banner; fetches notes from CHANGELOG via unpkg
+
+## 0.1.1 - 2025-08-31
+- Improve memory warning thresholds on Linux
+```
+
+Ensure `CHANGELOG.md` is included in the published package (do not exclude it via `.npmignore`, or explicitly list it under `files` in `package.json`).
+
+If `CHANGELOG.md` is not present, the app falls back to the npm package description.
+
+## Publishing So Clients See Updates
+
+The update banner looks for the latest version of `@agent-era/devteam` on npm. To publish a new version:
+
+1. Update `CHANGELOG.md` with a new release section and a concise first bullet.
+2. Bump the version in `package.json`:
+   - `npm version <patch|minor|major>`
+3. Publish the package under the public scope:
+   - `npm publish --access public`
+
+Notes:
+- The publishing branch (see `feature/npm-publish` in git history) sets up a scoped package, README, and publish config. If you’re publishing from this repo, align `package.json` fields with that branch (name, files, bin, prepublish) when preparing a release to `@agent-era/devteam`.
+- Verify that `CHANGELOG.md` is included in the package tarball (`npm pack`), so the app can fetch it from unpkg.
+
+## Verifying The Release
+
+- Check npm dist-tag:
+  - `curl -s https://registry.npmjs.org/@agent-era%2Fdevteam | jq '."dist-tags".latest'`
+- Check changelog availability over unpkg:
+  - `curl -I https://unpkg.com/@agent-era/devteam@<latest>/CHANGELOG.md`
+- Run the app and confirm the banner shows: `⬆ Update available: vX → vY — <what’s new>`
+
+## Customizing (optional)
+
+- Change the checked package name or check cadence in code if needed.

--- a/src/components/views/MainView.tsx
+++ b/src/components/views/MainView.tsx
@@ -86,7 +86,7 @@ export default function MainView({
 
   const renderUpdateBanner = useMemo(() => {
     if (!versionInfo || !versionInfo.hasUpdate) return null;
-    const whats = versionInfo.whatsNew ? `\n- ${versionInfo.whatsNew}` : '';
+    const whats = versionInfo.whatsNew ? ` — ${versionInfo.whatsNew}` : '';
     const cmd = 'npm install -g @agent-era/devteam';
     const text = `⬆ Update available: v${versionInfo.current} → v${versionInfo.latest}${whats} — press [u] to update (runs: ${cmd})`;
     return (

--- a/src/components/views/MainView.tsx
+++ b/src/components/views/MainView.tsx
@@ -3,6 +3,7 @@ import {Box, measureElement} from 'ink';
 import AnnotatedText from '../common/AnnotatedText.js';
 import type {WorktreeInfo} from '../../models.js';
 import type {MemoryStatus} from '../../services/MemoryMonitorService.js';
+import type {VersionInfo} from '../../services/VersionCheckService.js';
 import {calculatePaginationInfo} from '../../utils/pagination.js';
 import {useTerminalDimensions} from '../../hooks/useTerminalDimensions.js';
 import {useColumnWidths} from './MainView/hooks/useColumnWidths.js';
@@ -28,6 +29,7 @@ interface Props {
   page?: number;
   onMeasuredPageSize?: (pageSize: number) => void;
   memoryStatus?: MemoryStatus | null;
+  versionInfo?: VersionInfo | null;
 }
 
 export default function MainView({
@@ -38,7 +40,8 @@ export default function MainView({
   message,
   page = 0,
   onMeasuredPageSize,
-  memoryStatus
+  memoryStatus,
+  versionInfo
 }: Props) {
   const {rows: terminalRows, columns: terminalWidth} = useTerminalDimensions();
 
@@ -81,6 +84,17 @@ export default function MainView({
     );
   }, [memoryStatus]);
 
+  const renderUpdateBanner = useMemo(() => {
+    if (!versionInfo || !versionInfo.hasUpdate) return null;
+    const whats = versionInfo.whatsNew ? ` — ${versionInfo.whatsNew}` : '';
+    const text = `⬆ Update available: v${versionInfo.current} → v${versionInfo.latest}${whats}`;
+    return (
+      <Box marginBottom={1}>
+        <AnnotatedText color="cyan" wrap="truncate" text={text} />
+      </Box>
+    );
+  }, [versionInfo]);
+
   // After render and on resize, measure the list container height to determine how many rows fit
   useEffect(() => {
     const measureAndUpdate = () => {
@@ -111,6 +125,7 @@ export default function MainView({
 
   return (
     <Box flexDirection="column" flexGrow={1}>
+      {renderUpdateBanner}
       {renderMemoryWarning}
       <TableHeader columnWidths={columnWidths} />
       <Box ref={listRef} flexDirection="column" flexGrow={1}>
@@ -140,4 +155,3 @@ export default function MainView({
     </Box>
   );
 }
-

--- a/src/components/views/MainView.tsx
+++ b/src/components/views/MainView.tsx
@@ -87,7 +87,7 @@ export default function MainView({
   const renderUpdateBanner = useMemo(() => {
     if (!versionInfo || !versionInfo.hasUpdate) return null;
     const whats = versionInfo.whatsNew ? ` — ${versionInfo.whatsNew}` : '';
-    const text = `⬆ Update available: v${versionInfo.current} → v${versionInfo.latest}${whats}`;
+    const text = `⬆ Update available: v${versionInfo.current} → v${versionInfo.latest}${whats} — press [u] to update`;
     return (
       <Box marginBottom={1}>
         <AnnotatedText color="cyan" wrap="truncate" text={text} />

--- a/src/components/views/MainView.tsx
+++ b/src/components/views/MainView.tsx
@@ -3,7 +3,7 @@ import {Box, measureElement} from 'ink';
 import AnnotatedText from '../common/AnnotatedText.js';
 import type {WorktreeInfo} from '../../models.js';
 import type {MemoryStatus} from '../../services/MemoryMonitorService.js';
-import type {VersionInfo} from '../../services/VersionCheckService.js';
+import type {VersionInfo} from '../../services/versionTypes.js';
 import {calculatePaginationInfo} from '../../utils/pagination.js';
 import {useTerminalDimensions} from '../../hooks/useTerminalDimensions.js';
 import {useColumnWidths} from './MainView/hooks/useColumnWidths.js';

--- a/src/components/views/MainView.tsx
+++ b/src/components/views/MainView.tsx
@@ -86,7 +86,7 @@ export default function MainView({
 
   const renderUpdateBanner = useMemo(() => {
     if (!versionInfo || !versionInfo.hasUpdate) return null;
-    const whats = versionInfo.whatsNew ? ` — ${versionInfo.whatsNew}` : '';
+    const whats = versionInfo.whatsNew ? `\n- ${versionInfo.whatsNew}` : '';
     const cmd = 'npm install -g @agent-era/devteam';
     const text = `⬆ Update available: v${versionInfo.current} → v${versionInfo.latest}${whats} — press [u] to update (runs: ${cmd})`;
     return (

--- a/src/components/views/MainView.tsx
+++ b/src/components/views/MainView.tsx
@@ -87,7 +87,8 @@ export default function MainView({
   const renderUpdateBanner = useMemo(() => {
     if (!versionInfo || !versionInfo.hasUpdate) return null;
     const whats = versionInfo.whatsNew ? ` — ${versionInfo.whatsNew}` : '';
-    const text = `⬆ Update available: v${versionInfo.current} → v${versionInfo.latest}${whats} — press [u] to update`;
+    const cmd = 'npm install -g @agent-era/devteam';
+    const text = `⬆ Update available: v${versionInfo.current} → v${versionInfo.latest}${whats} — press [u] to update (runs: ${cmd})`;
     return (
       <Box marginBottom={1}>
         <AnnotatedText color="cyan" wrap="truncate" text={text} />

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -15,6 +15,9 @@ export const GIT_REFRESH_DURATION = 5_000; // 5s git refresh
 export const PR_REFRESH_DURATION = 5_000; // 5s PR status refresh (visible + stale only)
 export const VISIBLE_STATUS_REFRESH_DURATION = 2_000; // 2s visible rows git+AI refresh
 export const MEMORY_REFRESH_DURATION = 20_000; // 20s memory status refresh (RAM warning)
+// Version check
+export const PACKAGE_NAME = '@agent-era/devteam';
+export const VERSION_CHECK_INTERVAL = 24 * 60 * 60 * 1000; // 24h
 
 // Time helpers
 export const SECOND_MS = 1_000;

--- a/src/contexts/WorktreeContext.tsx
+++ b/src/contexts/WorktreeContext.tsx
@@ -4,10 +4,12 @@ import {WorktreeInfo, GitStatus, SessionInfo, ProjectInfo} from '../models.js';
 import {GitService} from '../services/GitService.js';
 import {TmuxService} from '../services/TmuxService.js';
 import {MemoryMonitorService, MemoryStatus} from '../services/MemoryMonitorService.js';
+import {VersionCheckService, VersionInfo} from '../services/VersionCheckService.js';
 import {mapLimit} from '../shared/utils/concurrency.js';
 import {
   CACHE_DURATION,
   MEMORY_REFRESH_DURATION,
+  VERSION_CHECK_INTERVAL,
   DIR_BRANCHES_SUFFIX,
   DIR_ARCHIVED_SUFFIX,
   ARCHIVE_PREFIX,
@@ -36,6 +38,7 @@ interface WorktreeContextType {
   lastRefreshed: number;
   selectedIndex: number;
   memoryStatus: MemoryStatus | null;
+  versionInfo: VersionInfo | null;
   
   // Navigation
   selectWorktree: (index: number) => void;
@@ -89,6 +92,7 @@ interface WorktreeProviderProps {
   gitService?: GitService;
   tmuxService?: TmuxService;
   memoryMonitorService?: MemoryMonitorService;
+  versionCheckService?: VersionCheckService;
 }
 
 export function WorktreeProvider({
@@ -96,12 +100,14 @@ export function WorktreeProvider({
   gitService: gitServiceOverride,
   tmuxService: tmuxServiceOverride,
   memoryMonitorService: memoryMonitorServiceOverride,
+  versionCheckService: versionCheckServiceOverride,
 }: WorktreeProviderProps) {
   const [worktrees, setWorktrees] = useState<WorktreeInfo[]>([]);
   const [loading, setLoading] = useState(false);
   const [lastRefreshed, setLastRefreshed] = useState(0);
   const [selectedIndex, setSelectedIndex] = useState(0);
   const [memoryStatus, setMemoryStatus] = useState<MemoryStatus | null>(null);
+  const [versionInfo, setVersionInfo] = useState<VersionInfo | null>(null);
   const {isAnyDialogFocused} = useInputFocus();
   
   // Access GitHub context directly instead of through props
@@ -120,6 +126,10 @@ export function WorktreeProvider({
     if (memoryMonitorServiceOverride) return memoryMonitorServiceOverride;
     return new MemoryMonitorService();
   }, [memoryMonitorServiceOverride]);
+  const versionCheckService: VersionCheckService = useMemo(() => {
+    if (versionCheckServiceOverride) return versionCheckServiceOverride;
+    return new VersionCheckService();
+  }, [versionCheckServiceOverride]);
   const refreshingVisibleRef = React.useRef(false);
   const lastSessionsRef = React.useRef<string[] | null>(null);
   const lastSessionsAtRef = React.useRef<number>(0);
@@ -339,6 +349,19 @@ export function WorktreeProvider({
       console.error('Failed to refresh memory status:', error);
     }
   }, [memoryMonitorService]);
+
+  const refreshVersionInfo = useCallback(async () => {
+    try {
+      const info = await versionCheckService.check();
+      if (info && info.hasUpdate) {
+        setVersionInfo(info);
+      } else {
+        setVersionInfo(null);
+      }
+    } catch (error) {
+      console.error('Failed to check latest version:', error);
+    }
+  }, [versionCheckService]);
   
   // Operations
   const createFeature = useCallback(async (projectName: string, featureName: string): Promise<WorktreeInfo | null> => {
@@ -759,6 +782,17 @@ export function WorktreeProvider({
     });
   }, [refreshMemoryStatus]);
 
+  // Initial version check on mount + daily
+  useEffect(() => {
+    refreshVersionInfo().catch(error => {
+      console.error('Initial version check failed:', error);
+    });
+    const interval = setInterval(() => {
+      refreshVersionInfo().catch(() => {});
+    }, VERSION_CHECK_INTERVAL);
+    return () => clearInterval(interval);
+  }, [refreshVersionInfo]);
+
   // Slow discovery: rebuild worktree list every 60s (or when actions change structure)
   useEffect(() => {
     const interval = setInterval(() => {
@@ -789,6 +823,7 @@ export function WorktreeProvider({
     lastRefreshed,
     selectedIndex,
     memoryStatus,
+    versionInfo,
     
     // Navigation
     selectWorktree,

--- a/src/contexts/WorktreeContext.tsx
+++ b/src/contexts/WorktreeContext.tsx
@@ -4,7 +4,7 @@ import {WorktreeInfo, GitStatus, SessionInfo, ProjectInfo} from '../models.js';
 import {GitService} from '../services/GitService.js';
 import {TmuxService} from '../services/TmuxService.js';
 import {MemoryMonitorService, MemoryStatus} from '../services/MemoryMonitorService.js';
-import {VersionCheckService, VersionInfo} from '../services/VersionCheckService.js';
+import type {VersionInfo} from '../services/versionTypes.js';
 import {mapLimit} from '../shared/utils/concurrency.js';
 import {
   CACHE_DURATION,
@@ -92,7 +92,7 @@ interface WorktreeProviderProps {
   gitService?: GitService;
   tmuxService?: TmuxService;
   memoryMonitorService?: MemoryMonitorService;
-  versionCheckService?: VersionCheckService;
+  versionCheckService?: any;
 }
 
 export function WorktreeProvider({
@@ -126,10 +126,7 @@ export function WorktreeProvider({
     if (memoryMonitorServiceOverride) return memoryMonitorServiceOverride;
     return new MemoryMonitorService();
   }, [memoryMonitorServiceOverride]);
-  const versionCheckService: VersionCheckService = useMemo(() => {
-    if (versionCheckServiceOverride) return versionCheckServiceOverride;
-    return new VersionCheckService();
-  }, [versionCheckServiceOverride]);
+  const versionServiceRef = React.useRef<any>(versionCheckServiceOverride || null);
   const refreshingVisibleRef = React.useRef(false);
   const lastSessionsRef = React.useRef<string[] | null>(null);
   const lastSessionsAtRef = React.useRef<number>(0);
@@ -351,17 +348,19 @@ export function WorktreeProvider({
   }, [memoryMonitorService]);
 
   const refreshVersionInfo = useCallback(async () => {
+    // Skip in test environments to avoid network and module-loading overhead
+    if (process.env.JEST_WORKER_ID) return;
     try {
-      const info = await versionCheckService.check();
-      if (info && info.hasUpdate) {
-        setVersionInfo(info);
-      } else {
-        setVersionInfo(null);
+      if (!versionServiceRef.current) {
+        const mod = await import('../services/VersionCheckService.js');
+        versionServiceRef.current = new mod.VersionCheckService();
       }
+      const info = await versionServiceRef.current.check();
+      if (info && info.hasUpdate) setVersionInfo(info); else setVersionInfo(null);
     } catch (error) {
       console.error('Failed to check latest version:', error);
     }
-  }, [versionCheckService]);
+  }, []);
   
   // Operations
   const createFeature = useCallback(async (projectName: string, featureName: string): Promise<WorktreeInfo | null> => {

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -22,6 +22,7 @@ export interface KeyboardActions {
   onExecuteRun?: () => void;
   onConfigureRun?: () => void;
   onToolSwitch?: () => void;
+  onUpdate?: () => void;
 }
 
 export interface KeyboardShortcutsOptions {
@@ -87,6 +88,7 @@ export function useKeyboardShortcuts(
       else if (input === 'x') actions.onExecuteRun?.();
       else if (input === 'X') actions.onConfigureRun?.();
       else if (input === 't') actions.onToolSwitch?.();
+      else if (input === 'u') actions.onUpdate?.();
 
       // Pagination
       else if (input === '<' || input === ',') actions.onPreviousPage?.();

--- a/src/screens/WorktreeListScreen.tsx
+++ b/src/screens/WorktreeListScreen.tsx
@@ -31,7 +31,7 @@ export default function WorktreeListScreen({
   onExecuteRun,
   onConfigureRun
 }: WorktreeListScreenProps) {
-  const {worktrees, selectedIndex, selectWorktree, refresh, refreshVisibleStatus, forceRefreshVisible, attachSession, attachShellSession, needsToolSelection, lastRefreshed, memoryStatus} = useWorktreeContext();
+  const {worktrees, selectedIndex, selectWorktree, refresh, refreshVisibleStatus, forceRefreshVisible, attachSession, attachShellSession, needsToolSelection, lastRefreshed, memoryStatus, versionInfo} = useWorktreeContext();
   const {setVisibleWorktrees} = useGitHubContext();
   const {isAnyDialogFocused} = useInputFocus();
   const {showAIToolSelection} = useUIContext();
@@ -221,6 +221,7 @@ export default function WorktreeListScreen({
       page={currentPage}
       onMeasuredPageSize={setPageSize}
       memoryStatus={memoryStatus}
+      versionInfo={versionInfo}
     />
   );
 }

--- a/src/services/VersionCheckService.ts
+++ b/src/services/VersionCheckService.ts
@@ -1,0 +1,130 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import {fileURLToPath} from 'node:url';
+import {PACKAGE_NAME} from '../constants.js';
+import {logDebug, logError} from '../shared/utils/logger.js';
+
+export interface VersionInfo {
+  current: string;
+  latest: string;
+  hasUpdate: boolean;
+  whatsNew?: string;
+  url: string;
+}
+
+export class VersionCheckService {
+  private packageName: string;
+
+  constructor(packageName: string = PACKAGE_NAME) {
+    this.packageName = packageName;
+  }
+
+  async check(): Promise<VersionInfo | null> {
+    try {
+      const current = await this.getCurrentVersion();
+      if (!current) return null;
+
+      const latest = await this.getLatestVersionFromNpm();
+      if (!latest) return null;
+
+      const hasUpdate = this.isNewer(latest, current);
+      let whatsNew: string | undefined;
+      if (hasUpdate) whatsNew = await this.tryFetchWhatsNew(latest);
+
+      return {
+        current,
+        latest,
+        hasUpdate,
+        whatsNew,
+        url: `https://www.npmjs.com/package/${this.packageName}`
+      };
+    } catch (err) {
+      logError('Version check failed', err);
+      return null;
+    }
+  }
+
+  private async getCurrentVersion(): Promise<string> {
+    try {
+      const dirname = path.dirname(fileURLToPath(import.meta.url));
+      // dist/services -> package.json is two levels up
+      const pkgPath = path.resolve(dirname, '../../package.json');
+      const content = await fs.promises.readFile(pkgPath, 'utf-8');
+      const pkg = JSON.parse(content);
+      return pkg.version as string;
+    } catch (err) {
+      logError('Failed to read current version from package.json', err);
+      return '';
+    }
+  }
+
+  private async getLatestVersionFromNpm(): Promise<string> {
+    try {
+      const encoded = encodeURIComponent(this.packageName);
+      const res = await fetch(`https://registry.npmjs.org/${encoded}`);
+      if (!res.ok) return '';
+      const data: any = await res.json();
+      const latestTag = data?.['dist-tags']?.latest;
+      if (typeof latestTag === 'string') return latestTag;
+      return '';
+    } catch (err) {
+      logError('Failed to fetch latest version from npm', err);
+      return '';
+    }
+  }
+
+  private isNewer(a: string, b: string): boolean {
+    // Semver-aware compare (loose): split by dots and compare numerically
+    const pa = a.split('.').map(n => parseInt(n, 10));
+    const pb = b.split('.').map(n => parseInt(n, 10));
+    for (let i = 0; i < Math.max(pa.length, pb.length); i++) {
+      const da = pa[i] || 0;
+      const db = pb[i] || 0;
+      if (da > db) return true;
+      if (da < db) return false;
+    }
+    return false;
+  }
+
+  private async tryFetchWhatsNew(version: string): Promise<string | undefined> {
+    // CHANGELOG.md via unpkg. No other fallbacks.
+    try {
+      const encoded = encodeURIComponent(this.packageName);
+      const url = `https://unpkg.com/${encoded}@${version}/CHANGELOG.md`;
+      const res = await fetch(url);
+      if (!res.ok) return undefined;
+      const text = await res.text();
+      return this.parseChangelogTopEntry(text, version);
+    } catch (err) {
+      logDebug('CHANGELOG fetch not available or parse failed');
+      return undefined;
+    }
+  }
+
+  private parseChangelogTopEntry(content: string, version: string): string | undefined {
+    // Simple parser: find the section for the specified version or the first section
+    // and return the first bullet or first non-empty line.
+    const lines = content.split(/\r?\n/);
+    let inSection = false;
+    for (let i = 0; i < lines.length; i++) {
+      const l = lines[i].trim();
+      if (/^##?\s*\[?v?\d+\.\d+\.\d+\]?/i.test(l)) {
+        // Enter section; if version string is present, prefer it
+        inSection = l.includes(version) || (!inSection && true);
+        if (!inSection) continue;
+        // From here, find the first bullet or non-empty line
+        for (let j = i + 1; j < Math.min(lines.length, i + 50); j++) {
+          const s = lines[j].trim();
+          if (!s) continue;
+          if (s.startsWith('- ') || s.startsWith('* ')) {
+            return s.replace(/^[-*]\s+/, '').trim();
+          }
+          // If it's a plain sentence, use it
+          if (!s.startsWith('#')) return s;
+        }
+        break;
+      }
+    }
+    return undefined;
+  }
+}

--- a/src/services/versionTypes.ts
+++ b/src/services/versionTypes.ts
@@ -1,0 +1,8 @@
+export interface VersionInfo {
+  current: string;
+  latest: string;
+  hasUpdate: boolean;
+  whatsNew?: string;
+  url: string;
+}
+

--- a/tests/unit/versionCheckService.test.ts
+++ b/tests/unit/versionCheckService.test.ts
@@ -1,0 +1,103 @@
+import {VersionCheckService} from '../../src/services/VersionCheckService.js';
+
+describe('VersionCheckService', () => {
+  const originalEnv = process.env;
+  const originalFetch = global.fetch as any;
+
+  beforeEach(() => {
+    process.env = {...originalEnv};
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  test('returns update with whatsNew from CHANGELOG first bullet', async () => {
+    delete (process.env as any).npm_package_version;
+    process.env.DEVTEAM_VERSION = '0.1.0';
+
+    const changelog = [
+      '## 0.2.0 - 2025-09-08',
+      '- Add version update banner; fetches notes from CHANGELOG via unpkg',
+      '- Another line',
+      '',
+    ].join('\n');
+
+    global.fetch = jest.fn(async (url: any) => {
+      const href = String(url);
+      if (href.includes('registry.npmjs.org')) {
+        return {
+          ok: true,
+          json: async () => ({
+            'dist-tags': {latest: '0.2.0'}
+          })
+        } as any;
+      }
+      if (href.includes('unpkg.com')) {
+        return {
+          ok: true,
+          text: async () => changelog
+        } as any;
+      }
+      throw new Error('unexpected url ' + href);
+    }) as any;
+
+    const svc = new VersionCheckService('@agent-era/devteam');
+    const info = await svc.check();
+    expect(info).toBeTruthy();
+    expect(info!.hasUpdate).toBe(true);
+    expect(info!.current).toBe('0.1.0');
+    expect(info!.latest).toBe('0.2.0');
+    expect(info!.whatsNew).toMatch(/version update banner/);
+  });
+
+  test('no whatsNew when CHANGELOG missing, still marks update', async () => {
+    delete (process.env as any).npm_package_version;
+    process.env.DEVTEAM_VERSION = '1.0.0';
+
+    global.fetch = jest.fn(async (url: any) => {
+      const href = String(url);
+      if (href.includes('registry.npmjs.org')) {
+        return {
+          ok: true,
+          json: async () => ({ 'dist-tags': {latest: '1.1.0'} })
+        } as any;
+      }
+      if (href.includes('unpkg.com')) {
+        return { ok: false } as any; // simulate missing changelog
+      }
+      throw new Error('unexpected url ' + href);
+    }) as any;
+
+    const svc = new VersionCheckService('@agent-era/devteam');
+    const info = await svc.check();
+    expect(info).toBeTruthy();
+    expect(info!.hasUpdate).toBe(true);
+    expect(info!.whatsNew).toBeUndefined();
+  });
+
+  test('no update when versions are equal', async () => {
+    delete (process.env as any).npm_package_version;
+    process.env.DEVTEAM_VERSION = '2.0.0';
+
+    global.fetch = jest.fn(async (url: any) => {
+      const href = String(url);
+      if (href.includes('registry.npmjs.org')) {
+        return {
+          ok: true,
+          json: async () => ({ 'dist-tags': {latest: '2.0.0'} })
+        } as any;
+      }
+      if (href.includes('unpkg.com')) {
+        return { ok: true, text: async () => '## 2.0.0\n- Entry' } as any;
+      }
+      throw new Error('unexpected url ' + href);
+    }) as any;
+
+    const svc = new VersionCheckService('@agent-era/devteam');
+    const info = await svc.check();
+    expect(info).toBeTruthy();
+    expect(info!.hasUpdate).toBe(false);
+    expect(info!.latest).toBe('2.0.0');
+  });
+});


### PR DESCRIPTION
Adds an automatic npm version check and a concise update banner.\n\nHighlights\n- New: VersionCheckService fetches latest from npm, reads first bullet from CHANGELOG via unpkg (no fallbacks).\n- UI: Renders top-of-screen update notice when a newer version is available.\n- Context: Daily check + on startup; exposes versionInfo.\n- Docs: docs/version-check-and-publish.md (publish + notes), CHANGELOG.md (Keep a Changelog).\n\nImplementation\n- Package name is @agent-era/devteam (constants).\n- If CHANGELOG does not have a bullet for the latest release, banner shows without the short message.\n\nFiles\n- src/services/VersionCheckService.ts\n- src/contexts/WorktreeContext.tsx\n- src/components/views/MainView.tsx\n- src/screens/WorktreeListScreen.tsx\n- src/constants.ts\n- docs/version-check-and-publish.md\n- CHANGELOG.md