### PR TITLE
Workspace rows: show AI status; rename CLAUDE_WAITING→AGENT_WAITING; dedupe mapping

### DIFF
--- a/src/components/views/MainView/WorkspaceGroupRow.tsx
+++ b/src/components/views/MainView/WorkspaceGroupRow.tsx
@@ -5,6 +5,7 @@ import type {ColumnWidths} from './hooks/useColumnWidths.js';
 import {stringDisplayWidth} from '../../../shared/utils/formatting.js';
 import {getAISymbol} from './utils.js';
 import StatusChip from '../../common/StatusChip.js';
+import {getAIStatusMeta} from './highlight.js';
 
 interface WorkspaceGroupRowProps {
   workspace: WorktreeInfo; // header item with is_workspace_header
@@ -30,6 +31,9 @@ export const WorkspaceGroupRow = memo<WorkspaceGroupRowProps>(({workspace, globa
     {text: '', width: columnWidths.changes, justify: 'flex-end' as const},
     {text: '', width: columnWidths.pr, justify: 'flex-end' as const},
   ];
+
+  // Determine STATUS for workspace header based solely on AI agent tool status (centralized mapping)
+  const {label: statusLabel, bg: statusBg, fg: statusFg} = getAIStatusMeta(workspace);
 
   const formatCellText = (text: string, width: number, justify: 'flex-start' | 'center' | 'flex-end'): string => {
     const raw = (text ?? '').trim();
@@ -94,9 +98,9 @@ export const WorkspaceGroupRow = memo<WorkspaceGroupRowProps>(({workspace, globa
       <Box width={columnWidths.number} justifyContent="flex-start" marginRight={1}>
         <Text bold={selected} inverse={selected}>{formatCellText(numberText, columnWidths.number, 'flex-start')}</Text>
       </Box>
-      {/* Second column: STATUS (blank for workspace rows) */}
+      {/* Second column: STATUS (AI tool status for workspace rows) */}
       <Box width={columnWidths.status} justifyContent="flex-start" marginRight={1}>
-        <StatusChip label={''} color={'black'} fg={'white'} width={columnWidths.status} />
+        <StatusChip label={statusLabel} color={statusBg} fg={statusFg} width={columnWidths.status} />
       </Box>
       {/* Remaining columns: PROJECT/FEATURE, AI, DIFF, CHANGES, PR */}
       {cells.map((cell, idx) => (

--- a/src/components/views/MainView/WorktreeRow.tsx
+++ b/src/components/views/MainView/WorktreeRow.tsx
@@ -89,7 +89,7 @@ export const WorktreeRow = memo<WorktreeRowProps>(({
     if (isPriorityCell(cellIndex)) {
       // Apply explicit text colors per status reason for the applicable column
       switch (highlightInfo?.reason) {
-        case StatusReason.CLAUDE_WAITING:
+        case StatusReason.AGENT_WAITING:
           return 'yellow';
         case StatusReason.AGENT_READY:
           return 'green';


### PR DESCRIPTION
This PR improves workspace row status visibility and unifies status naming:

- WorkspaceGroupRow: STATUS column now reflects AI agent status instead of staying blank.
  - waiting → yellow chip (AGENT_WAITING)
  - working → plain "working" (no bg)
  - idle/active + attached → "ready"
- Status naming: `CLAUDE_WAITING` renamed to `AGENT_WAITING` to be tool‑agnostic.
- Centralized AI‑only mapping in `getAIStatusMeta()` (adjacent to existing status helpers) to avoid duplication and keep logic close to `getStatusMeta`.
- Updated usages in `WorktreeRow` and `WorkspaceGroupRow` accordingly.

Why
- Workspace headers should communicate active agent state clearly.
- Align naming with multi‑tool support and avoid Claude‑specific terms.
- Reduce duplication by colocating AI‑status mapping with status helpers.

Verification
- Typecheck passes: `npm run typecheck`
- All tests pass: unit + E2E (`npm test`)

Files
- `src/components/views/MainView/highlight.ts`: rename + `getAIStatusMeta`
- `src/components/views/MainView/WorktreeRow.tsx`: switch to `AGENT_WAITING`
- `src/components/views/MainView/WorkspaceGroupRow.tsx`: use `getAIStatusMeta()`

Follow‑ups
- If desired, surface the same AI‑only status helper in other AI‑centric views.
