### PR TITLE
Improve zero-state: friendly welcome dialog and [n] hint when no worktrees

### DIFF
--- a/src/components/views/MainView.tsx
+++ b/src/components/views/MainView.tsx
@@ -30,6 +30,7 @@ interface Props {
   onMeasuredPageSize?: (pageSize: number) => void;
   memoryStatus?: MemoryStatus | null;
   versionInfo?: VersionInfo | null;
+  hasProjects?: boolean;
 }
 
 export default function MainView({
@@ -41,7 +42,8 @@ export default function MainView({
   page = 0,
   onMeasuredPageSize,
   memoryStatus,
-  versionInfo
+  versionInfo,
+  hasProjects,
 }: Props) {
   const {rows: terminalRows, columns: terminalWidth} = useTerminalDimensions();
 
@@ -121,7 +123,7 @@ export default function MainView({
   }
   
   if (!worktrees.length) {
-    return <EmptyState />;
+    return <EmptyState hasProjects={hasProjects} />;
   }
 
   return (

--- a/src/components/views/MainView/EmptyState.tsx
+++ b/src/components/views/MainView/EmptyState.tsx
@@ -1,17 +1,38 @@
 import React, {memo} from 'react';
 import {Box, Text} from 'ink';
-import {getProjectsDirectory} from '../../../config.js';
 
-export const EmptyState = memo(() => {
-  const projectsDir = getProjectsDirectory();
-  
-  return (
-    <Box flexDirection="column">
-      <Text color="yellow">No worktrees found.</Text>
-      <Text>Ensure your projects live under {projectsDir} and have worktrees in -branches folders.</Text>
-      <Text>Press q to quit.</Text>
-    </Box>
-  );
+interface EmptyStateProps {
+  hasProjects?: boolean;
+}
+
+export const EmptyState = memo(({hasProjects = false}: EmptyStateProps) => {
+
+  if (hasProjects) {
+    return (
+      <Box flexDirection="column" flexGrow={1} alignItems="center" justifyContent="center">
+        <Box
+          flexDirection="column"
+          borderStyle="round"
+          borderColor="cyan"
+          padding={1}
+          width={80}
+          alignSelf="center"
+        >
+          <Text bold color="cyan">Welcome to DevTeam</Text>
+          <Box marginTop={1} />
+          <Text>
+            Press <Text bold>[n]</Text> to create a new branch (we'll set up a git worktree for it).
+          </Text>
+          <Box marginTop={1} />
+          <Text color="magenta">Press [q] to quit</Text>
+        </Box>
+      </Box>
+    );
+  }
+
+  // No projects case is handled by NoProjectsDialog at the App level.
+  // Render nothing here to avoid redundant messaging.
+  return null;
 });
 
 EmptyState.displayName = 'EmptyState';

--- a/src/screens/WorktreeListScreen.tsx
+++ b/src/screens/WorktreeListScreen.tsx
@@ -31,12 +31,13 @@ export default function WorktreeListScreen({
   onExecuteRun,
   onConfigureRun
 }: WorktreeListScreenProps) {
-  const {worktrees, selectedIndex, selectWorktree, refresh, refreshVisibleStatus, forceRefreshVisible, attachSession, attachShellSession, needsToolSelection, lastRefreshed, memoryStatus, versionInfo} = useWorktreeContext();
+  const {worktrees, selectedIndex, selectWorktree, refresh, refreshVisibleStatus, forceRefreshVisible, attachSession, attachShellSession, needsToolSelection, lastRefreshed, memoryStatus, versionInfo, discoverProjects} = useWorktreeContext();
   const {setVisibleWorktrees} = useGitHubContext();
   const {isAnyDialogFocused} = useInputFocus();
   const {showAIToolSelection, tmuxHintShown, showTmuxHintFor} = useUIContext();
   const [pageSize, setPageSize] = useState(1);
   const [currentPage, setCurrentPage] = useState(0);
+  const [hasProjects, setHasProjects] = useState<boolean>(false);
 
   // Refresh data when component mounts, but only if data is missing or very stale
   useEffect(() => {
@@ -47,6 +48,16 @@ export default function WorktreeListScreen({
       refresh('none').catch(() => {});
     }
   }, []); // Only on mount
+
+  // Detect whether any projects are available (used for zero-state message)
+  useEffect(() => {
+    try {
+      const projects = discoverProjects();
+      setHasProjects(Array.isArray(projects) && projects.length > 0);
+    } catch {
+      setHasProjects(false);
+    }
+  }, []);
 
   // Keep GitHub context informed of which worktrees are visible (current page)
   useEffect(() => {
@@ -248,6 +259,7 @@ export default function WorktreeListScreen({
       onMeasuredPageSize={setPageSize}
       memoryStatus={memoryStatus}
       versionInfo={versionInfo}
+      hasProjects={hasProjects}
     />
   );
 }


### PR DESCRIPTION
Summary\n- Show a centered, welcoming dialog when projects exist but there are no worktrees.\n- Clear call-to-action: Press [n] to create a new branch (we'll set up a git worktree).\n- Remove redundant zero-projects guidance in EmptyState; rely on the dedicated NoProjectsDialog.\n\nBehavior\n- Projects exist + zero worktrees: friendly welcome dialog with the [n] hint; no extra navigation text.\n- No projects discovered: existing NoProjectsDialog remains the sole prompt.\n\nImplementation\n- MainView/EmptyState: redesigned to dialog style; accepts hasProjects and renders only the relevant case.\n- MainView: passes hasProjects through to EmptyState.\n- WorktreeListScreen: detects projects via discoverProjects() and passes hasProjects.\n\nFiles changed\n- src/components/views/MainView/EmptyState.tsx\n- src/components/views/MainView.tsx\n- src/screens/WorktreeListScreen.tsx\n\nNotes\n- Keeps initial experience welcoming and actionable; avoids jargon by focusing on "branch" and mentioning we set up a git worktree for it.