### PR TITLE
chore: add installer and release scripts; update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,12 @@ npm i -g @agent-era/devteam
 
 This installs the `devteam` command.
 
+Or run the provided installer script from a clone of this repo:
+
+```
+./install.sh
+```
+
 ## Usage
 
 Run the TUI in the top-level directory that you keep your git projects in:
@@ -66,3 +72,11 @@ npm publish --access public
 ```
 
 Note: `prepublishOnly` runs the build to ensure `dist/` is included in the published tarball.
+
+Convenience scripts:
+
+```
+npm run release:patch  # bump patch + publish
+npm run release:minor  # bump minor + publish
+npm run release:major  # bump major + publish
+```

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "==> DevTeam CLI installer (@agent-era/devteam)"
+
+# Check npm
+if ! command -v npm >/dev/null 2>&1; then
+  echo "Error: npm is not installed or not on PATH." >&2
+  echo "Install Node.js 18+ from https://nodejs.org and try again." >&2
+  exit 1
+fi
+
+# Check node version >= 18
+NODE_MAJOR=$(node -v | sed -E 's/^v([0-9]+).*/\1/')
+if [ "${NODE_MAJOR}" -lt 18 ]; then
+  echo "Error: Node.js >= 18 is required. Found $(node -v)." >&2
+  exit 1
+fi
+
+# Optional: check tmux presence and warn only
+if ! command -v tmux >/dev/null 2>&1; then
+  echo "Warning: tmux not found. DevTeam uses tmux for sessions." >&2
+  echo "Install tmux from your package manager for the best experience." >&2
+fi
+
+echo "==> Installing @agent-era/devteam globally via npm"
+npm i -g @agent-era/devteam
+
+echo "==> Verifying install"
+if command -v devteam >/dev/null 2>&1; then
+  echo "Success! Try: devteam --help"
+else
+  echo "Installed, but 'devteam' not on PATH. You may need to rehash your shell or restart terminal."
+fi
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@agent-era/devteam",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@agent-era/devteam",
-      "version": "0.1.0",
+      "version": "1.0.0",
       "dependencies": {
         "@inkjs/ui": "^2.0.0",
         "ink": "^5.2.1",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,10 @@
     "test": "jest",
     "test:watch": "jest --watch",
     "test:terminal": "npm run build && tsc -p tsconfig.node-tests.json && node --test tests/e2e/terminal/*.test.mjs",
-    "prepublishOnly": "npm run build"
+    "prepublishOnly": "npm run build",
+    "release:patch": "npm ci && npm version patch && npm publish --access public",
+    "release:minor": "npm ci && npm version minor && npm publish --access public",
+    "release:major": "npm ci && npm version major && npm publish --access public"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-era/devteam",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "description": "DevTeam: Git/Tmux development workflow TUI (Node + Ink)",
   "bin": {
     "devteam": "dist/bin/devteam.js"


### PR DESCRIPTION
This PR streamlines publishing and installation.\n\n- Add install.sh: one-command global install via npm with Node >=18 check and tmux warning.\n- Add npm scripts: release:patch|minor|major to build + publish (scoped public).\n- Update README: installer usage and new release scripts.\n\nNo functional runtime changes; build/publish only.