### PR TITLE
Fix: file-level comment duplication

### DIFF
--- a/src/components/views/DiffView.tsx
+++ b/src/components/views/DiffView.tsx
@@ -193,6 +193,41 @@ type Props = {worktreePath: string; title?: string; onClose: () => void; diffTyp
 type ViewMode = 'unified' | 'sidebyside';
 type WrapMode = 'truncate' | 'wrap';
 
+// Exported utility for formatting comments into a Claude-friendly prompt
+export function formatCommentsAsPrompt(comments: any[]): string {
+  let prompt = "Please address the following code review comments:\n\n";
+
+  const commentsByFile: {[key: string]: typeof comments} = {};
+  comments.forEach(comment => {
+    if (!commentsByFile[comment.fileName]) {
+      commentsByFile[comment.fileName] = [];
+    }
+    commentsByFile[comment.fileName].push(comment);
+  });
+
+  Object.entries(commentsByFile).forEach(([fileName, fileComments]) => {
+    prompt += `File: ${fileName}\n`;
+    fileComments.forEach(comment => {
+      if (comment.lineIndex !== undefined) {
+        // Normal line with line number
+        prompt += `  Line ${comment.lineIndex + 1}: ${comment.lineText}\n`;
+      } else if (
+        comment.lineText &&
+        comment.lineText.trim().length > 0 &&
+        !comment.isFileLevel
+      ) {
+        // Removed line or other content - show line content without line number
+        prompt += `  Line content: ${comment.lineText}\n`;
+      }
+      // For file headers (no meaningful lineText), just show the comment
+      prompt += `  Comment: ${comment.commentText}\n`;
+    });
+    prompt += "\n";
+  });
+
+  return prompt;
+}
+
 export default function DiffView({worktreePath, title = 'Diff Viewer', onClose, diffType = 'full', onAttachToSession}: Props) {
   const {rows: terminalHeight, columns: terminalWidth} = useTerminalDimensions();
   const [lines, setLines] = useState<DiffLine[]>([]);
@@ -667,35 +702,7 @@ export default function DiffView({worktreePath, title = 'Diff Viewer', onClose, 
     }
   }, [selectedLine, viewMode, wrapMode, terminalWidth, lines, sideBySideLines, measuredPageSize, isFileNavigation]);
 
-  const formatCommentsAsPrompt = (comments: any[]): string => {
-    let prompt = "Please address the following code review comments:\\n\\n";
-    
-    const commentsByFile: {[key: string]: typeof comments} = {};
-    comments.forEach(comment => {
-      if (!commentsByFile[comment.fileName]) {
-        commentsByFile[comment.fileName] = [];
-      }
-      commentsByFile[comment.fileName].push(comment);
-    });
-
-    Object.entries(commentsByFile).forEach(([fileName, fileComments]) => {
-      prompt += `File: ${fileName}\\n`;
-      fileComments.forEach(comment => {
-        if (comment.lineIndex !== undefined) {
-          // Normal line with line number
-          prompt += `  Line ${comment.lineIndex + 1}: ${comment.lineText}\\n`;
-        } else if (comment.lineText && comment.lineText.trim().length > 0) {
-          // Removed line or other content - show line content without line number
-          prompt += `  Line content: ${comment.lineText}\\n`;
-        }
-        // For file headers (no meaningful lineText), just show the comment
-        prompt += `  Comment: ${comment.commentText}\\n`;
-      });
-      prompt += "\\n";
-    });
-    
-    return prompt;
-  };
+  
 
   const getLastTwoCommentLines = (comments: any[]): string[] => {
     const lines: string[] = [];
@@ -764,7 +771,15 @@ export default function DiffView({worktreePath, title = 'Diff Viewer', onClose, 
     Object.entries(commentsByFile).forEach(([fileName, fileComments]) => {
       messageLines.push(`File: ${fileName}`);
       fileComments.forEach(comment => {
-        messageLines.push(`  Line ${comment.lineIndex + 1}: ${comment.lineText}`);
+        if (comment.lineIndex !== undefined) {
+          messageLines.push(`  Line ${comment.lineIndex + 1}: ${comment.lineText}`);
+        } else if (
+          comment.lineText &&
+          comment.lineText.trim().length > 0 &&
+          !comment.isFileLevel
+        ) {
+          messageLines.push(`  Line content: ${comment.lineText}`);
+        }
         messageLines.push(`  Comment: ${comment.commentText}`);
       });
       messageLines.push("");
@@ -866,11 +881,12 @@ export default function DiffView({worktreePath, title = 'Diff Viewer', onClose, 
         const perFileIndex = unifiedPerFileIndex[selectedLine];
         if (perFileIndex !== undefined) {
           // Original logic for lines with valid line numbers
-          commentStore.addComment(perFileIndex, currentLine.fileName, currentLine.text, commentText);
+          commentStore.addComment(perFileIndex, currentLine.fileName, currentLine.text, commentText, false);
         } else {
           // New logic for removed lines and file headers
-          const lineText = currentLine.type === 'header' ? currentLine.fileName : currentLine.text;
-          commentStore.addComment(undefined, currentLine.fileName, lineText, commentText);
+          const isFileLevel = currentLine.type === 'header' && currentLine.headerType === 'file';
+          const lineText = isFileLevel ? (currentLine.fileName || '') : currentLine.text;
+          commentStore.addComment(undefined, currentLine.fileName, lineText, commentText, isFileLevel);
         }
       }
     } else {
@@ -882,18 +898,19 @@ export default function DiffView({worktreePath, title = 'Diff Viewer', onClose, 
         const perFileIndex = sideBySidePerFileIndex[selectedLine];
         if (perFileIndex !== undefined) {
           // Original logic for lines with valid line numbers
-          commentStore.addComment(perFileIndex, fileName, lineText, commentText);
+          commentStore.addComment(perFileIndex, fileName, lineText, commentText, false);
         } else {
           // New logic for removed lines and file headers
           let textForComment = '';
-          if (currentLine?.left?.type === 'header' && currentLine.left.headerType === 'file') {
+          const isFileLevel = currentLine?.left?.type === 'header' && currentLine.left.headerType === 'file';
+          if (isFileLevel) {
             // File header - use filename as line text
             textForComment = fileName || '';
           } else {
             // Removed lines - use the line text
             textForComment = currentLine?.left?.text || lineText;
           }
-          commentStore.addComment(undefined, fileName, textForComment, commentText);
+          commentStore.addComment(undefined, fileName, textForComment, commentText, isFileLevel);
         }
       }
     }

--- a/src/models.ts
+++ b/src/models.ts
@@ -179,12 +179,14 @@ export class DiffComment {
   lineText: string;
   commentText: string;
   timestamp: number;
+  isFileLevel: boolean;
   constructor(init: Partial<DiffComment> = {}) {
     this.lineIndex = undefined;
     this.fileName = '';
     this.lineText = '';
     this.commentText = '';
     this.timestamp = Date.now();
+    this.isFileLevel = false;
     Object.assign(this, init);
   }
 }
@@ -195,7 +197,7 @@ export class CommentStore {
     this.comments = [];
   }
   
-  addComment(lineIndex: number | undefined, fileName: string, lineText: string, commentText: string): DiffComment {
+  addComment(lineIndex: number | undefined, fileName: string, lineText: string, commentText: string, isFileLevel: boolean = false): DiffComment {
     // Remove existing comment for this line if any
     this.comments = this.comments.filter(c => c.lineIndex !== lineIndex || c.fileName !== fileName);
     
@@ -204,7 +206,8 @@ export class CommentStore {
       fileName,
       lineText,
       commentText,
-      timestamp: Date.now()
+      timestamp: Date.now(),
+      isFileLevel
     });
     
     this.comments.push(comment);

--- a/tests/unit/comment-fileheader-duplicate.test.tsx
+++ b/tests/unit/comment-fileheader-duplicate.test.tsx
@@ -1,0 +1,44 @@
+import {describe, test, expect} from '@jest/globals';
+import {formatCommentsAsPrompt} from '../../src/components/views/DiffView.js';
+
+describe('File-level comment formatting', () => {
+  test('does not include redundant filename line content for file header comments', () => {
+    const fileName = 'src/newfile.ts';
+    const comments = [
+      {
+        lineIndex: undefined,
+        fileName,
+        lineText: fileName, // file header stores filename as lineText
+        commentText: 'Review this new file',
+        isFileLevel: true
+      }
+    ];
+
+    const prompt = formatCommentsAsPrompt(comments as any);
+
+    // The prompt should contain the file header and the comment
+    expect(prompt).toContain(`File: ${fileName}`);
+    expect(prompt).toContain('Comment: Review this new file');
+
+    // It should NOT redundantly include the filename as line content
+    expect(prompt).not.toContain(`Line content: ${fileName}`);
+  });
+
+  test('includes line content when not file-level even if content equals filename', () => {
+    const fileName = 'src/weird.ts';
+    const comments = [
+      {
+        lineIndex: undefined,
+        fileName,
+        lineText: fileName, // looks like filename but is not a file header
+        commentText: 'This is actually a removed line that equals filename',
+        isFileLevel: false
+      }
+    ];
+
+    const prompt = formatCommentsAsPrompt(comments as any);
+    expect(prompt).toContain(`File: ${fileName}`);
+    expect(prompt).toContain(`Line content: ${fileName}`);
+    expect(prompt).toContain('Comment: This is actually a removed line that equals filename');
+  });
+});


### PR DESCRIPTION
- Track file-level comments with isFileLevel in DiffComment/CommentStore
- Use isFileLevel in formatCommentsAsPrompt and sendCommentsViaAltEnter to suppress redundant 'Line content' for file headers
- Add unit tests to cover both file-level and non-file-level cases

All tests pass (441), typecheck/build clean.