### PR TITLE
Clean ignored files when archiving

### DIFF
--- a/src/services/GitService.ts
+++ b/src/services/GitService.ts
@@ -477,10 +477,17 @@ export class GitService {
       fs.symlinkSync(claudeDirSrc, claudeDirDst, 'dir');
     }
   }
-
+  
   
 
   archiveWorktree(project: string, sourcePath: string, archivedDest: string): void {
+    // Clean ignored files in the worktree before archiving
+    try {
+      runCommandQuick(['git', '-C', sourcePath, 'clean', '-fdX']);
+    } catch {
+      // Silent failure; cleaning is best-effort and should not block archiving
+    }
+
     try {
       fs.renameSync(sourcePath, archivedDest);
     } catch {

--- a/tests/unit/git-archive-clean.test.ts
+++ b/tests/unit/git-archive-clean.test.ts
@@ -1,0 +1,57 @@
+import {describe, beforeEach, test, expect, jest} from '@jest/globals';
+
+jest.mock('../../src/shared/utils/commandExecutor.js');
+jest.mock('node:fs');
+
+import {GitService} from '../../src/services/GitService.js';
+import * as commandExecutor from '../../src/shared/utils/commandExecutor.js';
+import fs from 'node:fs';
+
+const mockCommandExecutor = commandExecutor as jest.Mocked<typeof commandExecutor>;
+const mockFs = fs as jest.Mocked<typeof fs>;
+
+describe('GitService archiveWorktree cleaning', () => {
+  let gitService: GitService;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    gitService = new GitService('/base/path');
+
+    // Default mocks
+    mockCommandExecutor.runCommandQuick.mockReturnValue('');
+    mockFs.renameSync.mockImplementation((() => undefined) as any);
+  });
+
+  test('runs git clean -fdX before archiving', () => {
+    const sourcePath = '/proj-branches/feature-x';
+    const archivedDest = '/proj-archived/archived-123_feature-x';
+
+    gitService.archiveWorktree('proj', sourcePath, archivedDest);
+
+    // Ensure the clean command was called for ignored files only (-X)
+    expect(mockCommandExecutor.runCommandQuick).toHaveBeenCalledWith(
+      ['git', '-C', sourcePath, 'clean', '-fdX']
+    );
+
+    // Ensure the move was attempted
+    expect(mockFs.renameSync).toHaveBeenCalledWith(sourcePath, archivedDest);
+
+    // Ensure clean ran before rename (call order)
+    const cleanCall = mockCommandExecutor.runCommandQuick.mock.invocationCallOrder[0];
+    const renameCall = mockFs.renameSync.mock.invocationCallOrder[0];
+    expect(cleanCall).toBeLessThan(renameCall);
+  });
+
+  test('continues archiving if clean fails', () => {
+    const sourcePath = '/proj-branches/feature-y';
+    const archivedDest = '/proj-archived/archived-456_feature-y';
+
+    // Simulate clean throwing (e.g., git not available). Our code should ignore and continue.
+    mockCommandExecutor.runCommandQuick.mockImplementation(() => { throw new Error('git failed'); });
+
+    gitService.archiveWorktree('proj', sourcePath, archivedDest);
+
+    // Rename should still be attempted even if clean throws
+    expect(mockFs.renameSync).toHaveBeenCalledWith(sourcePath, archivedDest);
+  });
+});


### PR DESCRIPTION
This PR cleans git-ignored files prior to archiving a worktree.

Changes
- Run `git clean -fdX` in the worktree before moving to archived.
- Best-effort: failures are ignored so archiving proceeds.
- Adds unit test to verify the clean command and call ordering.

Why
- Keeps archived copies free of build artifacts, node_modules, and other ignored files while preserving any unignored work-in-progress.

Testing
- Typecheck passes (`npm run typecheck`).
- Full test suite passes (`npm test -- --runInBand`).
