### PR TITLE
Fix: PRs without checks marked ready to merge

### DIFF
--- a/src/components/views/MainView/highlight.ts
+++ b/src/components/views/MainView/highlight.ts
@@ -47,6 +47,7 @@ export function determineStatusReason(worktree: WorktreeInfo, pr: PRStatus | und
     if (pr.has_conflicts) return StatusReason.PR_CONFLICTS;
     if (pr.checks === 'failing') return StatusReason.PR_FAILING;
     if (pr.is_ready_to_merge) return StatusReason.PR_READY_TO_MERGE;
+    // Explicit pending checks
     if (pr.is_open && pr.number && pr.checks === 'pending') return StatusReason.PR_CHECKING;
     if (pr.noPR) {
       const hasCommittedBaseDiff = ((worktree.git?.base_added_lines ?? 0) + (worktree.git?.base_deleted_lines ?? 0)) > 0;
@@ -54,8 +55,8 @@ export function determineStatusReason(worktree: WorktreeInfo, pr: PRStatus | und
       return StatusReason.AGENT_READY;
     }
     if (pr.is_open && pr.number) {
-      // Default open PRs to pending until explicit status arrives
-      return StatusReason.PR_CHECKING;
+      // Open PR with no explicit checks state: treat as ready to merge
+      return StatusReason.PR_READY_TO_MERGE;
     }
     if (pr.is_merged && pr.number) return StatusReason.PR_MERGED;
     if (worktree.session?.attached && (cs.includes('idle') || cs.includes('active'))) return StatusReason.AGENT_READY;

--- a/src/models.ts
+++ b/src/models.ts
@@ -76,11 +76,13 @@ export class PRStatus {
   
   // Status aggregation helpers
   get needs_attention(): boolean { return this.checks === 'failing' || this.has_conflicts; }
-  get is_ready_to_merge(): boolean { 
-    return this.state === 'OPEN' && 
-           this.checks === 'passing' && 
-           this.mergeable === 'MERGEABLE' && 
-           !this.isLoading; 
+  get is_ready_to_merge(): boolean {
+    // Treat PRs with no checks as not blocking merge when mergeable
+    const checksPassingOrNone = this.checks === 'passing' || this.checks == null;
+    return this.state === 'OPEN' &&
+      checksPassingOrNone &&
+      this.mergeable === 'MERGEABLE' &&
+      !this.isLoading;
   }
 }
 


### PR DESCRIPTION
This PR fixes PR status handling when repositories have no CI checks:\n\n- Treat no-checks + MERGEABLE as ready to merge (pr-passed)\n- Avoid defaulting open PRs without checks to "pr-checking"\n- Update highlight mapping per review to mark open PRs without explicit checks as ready to merge\n\nValidation:\n- Typecheck passes (tsc)\n- Jest: 55 suites, 450 tests passing\n\nFiles:\n- src/models.ts\n- src/components/views/MainView/highlight.ts