### PR TITLE
UI: replace 'Claude' with 'agent' in non-functional dialog text

### DIFF
--- a/src/components/dialogs/SessionWaitingDialog.tsx
+++ b/src/components/dialogs/SessionWaitingDialog.tsx
@@ -30,14 +30,14 @@ export default function SessionWaitingDialog({sessionName, onGoToSession, onCanc
       width={80}
       alignSelf="center"
     >
-      <Text bold color="yellow">⚠ Claude is Waiting for Response</Text>
+      <Text bold color="yellow">⚠ Agent is Waiting for Response</Text>
       <Box marginTop={1} marginBottom={1} />
-      <Text>Claude in session "{sessionName}" is waiting for a response to a question</Text>
+      <Text>Agent in session "{sessionName}" is waiting for a response to a question</Text>
       <Text>and cannot accept new input right now.</Text>
       <Box marginTop={1} marginBottom={1} />
       <Text bold>Options:</Text>
-      <Text>• Go to session to respond to Claude's question</Text>
-      <Text>• Cancel and try again later when Claude is idle</Text>
+      <Text>• Go to session to respond to the agent's question</Text>
+      <Text>• Cancel and try again later when the agent is idle</Text>
       <Box marginTop={1} marginBottom={1} />
       <AnnotatedText color="magenta" wrap="truncate" text={'[g]o to session  •  [c]ancel  •  [esc] cancel'} />
     </Box>

--- a/src/components/dialogs/UnsubmittedCommentsDialog.tsx
+++ b/src/components/dialogs/UnsubmittedCommentsDialog.tsx
@@ -24,7 +24,7 @@ export default function UnsubmittedCommentsDialog({commentCount, onSubmit, onExi
       <Text>What would you like to do?</Text>
       <Text></Text>
       <Box marginTop={1} />
-      <AnnotatedText color="green" text={'[S]ubmit comments to Claude'} />
+      <AnnotatedText color="green" text={'[S]ubmit comments to agent'} />
       <AnnotatedText color="blue" text={'[q] exit without submitting (comments will be kept)'} />
       <AnnotatedText color="magenta" wrap="truncate" text={'[esc] cancel (return to diff view)'} />
     </Box>


### PR DESCRIPTION
This PR updates UI text to use ‘agent’ (not Claude) where the action is tool-agnostic.\n\nChanges:\n- UnsubmittedCommentsDialog: ‘[S]ubmit comments to agent’\n- SessionWaitingDialog: ‘Agent is Waiting for Response’ and related lines\n\nNotes:\n- No functional changes.\n- Typecheck and full test suite pass (47/47).