### PR TITLE
ci: disable terminal tests in CI (flaky)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,6 @@ on:
     paths:
       - 'src/**'
       - 'tests/**' 
-      - 'tests/e2e/terminal/**'
       - 'package.json'
       - 'package-lock.json'
       - 'tsconfig.json'
@@ -17,7 +16,6 @@ on:
     paths:
       - 'src/**'
       - 'tests/**'
-      - 'tests/e2e/terminal/**'
       - 'package.json'
       - 'package-lock.json' 
       - 'tsconfig.json'
@@ -47,9 +45,6 @@ jobs:
 
     - name: Run all tests
       run: npm test -- --coverage --watchAll=false
-
-    - name: Run terminal rendering tests (node:test)
-      run: npm run test:terminal
 
     - name: Upload coverage reports to Codecov
       uses: codecov/codecov-action@v4


### PR DESCRIPTION
This PR disables the terminal rendering tests from the GitHub Actions test workflow due to flakiness.\n\nChanges:\n- Remove 'test:terminal' step from CI.\n- Remove 'tests/e2e/terminal/**' from workflow path filters so edits there don’t trigger CI.\n\nImpact:\n- CI runs typecheck and Jest tests (unit + mock-rendered E2E) only.\n- Terminal tests remain available locally via 'npm run test:terminal'.\n\nFollow-ups (optional):\n- Consider a scheduled/nightly workflow or manual dispatch to run terminal tests occasionally.\n- Re-enable once stability improves.