### PR TITLE
fix(diff): prevent crash on empty diffs in DiffView

### DIFF
--- a/src/components/views/DiffView.tsx
+++ b/src/components/views/DiffView.tsx
@@ -436,7 +436,7 @@ export default function DiffView({worktreePath, title = 'Diff Viewer', onClose, 
         }
       } else {
         const currentLine = sideBySideLines[selectedLine];
-        const fileName = currentLine.left?.fileName || currentLine.right?.fileName;
+        const fileName = currentLine?.left?.fileName || currentLine?.right?.fileName;
         if (currentLine && fileName) {
           const perFileIndex = sideBySidePerFileIndex[selectedLine];
           if (perFileIndex !== undefined) {
@@ -875,8 +875,8 @@ export default function DiffView({worktreePath, title = 'Diff Viewer', onClose, 
       }
     } else {
       const currentLine = sideBySideLines[selectedLine];
-      const fileName = currentLine.right?.fileName || currentLine.left?.fileName;
-      const lineText = currentLine.right?.text || currentLine.left?.text;
+      const fileName = currentLine?.right?.fileName || currentLine?.left?.fileName;
+      const lineText = currentLine?.right?.text || currentLine?.left?.text;
       
       if (currentLine && fileName && lineText) {
         const perFileIndex = sideBySidePerFileIndex[selectedLine];
@@ -886,12 +886,12 @@ export default function DiffView({worktreePath, title = 'Diff Viewer', onClose, 
         } else {
           // New logic for removed lines and file headers
           let textForComment = '';
-          if (currentLine.left?.type === 'header' && currentLine.left.headerType === 'file') {
+          if (currentLine?.left?.type === 'header' && currentLine.left.headerType === 'file') {
             // File header - use filename as line text
             textForComment = fileName || '';
           } else {
             // Removed lines - use the line text
-            textForComment = currentLine.left?.text || lineText;
+            textForComment = currentLine?.left?.text || lineText;
           }
           commentStore.addComment(undefined, fileName, textForComment, commentText);
         }


### PR DESCRIPTION
This PR fixes a crash in the DiffView when viewing side-by-side diffs with no selectable line (e.g., empty or minimal diffs).\n\nProblem\n- Pressing keys that operate on the current side-by-side line could access undefined / objects.\n- Runtime stack: TypeError: Cannot read properties of undefined (reading 'left') at DiffView.js around comment delete/save handlers.\n\nFix\n- Guard all side-by-side current line lookups with optional chaining (, ).\n- Apply guards in delete-comment and save-comment paths.\n\nVerification\n- 
> @agent-era/devteam@1.0.6 typecheck
> npm install && tsc -p tsconfig.test.json


up to date, audited 676 packages in 1s

111 packages are looking for funding
  run `npm fund` for details

found 0 vulnerabilities passes.\n- 
> @agent-era/devteam@1.0.6 build
> rm -rf dist && tsc -p . succeeds.\n- Manual check: no crash when opening DiffView on empty diffs and using comment/delete keys.\n\nScope\n- No UI changes.\n- No behavior changes outside preventing the crash.