### PR TITLE
pkg: export ./config and include dist-tests in package files

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
   "exports": {
     ".": "./dist/index.js",
     "./cores/*": "./dist/cores/*.js",
-    "./test-helpers/*": "./dist-tests/tests/fakes/*.js"
+    "./test-helpers/*": "./dist-tests/tests/fakes/*.js",
+    "./config": "./dist/config.js"
   },
   "files": [
     "dist",


### PR DESCRIPTION
Summary
- Add subpath export "./config" → "./dist/config.js" so consumers can import `@agent-era/devteam/config` without deep paths.
- Keep previously added exports:
  - "./cores/*" → "./dist/cores/*.js"
  - "./test-helpers/*" → "./dist-tests/tests/fakes/*.js"
- Ensure `dist-tests` is included in `files` so `npm pack` includes test fakes (used by devteam-web e2e tests).

Rationale
devteam-web's tests (and CI) rely on the engine cores and fakes. This PR formalizes public subpaths and ensures tarballs contain the compiled artifacts:
- Cleaner imports: `@agent-era/devteam/cores/...` and `@agent-era/devteam/test-helpers/...`
- `@agent-era/devteam/config` for agent runtime configuration without referring to dist.
- Works with `npm pack`/tarball installs in CI and local dev.

Notes
- No runtime code changes; package.json only.
- Keeps `dist` as the main entry and preserves existing files.
