### PR TITLE
Status chip: plain centered text for no-bg states; no-pr cyan; modified plain blue; refactor StatusReason

### DIFF
--- a/src/components/common/StatusChip.tsx
+++ b/src/components/common/StatusChip.tsx
@@ -4,12 +4,36 @@ import {stringDisplayWidth} from '../../shared/utils/formatting.js';
 
 interface StatusChipProps {
   label: string;
-  color: string; // background color
+  color: string | undefined; // background color; 'none' or undefined => no background
   fg?: string;   // foreground color
   width?: number; // optional fixed width for alignment
 }
 
 export default function StatusChip({label, color, fg = 'white', width}: StatusChipProps) {
+  const isPlain = !color || color === 'none' || color === 'transparent';
+
+  // Plain text mode (no background, left-aligned, magenta etc.)
+  if (isPlain) {
+    const makePlain = (): string => {
+      const base = label;
+      if (!width || width <= 0) return base;
+      let visible = base;
+      if (stringDisplayWidth(visible) > width) {
+        visible = visible.slice(0, Math.max(0, width));
+      }
+      const pad = Math.max(0, width - stringDisplayWidth(visible));
+      const left = Math.floor(pad / 2);
+      const right = pad - left;
+      return ' '.repeat(left) + visible + ' '.repeat(right);
+    };
+
+    return (
+      <Box width={width} justifyContent="flex-start">
+        <Text color={fg}>{makePlain()}</Text>
+      </Box>
+    );
+  }
+
   // Create a string that exactly fills the width with background, centered label
   const makeChip = (): string => {
     const base = ` ${label} `; // padding around the label

--- a/tests/unit/statusChipMapping.test.ts
+++ b/tests/unit/statusChipMapping.test.ts
@@ -1,0 +1,61 @@
+import {describe, test, expect} from '@jest/globals';
+import {getStatusMeta} from '../../src/components/views/MainView/highlight.js';
+import {PRStatus, WorktreeInfo} from '../../src/models.js';
+
+function wt(init?: Partial<WorktreeInfo>): WorktreeInfo {
+  return new WorktreeInfo({
+    project: 'proj',
+    feature: 'feat',
+    path: '/proj/feat',
+    git: {has_remote: true, ahead: 0, behind: 0, is_pushed: true, has_changes: false, base_added_lines: 0, base_deleted_lines: 0, added_lines: 0, deleted_lines: 0, modified_files: 0, untracked_lines: 0},
+    session: {attached: true, session_name: 's', ai_status: 'idle', ai_tool: 'none'},
+    ...init,
+  });
+}
+
+describe('STATUS chip mapping', () => {
+  test('PR checking => plain magenta pr-checking', () => {
+    const worktree = wt();
+    const pr = new PRStatus({loadingStatus: 'exists', number: 12, state: 'OPEN', checks: 'pending'});
+    const meta = getStatusMeta(worktree, pr);
+    expect(meta.label).toBe('pr-checking');
+    expect(meta.bg).toBe('none');
+    expect(meta.fg).toBe('magenta');
+  });
+
+  test('AI working => plain working, no bg', () => {
+    const worktree = wt({session: {attached: true, session_name: 's', ai_status: 'working', ai_tool: 'none'}});
+    const pr = undefined;
+    const meta = getStatusMeta(worktree, pr as any);
+    expect(meta.label).toBe('working');
+    expect(meta.bg).toBe('none');
+  });
+
+  test('PR merged => plain grey merged, no bg', () => {
+    const worktree = wt();
+    const pr = new PRStatus({loadingStatus: 'exists', number: 5, state: 'MERGED'});
+    const meta = getStatusMeta(worktree, pr);
+    expect(meta.label).toBe('merged');
+    expect(meta.bg).toBe('none');
+    expect(meta.fg).toBe('gray');
+  });
+
+  test('No PR and pushed with committed changes => plain cyan no-pr (no bg)', () => {
+    const baseGit = wt().git;
+    const worktree = wt({git: {...baseGit, has_remote: true, ahead: 0, is_pushed: true, base_added_lines: 10, base_deleted_lines: 2}});
+    const pr = new PRStatus({loadingStatus: 'no_pr'});
+    const meta = getStatusMeta(worktree, pr);
+    expect(meta.label).toBe('no-pr');
+    expect(meta.bg).toBe('none');
+    expect(meta.fg).toBe('cyan');
+  });
+
+  test('No PR and no base diff => ready', () => {
+    const baseGit = wt().git;
+    // No base diff, nothing to push
+    const worktree = wt({git: {...baseGit, has_remote: true, ahead: 0, is_pushed: false, base_added_lines: 0, base_deleted_lines: 0}});
+    const pr = new PRStatus({loadingStatus: 'no_pr'});
+    const meta = getStatusMeta(worktree, pr);
+    expect(meta.label).toBe('ready');
+  });
+});


### PR DESCRIPTION
UI tweaks to STATUS column and PR state handling\n\nChanges\n- Plain, centered text (no background) for these STATUS states:\n  - pr-checking (magenta), working (white), merged (gray), no-pr (cyan), modified (blue)\n- no-pr shows only when branch has remote and committed base diff; otherwise shows ready\n- no-pr text is cyan with no background\n- Refactor: introduce StatusReason enum and determineStatusReason()\n- Simplify computeHighlightInfo by separating reason from presentation\n- Center plain labels in StatusChip; keep truncation\n- Tests added for status mappings\n\nVerification\n- npm ci && npm run build\n- npm test: all tests pass (55 suites, 450 tests)\n\nNotes\n- Column highlighting remains a neutral gray bar; color emphasis is reserved for the STATUS chip.\n- Ready retains default styling.\n