### PR TITLE
Fix flaky terminal test: stable pagination + settle waits

### DIFF
--- a/), snapping the view back to Page 1. Seeding pageSize and waiting for pagination to settle eliminates this window.

No behavior change for end users; improves test stability only.
+++ b/), snapping the view back to Page 1. Seeding pageSize and waiting for pagination to settle eliminates this window.

No behavior change for end users; improves test stability only.
@@ -1,0 +1,1 @@
+https://github.com/agent-era/devteam/pull/157

--- a/src/screens/WorktreeListScreen.tsx
+++ b/src/screens/WorktreeListScreen.tsx
@@ -10,6 +10,8 @@ import {useKeyboardShortcuts} from '../hooks/useKeyboardShortcuts.js';
 import {VISIBLE_STATUS_REFRESH_DURATION} from '../constants.js';
 import {isAppIntervalsEnabled} from '../config.js';
 import {startIntervalIfEnabled} from '../shared/utils/intervals.js';
+import {useTerminalDimensions} from '../hooks/useTerminalDimensions.js';
+import {calculatePageSize} from '../utils/pagination.js';
 
 
 interface WorktreeListScreenProps {
@@ -37,7 +39,11 @@ export default function WorktreeListScreen({
   const {setVisibleWorktrees} = useGitHubContext();
   const {isAnyDialogFocused} = useInputFocus();
   const {showAIToolSelection, showList, runWithLoading, showInfo} = useUIContext();
-  const [pageSize, setPageSize] = useState(1);
+  // Seed page size with a realistic fallback based on terminal dimensions
+  // to avoid early navigation using a placeholder value (which can cause
+  // page jumps once the measured size arrives from MainView).
+  const {rows: termRows, columns: termCols} = useTerminalDimensions();
+  const [pageSize, setPageSize] = useState<number>(() => calculatePageSize(termRows, termCols));
   const [currentPage, setCurrentPage] = useState(0);
   const [hasProjects, setHasProjects] = useState<boolean>(false);
 

--- a/tests/e2e/terminal/exact-page-size-navigation.test.mjs
+++ b/tests/e2e/terminal/exact-page-size-navigation.test.mjs
@@ -43,6 +43,11 @@ test('does not go blank when items equal page size and pressing down', async () 
   await waitFor(() => includesWorktree(stdout.lastFrame() || '', 'demo', 'feature-01'), {timeout: 3000, interval: 50, message: 'first item visible'});
   let frame = stdout.lastFrame() || '';
   let clean = stripAnsi(frame);
+  // Settle: wait until pagination footer shows the full range for page 1
+  await waitFor(() => {
+    const s = stripAnsi(stdout.lastFrame() || '');
+    return new RegExp(`\\[Page 1/\\d+: 1-\\d+/${PAGE_SIZE}\\]`).test(s);
+  }, {timeout: 3000, interval: 50, message: 'pagination settled for single page'});
   // Derive the end of the visible range from the pagination footer (e.g., "Page 1/X: 1-25/25")
   const footerMatch = clean.match(/Page\s+1\/\d+:\s+1-(\d+)\/(\d+)/);
   if (footerMatch) {

--- a/tests/e2e/terminal/page-preserve-after-attach.test.mjs
+++ b/tests/e2e/terminal/page-preserve-after-attach.test.mjs
@@ -47,8 +47,10 @@ test('preserves page after attach/detach (selectedIndex visible)', async () => {
   }, {timeout: 3000, interval: 50, message: 'pagination settled on Page 1'});
 
   // Go to Page 2 (full-page pagination)
+  // Give the keyboard listener a brief moment to attach in CI
+  await new Promise(r => setTimeout(r, 100));
   stdin.emit('data', Buffer.from('>'));
-  await waitForText(() => stdout.lastFrame() || '', 'Page 2/', {timeout: 3000});
+  await waitForText(() => stdout.lastFrame() || '', 'Page 2/', {timeout: 5000});
   // Settle: ensure pagination range for Page 2 is visible
   await waitFor(() => {
     const s = stripAnsi(stdout.lastFrame() || '');
@@ -71,8 +73,9 @@ test('preserves page after attach/detach (selectedIndex visible)', async () => {
   await new Promise(r => setTimeout(r, 100));
 
   // Press Enter to attach directly (no tmux hint)
+  await new Promise(r => setTimeout(r, 50));
   stdin.emit('data', Buffer.from('\r'));
-  await waitForText(() => stdout.lastFrame() || '', 'Page 2/', {timeout: 3000});
+  await waitForText(() => stdout.lastFrame() || '', 'Page 2/', {timeout: 5000});
   // Settle again after detach returns control
   await waitFor(() => {
     const s = stripAnsi(stdout.lastFrame() || '');

--- a/tests/e2e/terminal/page-preserve-after-attach.test.mjs
+++ b/tests/e2e/terminal/page-preserve-after-attach.test.mjs
@@ -34,16 +34,26 @@ test('preserves page after attach/detach (selectedIndex visible)', async () => {
 
   const inst = Ink.render(tree, {stdout, stdin, debug: true, exitOnCtrlC: false, patchConsole: false});
 
-  // Allow initial frame to render
+  // Allow initial frame to render and wait for pagination to settle
   await new Promise(r => setTimeout(r, 250));
   const {waitFor, waitForText, worktreeRegex, stripAnsi} = await import('./_utils.js');
   let frame = stdout.lastFrame() || '';
   let clean = stripAnsi(frame);
   assert.ok(clean.includes('Page 1/'), 'Expected to start on Page 1');
+  // Settle: wait until pagination text includes a full range like "[Page 1/…: 1-XX/40]"
+  await waitFor(() => {
+    const s = stripAnsi(stdout.lastFrame() || '');
+    return /\[Page 1\/\d+: 1-\d+\/40\]/.test(s);
+  }, {timeout: 3000, interval: 50, message: 'pagination settled on Page 1'});
 
   // Go to Page 2 (full-page pagination)
   stdin.emit('data', Buffer.from('>'));
   await waitForText(() => stdout.lastFrame() || '', 'Page 2/', {timeout: 3000});
+  // Settle: ensure pagination range for Page 2 is visible
+  await waitFor(() => {
+    const s = stripAnsi(stdout.lastFrame() || '');
+    return /\[Page 2\/\d+: \d+-\d+\/40\]/.test(s);
+  }, {timeout: 3000, interval: 50, message: 'pagination settled on Page 2'});
   // wait until a worktree label is visible on Page 2 as well
   await waitFor(() => {
     const f = stdout.lastFrame() || '';
@@ -63,6 +73,11 @@ test('preserves page after attach/detach (selectedIndex visible)', async () => {
   // Press Enter to attach directly (no tmux hint)
   stdin.emit('data', Buffer.from('\r'));
   await waitForText(() => stdout.lastFrame() || '', 'Page 2/', {timeout: 3000});
+  // Settle again after detach returns control
+  await waitFor(() => {
+    const s = stripAnsi(stdout.lastFrame() || '');
+    return /\[Page 2\/\d+: \d+-\d+\/40\]/.test(s);
+  }, {timeout: 3000, interval: 50, message: 'pagination re-settled on Page 2'});
   frame = stdout.lastFrame() || '';
   clean = stripAnsi(frame);
   


### PR DESCRIPTION
This PR fixes a flaky terminal test by addressing a timing race between initial navigation and page-size synchronization.

Changes
- Seed WorktreeListScreen pageSize from terminal dimensions via calculatePageSize() to avoid early navigation using a placeholder value.
- Harden pagination-sensitive terminal tests:
  - page-preserve-after-attach.test.mjs: wait for pagination to settle on Page 1 and Page 2 before asserting; re-settle after detach.
  - exact-page-size-navigation.test.mjs: wait for pagination footer to show full range before pressing down.

Verification
- Build + typecheck pass.
- Jest suites: 54/54 passing (445 tests).
- Terminal tests: 12/12 passing, including the previously flaky case.

Rationale
The flake was a race where the parent pageSize defaulted to 1 and then updated after initial navigation (