### PR TITLE
Archive: git clean -fdx + warn about untracked files before confirm

### DIFF
--- a/src/contexts/WorktreeContext.tsx
+++ b/src/contexts/WorktreeContext.tsx
@@ -28,6 +28,7 @@ interface WorktreeContextType {
   createFromBranch: (project: string, remoteBranch: string, localName: string) => Promise<boolean>;
   archiveFeature: (worktreeOrProject: WorktreeInfo | string, path?: string, feature?: string) => Promise<{archivedPath: string}>;
   archiveWorkspace: (featureName: string) => Promise<void>;
+  getUntrackedNonIgnoredFiles: (worktreePath: string) => string[];
   // Workspace operations
   createWorkspace: (featureName: string, projects: string[]) => Promise<string | null>;
   attachWorkspaceSession: (featureName: string, aiTool?: AITool) => Promise<void>;
@@ -79,6 +80,7 @@ export function WorktreeProvider({children, core: coreOverride}: WorktreeProvide
   const createFromBranch = useCallback(async (project: string, remoteBranch: string, localName: string) => core.createFromBranch(project, remoteBranch, localName), [core]);
   const archiveFeature = useCallback(async (wtOrProject: WorktreeInfo | string, p?: string, f?: string) => core.archiveFeature(wtOrProject, p, f), [core]);
   const archiveWorkspace = useCallback(async (featureName: string) => core.archiveWorkspace(featureName), [core]);
+  const getUntrackedNonIgnoredFiles = useCallback((worktreePath: string) => core.getUntrackedNonIgnoredFiles(worktreePath), [core]);
   const createWorkspace = useCallback(async (featureName: string, projects: string[]) => core.createWorkspace(featureName, projects), [core]);
   const attachWorkspaceSession = useCallback(async (featureName: string, aiTool?: AITool) => {
     // Find workspace header if present
@@ -127,6 +129,7 @@ export function WorktreeProvider({children, core: coreOverride}: WorktreeProvide
     createFromBranch,
     archiveFeature,
     archiveWorkspace,
+    getUntrackedNonIgnoredFiles,
     // Workspace operations
     createWorkspace,
     attachWorkspaceSession,

--- a/src/cores/WorktreeCore.ts
+++ b/src/cores/WorktreeCore.ts
@@ -199,6 +199,10 @@ export class WorktreeCore implements CoreBase<State> {
     return true;
   }
 
+  getUntrackedNonIgnoredFiles(worktreePath: string): string[] {
+    return this.git.getUntrackedNonIgnoredFiles(worktreePath);
+  }
+
   async archiveFeature(worktreeOrProject: WorktreeInfo | string, worktreePath?: string, feature?: string): Promise<{archivedPath: string}> {
     let project: string, workPath: string, featureName: string;
     if (typeof worktreeOrProject === 'string') { project = worktreeOrProject; workPath = worktreePath!; featureName = feature!; }

--- a/src/screens/ArchiveConfirmScreen.tsx
+++ b/src/screens/ArchiveConfirmScreen.tsx
@@ -1,4 +1,4 @@
-import React, {useState} from 'react';
+import React, {useEffect, useState} from 'react';
 import {Box, Text, useInput, useStdin} from 'ink';
 import {useWorktreeContext} from '../contexts/WorktreeContext.js';
 import ProgressDialog from '../components/dialogs/ProgressDialog.js';
@@ -16,14 +16,26 @@ interface ArchiveConfirmScreenProps {
   onSuccess: () => void;
 }
 
+const UNTRACKED_PREVIEW_LIMIT = 5;
+
 export default function ArchiveConfirmScreen({
   featureInfo,
   onCancel,
   onSuccess
 }: ArchiveConfirmScreenProps) {
-  const {archiveFeature, archiveWorkspace} = useWorktreeContext();
+  const {archiveFeature, archiveWorkspace, getUntrackedNonIgnoredFiles} = useWorktreeContext();
   const {isRawModeSupported} = useStdin();
   const [isArchiving, setIsArchiving] = useState(false);
+  const [untrackedFiles, setUntrackedFiles] = useState<string[]>([]);
+
+  useEffect(() => {
+    if (featureInfo.project === 'workspace') return;
+    try {
+      setUntrackedFiles(getUntrackedNonIgnoredFiles(featureInfo.path));
+    } catch {
+      setUntrackedFiles([]);
+    }
+  }, [featureInfo.path, featureInfo.project, getUntrackedNonIgnoredFiles]);
 
   const handleConfirm = async () => {
     try {
@@ -74,6 +86,19 @@ export default function ArchiveConfirmScreen({
               <Text>Archive {featureInfo.project}/{featureInfo.feature}?</Text>
             )}
           </Box>
+          {untrackedFiles.length > 0 && (
+            <Box flexDirection="column" marginTop={1}>
+              <Text color="yellow">
+                Warning: {untrackedFiles.length} untracked file{untrackedFiles.length === 1 ? '' : 's'} will be deleted (git clean -fdx):
+              </Text>
+              {untrackedFiles.slice(0, UNTRACKED_PREVIEW_LIMIT).map((f) => (
+                <Text key={f} color="yellow">  • {f}</Text>
+              ))}
+              {untrackedFiles.length > UNTRACKED_PREVIEW_LIMIT && (
+                <Text color="yellow">  … and {untrackedFiles.length - UNTRACKED_PREVIEW_LIMIT} more</Text>
+              )}
+            </Box>
+          )}
           <Box marginTop={1}>
             <Text color="magenta" wrap="truncate">Press y to confirm, n to cancel</Text>
           </Box>

--- a/src/services/GitService.ts
+++ b/src/services/GitService.ts
@@ -500,10 +500,22 @@ export class GitService {
   
   
 
-  archiveWorktree(project: string, sourcePath: string, archivedDest: string): void {
-    // Clean ignored files in the worktree before archiving
+  // Lists untracked, non-ignored files that a `git clean -fdx` would wipe
+  // but `-fdX` would preserve. Used to warn before destructive archive cleans.
+  getUntrackedNonIgnoredFiles(worktreePath: string): string[] {
     try {
-      runCommandQuick(['git', '-C', sourcePath, 'clean', '-fdX']);
+      const out = runCommandQuick(['git', '-C', worktreePath, 'ls-files', '--others', '--exclude-standard']);
+      if (!out) return [];
+      return out.split('\n').map((s) => s.trim()).filter(Boolean);
+    } catch {
+      return [];
+    }
+  }
+
+  archiveWorktree(project: string, sourcePath: string, archivedDest: string): void {
+    // Clean all untracked files (ignored + non-ignored) in the worktree before archiving
+    try {
+      runCommandQuick(['git', '-C', sourcePath, 'clean', '-fdx']);
     } catch {
       // Silent failure; cleaning is best-effort and should not block archiving
     }

--- a/tests/unit/git-archive-clean.test.ts
+++ b/tests/unit/git-archive-clean.test.ts
@@ -22,15 +22,15 @@ describe('GitService archiveWorktree cleaning', () => {
     mockFs.renameSync.mockImplementation((() => undefined) as any);
   });
 
-  test('runs git clean -fdX before archiving', () => {
+  test('runs git clean -fdx before archiving', () => {
     const sourcePath = '/proj-branches/feature-x';
     const archivedDest = '/proj-archived/archived-123_feature-x';
 
     gitService.archiveWorktree('proj', sourcePath, archivedDest);
 
-    // Ensure the clean command was called for ignored files only (-X)
+    // Ensure the clean command was called for all untracked files (-x)
     expect(mockCommandExecutor.runCommandQuick).toHaveBeenCalledWith(
-      ['git', '-C', sourcePath, 'clean', '-fdX']
+      ['git', '-C', sourcePath, 'clean', '-fdx']
     );
 
     // Ensure the move was attempted
@@ -53,5 +53,35 @@ describe('GitService archiveWorktree cleaning', () => {
 
     // Rename should still be attempted even if clean throws
     expect(mockFs.renameSync).toHaveBeenCalledWith(sourcePath, archivedDest);
+  });
+});
+
+describe('GitService getUntrackedNonIgnoredFiles', () => {
+  let gitService: GitService;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    gitService = new GitService('/base/path');
+  });
+
+  test('returns list of untracked non-ignored files', () => {
+    mockCommandExecutor.runCommandQuick.mockReturnValue('new-file.ts\nsrc/scratch.md\n');
+
+    const files = gitService.getUntrackedNonIgnoredFiles('/proj-branches/feature-x');
+
+    expect(mockCommandExecutor.runCommandQuick).toHaveBeenCalledWith(
+      ['git', '-C', '/proj-branches/feature-x', 'ls-files', '--others', '--exclude-standard']
+    );
+    expect(files).toEqual(['new-file.ts', 'src/scratch.md']);
+  });
+
+  test('returns empty array when no untracked files', () => {
+    mockCommandExecutor.runCommandQuick.mockReturnValue('');
+    expect(gitService.getUntrackedNonIgnoredFiles('/proj-branches/feature-x')).toEqual([]);
+  });
+
+  test('returns empty array if git command throws', () => {
+    mockCommandExecutor.runCommandQuick.mockImplementation(() => { throw new Error('git failed'); });
+    expect(gitService.getUntrackedNonIgnoredFiles('/proj-branches/feature-x')).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary

- Switch archive worktree clean from `-fdX` (ignored files only) to `-fdx` (all untracked files, including non-ignored) so scratch files and uncommitted new files are stripped before the worktree is moved
- Add `GitService.getUntrackedNonIgnoredFiles()` using `git ls-files --others --exclude-standard` to detect files that `-fdx` removes but `-fdX` wouldn't
- Show a yellow warning in `ArchiveConfirmScreen` listing those files (up to 5, with overflow count) so the user knows what will be permanently deleted before confirming

## Test plan

- [ ] Archive a worktree with no untracked files — no warning shown, confirm prompt appears as before
- [ ] Archive a worktree with untracked non-ignored files — yellow warning lists them before the prompt
- [ ] Archive a worktree with >5 untracked files — warning shows first 5 + "… and N more"
- [ ] Archive a workspace — no warning (workspace dir is not a git repo, skipped correctly)
- [ ] Verify archived worktree no longer contains untracked files after archive
- [ ] All 55 Jest suites pass (`npm test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)