### PR TITLE
DiffView: add Shift+↑/↓, shorten labels, send to agent

### DIFF
--- a/src/components/views/DiffView.tsx
+++ b/src/components/views/DiffView.tsx
@@ -1726,7 +1726,7 @@ export default function DiffView({worktreePath, title = 'Diff Viewer', onClose, 
         <AnnotatedText
           color="magenta"
           wrap="truncate"
-          text={truncateDisplay(`[j]/[k] move  toggle [v]iew (${viewMode})  toggle [w]rap (${wrapMode})  [c]omment  [C] show all  [d]elete  [S]end to Claude  [q] close`, terminalWidth)}
+          text={truncateDisplay(`Shift+↑/↓ prev/next file  [v]iew (${viewMode})  [w]rap (${wrapMode})  [c]omment  [C] show all  [d]elete  [S]end to agent  [q] close`, terminalWidth)}
         />
       )}
       


### PR DESCRIPTION
Summary
- Update DiffView help footer to show Shift+↑/↓ for prev/next file
- Shorten labels: use [w]rap, drop "toggle"
- Rename "Send to Claude" to "Send to agent"
- Remove "jk" nav hint

Rationale
- Make file navigation discoverable and align with implemented Shift+Up/Down handlers
- Reduce verbosity to maximize horizontal space in narrow terminals
- Terminology now refers to the active AI agent rather than a specific tool

Notes
- No behavior changes beyond the footer text; keyboard handlers already supported Shift+Up/Down
- Safe, UI-only change

Testing
- Manually verified footer renders with new text in DiffView
- No tests rely on exact footer string; no updates required