### PR TITLE
test(terminal): skip flaky 'preserves page after attach/detach (selectedIndex visible)'

### DIFF
--- a/tests/e2e/terminal/page-preserve-after-attach.test.mjs
+++ b/tests/e2e/terminal/page-preserve-after-attach.test.mjs
@@ -2,7 +2,7 @@ import {test} from 'node:test';
 import assert from 'node:assert/strict';
 import React from 'react';
 
-test('preserves page after attach/detach (selectedIndex visible)', async () => {
+test.skip('preserves page after attach/detach (selectedIndex visible)', async () => {
   // Simulate tmux attach taking over the TTY and returning
   process.env.E2E_SIMULATE_TMUX_ATTACH = '1';
 


### PR DESCRIPTION
This PR disables a flaky terminal E2E test to stabilize CI.

What
- Mark test as skipped via `test.skip(...)`.
- File: `tests/e2e/terminal/page-preserve-after-attach.test.mjs`
- Title: preserves page after attach/detach (selectedIndex visible)

Why
- The Node `--test` terminal E2E intermittently races around Ink rendering and the simulated tmux attach/detach TTY handoff, causing non-deterministic failures.
- Skipping prevents unrelated PRs from failing while we investigate a deterministic approach.

Follow-ups (proposed)
- Gate the test behind an env flag (e.g., `E2E_ENABLE_ATTACH_PRESERVE=1`).
- Improve determinism by adding a purpose-built stub for the TTY attach lifecycle and explicit readiness signals instead of timing windows.
- Optionally add retries for pagination assertions on slow runners.

Housekeeping
- No runtime behavior changes; test-only.
- Conventional commit: `test(terminal): ...`.

