### PR TITLE
test(e2e): zero-state coverage (no projects, empty list)

### DIFF
--- a/tests/e2e/terminal/zero-state-empty.test.mjs
+++ b/tests/e2e/terminal/zero-state-empty.test.mjs
@@ -1,0 +1,25 @@
+import {test} from 'node:test';
+import assert from 'node:assert/strict';
+import React from 'react';
+
+test('MainView shows EmptyState when projects exist but no worktrees', async () => {
+  const {render} = await import('../../../node_modules/ink-testing-library/build/index.js');
+  const MainView = (await import('../../../dist/components/views/MainView.js')).default;
+
+  const {lastFrame, unmount} = render(
+    React.createElement(MainView, {
+      worktrees: [],
+      selectedIndex: 0,
+      page: 0,
+      hasProjects: true,
+    })
+  );
+
+  await new Promise(r => setTimeout(r, 100));
+  const frame = lastFrame?.() || '';
+  assert.ok(frame.includes('Welcome to DevTeam'), 'Expected EmptyState welcome text');
+  assert.ok(frame.includes('Press [n] to create a new branch'), 'Expected create-branch hint');
+  assert.ok(frame.includes('Press [q] to quit'), 'Expected quit hint');
+  try { unmount?.(); } catch {}
+});
+

--- a/tests/e2e/terminal/zero-state-no-projects.test.mjs
+++ b/tests/e2e/terminal/zero-state-no-projects.test.mjs
@@ -1,0 +1,49 @@
+import {test} from 'node:test';
+import assert from 'node:assert/strict';
+import React from 'react';
+
+test('App shows NoProjectsDialog when no projects discovered', async () => {
+  const Ink = await import('../../../node_modules/ink/build/index.js');
+  const {TestableApp} = await import('../../../dist/App.js');
+  const {FakeGitService} = await import('../../../dist-tests/tests/fakes/FakeGitService.js');
+  const {FakeTmuxService} = await import('../../../dist-tests/tests/fakes/FakeTmuxService.js');
+  const {FakeGitHubService} = await import('../../../dist-tests/tests/fakes/FakeGitHubService.js');
+  const {memoryStore} = await import('../../../dist-tests/tests/fakes/stores.js');
+
+  // Ensure zero projects
+  memoryStore.reset();
+
+  // Custom stdout/stdin to satisfy Ink raw-mode and capture frames
+  const {EventEmitter} = await import('node:events');
+  class CapturingStdout extends EventEmitter {
+    constructor(){ super(); this.frames=[]; this._last=''; this.isTTY=true; this.columns=100; this.rows=30; }
+    write(chunk){ const s = typeof chunk === 'string'? chunk: String(chunk); this.frames.push(s); this._last=s; return true; }
+    lastFrame(){ return this._last; }
+    on(){ return super.on(...arguments); }
+    off(){ return super.off(...arguments); }
+  }
+  class StdinStub extends EventEmitter {
+    constructor(){ super(); this.isTTY=true; }
+    setEncoding(){}
+    setRawMode(){}
+    ref(){}
+    unref(){}
+    read(){ return null; }
+  }
+  const stdout = new CapturingStdout();
+  const stdin = new StdinStub();
+
+  const tree = React.createElement(TestableApp, {
+    gitService: new FakeGitService('/fake/projects'),
+    gitHubService: new FakeGitHubService(),
+    tmuxService: new FakeTmuxService()
+  });
+  const inst = Ink.render(tree, {stdout, stdin, debug: true, exitOnCtrlC: false, patchConsole: false});
+  await new Promise(r => setTimeout(r, 200));
+  const frame = stdout.lastFrame() || '';
+  assert.ok(frame.includes('No projects found'), 'Expected NoProjectsDialog title');
+  assert.ok(frame.includes('has no project folders with a .git'), 'Expected NoProjectsDialog guidance');
+  assert.ok(frame.includes('Press [enter] or [q] to exit'), 'Expected exit hint');
+  try { inst.unmount?.(); } catch {}
+});
+

--- a/tests/e2e/zero-state.test.tsx
+++ b/tests/e2e/zero-state.test.tsx
@@ -1,0 +1,61 @@
+import {describe, beforeEach, test, expect} from '@jest/globals';
+import {renderTestApp} from '../utils/renderApp.js';
+import {
+  resetTestData,
+  setupBasicProject,
+  simulateTimeDelay,
+  memoryStore,
+} from '../utils/testHelpers.js';
+
+describe('Zero-State E2E (mock-rendered)', () => {
+  beforeEach(() => {
+    resetTestData();
+  });
+
+  test('shows no-worktrees message when no projects exist', async () => {
+    // No projects and no worktrees in memory
+    const {lastFrame} = renderTestApp();
+    await simulateTimeDelay(50);
+
+    const output = lastFrame();
+    expect(output).toContain('No worktrees found');
+    expect(output).toContain('Ensure your projects have worktrees');
+    expect(output).toContain('Press q to quit');
+  });
+
+  test('shows list header (no rows) when projects exist but no worktrees', async () => {
+    // Project exists, but no worktrees yet
+    setupBasicProject('demo');
+
+    const {lastFrame} = renderTestApp();
+    await simulateTimeDelay(50);
+
+    const output = lastFrame();
+    // Should not show the "no worktrees" zero-state since projects exist
+    expect(output).not.toContain('No worktrees found');
+    // Should show the main header and columns even with zero rows
+    expect(output).toContain('Enter attach, n new, a archive, x exec, d diff, s shell, q quit');
+    expect(output).toContain('#    PROJECT/FEATURE        AI  DIFF     CHANGES  PUSHED  PR');
+  });
+
+  test('transitions from empty to non-empty after creating first worktree', async () => {
+    // Start with project and no worktrees
+    setupBasicProject('demo');
+
+    const {services, lastFrame} = renderTestApp();
+    await simulateTimeDelay(50);
+
+    // Initially no rows, show header
+    let output = lastFrame();
+    expect(output).toContain('#    PROJECT/FEATURE');
+    expect(output).not.toContain('demo/');
+
+    // Create first worktree via fake git service
+    services.gitService.createWorktree('demo', 'first-feature');
+    await simulateTimeDelay(100);
+
+    output = lastFrame();
+    expect(output).toContain('demo/first-feature');
+  });
+});
+


### PR DESCRIPTION
Adds comprehensive zero-state end-to-end tests:

- Mock-rendered Jest E2E: verifies messages when there are no projects; verifies header-only state when projects exist but no worktrees; verifies transition after first worktree creation.
- Terminal E2E (real Ink): verifies EmptyState when projects exist but no worktrees; verifies NoProjectsDialog when no projects are discovered.

All tests pass locally; build and typecheck are green. No app code changes.
