### PR TITLE
Remove Shift+Enter; TextInput is single-line per ink-ui

### DIFF
--- a/src/components/dialogs/CommentInputDialog.tsx
+++ b/src/components/dialogs/CommentInputDialog.tsx
@@ -26,12 +26,6 @@ const CommentInputDialog = React.memo(function CommentInputDialog({fileName, lin
       onCancel();
       return;
     }
-
-    if (key.return && key.shift) {
-      // Handle newlines for multi-line comments
-      setComment(prev => prev + '\n');
-      return;
-    }
   });
 
   const handleSubmit = (value: string) => {
@@ -74,7 +68,7 @@ const CommentInputDialog = React.memo(function CommentInputDialog({fileName, lin
           onChange={handleChange}
         />
       </Box>
-      <AnnotatedText color="magenta" wrap="truncate" text={'[enter] save  [shift]+[enter] new line  [esc] cancel'} />
+      <AnnotatedText color="magenta" wrap="truncate" text={'[enter] save  [esc] cancel'} />
     </Box>
   );
 });


### PR DESCRIPTION
- Remove Shift+Enter newline handling in comment dialog\n- Update helper text to reflect single-line input\n\nink-ui's TextInput is single-line (see docs), so Shift+Enter shouldn't attempt to insert a newline.