### PR TITLE
Add tmux worktree and mode tabs

### DIFF
--- a/src/TmuxNavigatorApp.tsx
+++ b/src/TmuxNavigatorApp.tsx
@@ -19,7 +19,7 @@ type NavWorktree = {
   path: string;
   branch: string;
   lastCommitTs: number;
-  sessions: Record<NavMode, boolean>;
+  sessions: Record<NavMode, {exists: boolean; usable: boolean}>;
 };
 
 export default function TmuxNavigatorApp(props: {sessionName: string}) {
@@ -32,13 +32,13 @@ export default function TmuxNavigatorApp(props: {sessionName: string}) {
   const git = useMemo(() => new GitService(getProjectsDirectory()), []);
   const tmux = useMemo(() => new TmuxService(), []);
   const availableTools = useMemo(() => detectAvailableAITools(), []);
+  const currentMode = sessionMode(sessionName);
+  const currentBase = baseSessionName(sessionName);
 
   const [items, setItems] = useState<NavWorktree[]>([]);
   const [selectedIndex, setSelectedIndex] = useState(0);
+  const [selectedActionMode, setSelectedActionMode] = useState<NavMode>('agent');
   const [statusMessage, setStatusMessage] = useState<string>('loading...');
-
-  const currentMode = sessionMode(sessionName);
-  const currentBase = baseSessionName(sessionName);
 
   const load = async () => {
     const projects = git.discoverProjects();
@@ -55,9 +55,9 @@ export default function TmuxNavigatorApp(props: {sessionName: string}) {
           branch: worktree.branch,
           lastCommitTs: worktree.last_commit_ts || 0,
           sessions: {
-            agent: sessions.has(tmux.sessionName(worktree.project, worktree.feature)),
-            shell: sessions.has(tmux.shellSessionName(worktree.project, worktree.feature)),
-            run: sessions.has(tmux.runSessionName(worktree.project, worktree.feature)),
+            agent: sessionState(tmux, tmux.sessionName(worktree.project, worktree.feature), sessions),
+            shell: sessionState(tmux, tmux.shellSessionName(worktree.project, worktree.feature), sessions),
+            run: sessionState(tmux, tmux.runSessionName(worktree.project, worktree.feature), sessions),
           }
         });
       }
@@ -68,7 +68,7 @@ export default function TmuxNavigatorApp(props: {sessionName: string}) {
 
     const idx = next.findIndex((item) => tmux.sessionName(item.project, item.feature) === currentBase);
     if (idx >= 0) setSelectedIndex(idx);
-    setStatusMessage(next.length ? 'enter switch  1/2/3 modes  esc focus main' : 'no worktrees found');
+    setStatusMessage(next.length ? 'click tile or mode  x closes selected mode  esc back' : 'no worktrees found');
   };
 
   useEffect(() => {
@@ -96,16 +96,23 @@ export default function TmuxNavigatorApp(props: {sessionName: string}) {
   }, [stdout]);
 
   useEffect(() => {
+    setSelectedActionMode(currentMode);
+  }, [currentMode]);
+
+  useEffect(() => {
     setRawMode(true);
     const handler = (buf: Buffer) => {
       const input = buf.toString('utf8');
       if (handleMouseInput(input)) return;
       if (input === 'j' || input === '\u001b[B') setSelectedIndex((prev) => Math.min(prev + 1, Math.max(items.length - 1, 0)));
       else if (input === 'k' || input === '\u001b[A') setSelectedIndex((prev) => Math.max(prev - 1, 0));
+      else if (input === 'h' || input === '\u001b[D') setSelectedActionMode((prev) => prev === 'run' ? 'shell' : prev === 'shell' ? 'agent' : 'agent');
+      else if (input === 'l' || input === '\u001b[C') setSelectedActionMode((prev) => prev === 'agent' ? 'shell' : prev === 'shell' ? 'run' : 'run');
       else if (input === 'r') void load();
-      else if (input === '1') void activate('agent');
-      else if (input === '2') void activate('shell');
-      else if (input === '3') void activate('run');
+      else if (input === '1') { setSelectedActionMode('agent'); void activate('agent'); }
+      else if (input === '2') { setSelectedActionMode('shell'); void activate('shell'); }
+      else if (input === '3') { setSelectedActionMode('run'); void activate('run'); }
+      else if (input === 'x' || input === 'X') void closeMode(selectedActionMode);
       else if (input === '\r' || input === '\n') void activate(currentMode);
       else if (input === '\u001b' || input === 'q') {
         tmux.selectMainPane(sessionName);
@@ -117,7 +124,7 @@ export default function TmuxNavigatorApp(props: {sessionName: string}) {
       stdin.off('data', handler);
       setRawMode(false);
     };
-  }, [currentMode, exit, items.length, load, sessionName, setRawMode, stdin, tmux]);
+  }, [currentMode, exit, items.length, load, selectedActionMode, sessionName, setRawMode, stdin, tmux]);
 
   const handleMouseInput = (input: string): boolean => {
     const match = input.match(/\x1b\[<(\d+);(\d+);(\d+)([Mm])/);
@@ -131,26 +138,27 @@ export default function TmuxNavigatorApp(props: {sessionName: string}) {
     if (eventType !== 'M') return true;
     if (button >= 64) return true;
 
-    if (y === 2) {
-      const mode = modeFromHeaderClick(x);
-      if (mode) {
-        void activate(mode);
-        return true;
-      }
-    }
-
-    const listRow = y - 3;
-    if (listRow >= 0 && listRow < visible.length) {
-      const absoluteIndex = start + listRow;
+    const tileHit = tileHitTarget(x, y, columns, visible.length);
+    if (tileHit !== null) {
+      const absoluteIndex = pageStart + tileHit;
       setSelectedIndex(absoluteIndex);
-      const clickedMode = modeFromRowClick(x, columns);
-      void activate(clickedMode || currentMode, absoluteIndex);
+      void activate(currentMode, absoluteIndex);
       return true;
     }
 
-    if (y === rows - 1) {
+    const action = bottomActionHit(x, y, columns);
+    if (action === 'back') {
       tmux.selectMainPane(sessionName);
       exit();
+      return true;
+    }
+    if (action === 'close') {
+      void closeMode(selectedActionMode);
+      return true;
+    }
+    if (action) {
+      setSelectedActionMode(action);
+      void activate(action);
       return true;
     }
 
@@ -160,43 +168,44 @@ export default function TmuxNavigatorApp(props: {sessionName: string}) {
   const activate = async (mode: NavMode, index: number = selectedIndex) => {
     const item = items[index];
     if (!item) return;
-    const targetSession = modeSessionName(tmux, item.project, item.feature, mode);
-    const exists = tmux.hasSession(targetSession);
-    const needsMainPane = exists && !tmux.hasUsableMainPane(targetSession);
-
-    if (!exists || needsMainPane) {
-      if (mode === 'agent') {
-        const remembered = getLastTool(item.path);
-        const tool = ((remembered && remembered !== 'none') ? remembered : (availableTools[0] || 'none')) as AITool;
-        if (!exists) {
-          if (tool === 'none') {
-            tmux.createSession(targetSession, item.path, true);
-          } else {
-            tmux.createSessionWithCommand(targetSession, item.path, aiLaunchCommand(tool), true);
-            setLastTool(tool, item.path);
-          }
-        } else if (tool !== 'none') {
-          tmux.ensureMainPane(targetSession, item.path, aiLaunchCommand(tool as Exclude<AITool, 'none'>));
-        } else {
-          tmux.ensureMainPane(targetSession, item.path);
-        }
-      } else if (mode === 'shell') {
-        if (!exists) tmux.createSession(targetSession, item.path, false);
-        else tmux.ensureMainPane(targetSession, item.path);
-      } else {
-        const configured = thisRunSession(tmux, item, exists);
-        if (!configured) return;
-      }
-    }
+    const targetSession = ensureModeReady(tmux, item, mode, availableTools);
+    if (!targetSession) return;
 
     tmux.prepareSessionNavigator(targetSession);
     tmux.selectMainPane(targetSession);
     tmux.switchClient(targetSession);
   };
 
-  const visibleRows = Math.max(1, rows - 4);
-  const start = Math.max(0, Math.min(selectedIndex - Math.floor(visibleRows / 2), Math.max(0, items.length - visibleRows)));
-  const visible = items.slice(start, start + visibleRows);
+  const closeMode = async (mode: NavMode) => {
+    const item = items[selectedIndex];
+    if (!item) return;
+    const targetSession = modeSessionName(tmux, item.project, item.feature, mode);
+    if (!item.sessions[mode].exists) {
+      setStatusMessage(`${mode} is not running`);
+      return;
+    }
+    if (targetSession === sessionName) {
+      const fallbackMode = fallbackModeForClose(mode);
+      const fallbackSession = ensureModeReady(tmux, item, fallbackMode, availableTools);
+      if (!fallbackSession || fallbackSession === targetSession) {
+        setStatusMessage(`unable to switch away before closing ${mode}`);
+        return;
+      }
+      tmux.prepareSessionNavigator(fallbackSession);
+      tmux.selectMainPane(fallbackSession);
+      tmux.switchClient(fallbackSession);
+      tmux.killSession(targetSession);
+      return;
+    }
+    tmux.killSession(targetSession);
+    await load();
+    setStatusMessage(`closed ${mode} for ${item.feature}`);
+  };
+
+  const tabsPerRow = Math.max(1, Math.floor((columns - 2) / TAB_WIDTH));
+  const tabsPerPage = tabsPerRow * 2;
+  const pageStart = Math.max(0, Math.floor(selectedIndex / tabsPerPage) * tabsPerPage);
+  const visible = items.slice(pageStart, pageStart + tabsPerPage);
   const selectedItem = items[selectedIndex] || null;
   const statusTone: 'cyan' | 'yellow' = items.length ? 'cyan' : 'yellow';
 
@@ -208,54 +217,35 @@ export default function TmuxNavigatorApp(props: {sessionName: string}) {
           <Text color="gray">{truncateText(selectedItem ? `${selectedItem.feature} [${selectedItem.project}]` : 'no selection', Math.max(12, columns - 22))}</Text>
         </Box>
         <Box justifyContent="space-between">
-          <Box>
-            {modeOrder.map((mode, index) => {
-              const active = mode === currentMode;
-              return (
-                <Text
-                  key={mode}
-                  color={active ? 'black' : 'gray'}
-                  backgroundColor={active ? modeColor(mode) : undefined}
-                >
-                  {`${index === 0 ? '' : ' '}${modePill(mode)}`}
-                </Text>
-              );
-            })}
-          </Box>
+          <Text color="magenta">{`tiles ${pageStart + 1}-${Math.min(pageStart + visible.length, items.length)} of ${items.length}`}</Text>
           <Text color={statusTone}>{truncateText(statusMessage, Math.max(16, Math.floor(columns / 2)))} </Text>
         </Box>
-        {visible.map((item, offset) => {
-          const absoluteIndex = start + offset;
-          const isSelected = absoluteIndex === selectedIndex;
-          const isCurrent = tmux.sessionName(item.project, item.feature) === currentBase;
-          const maxLabelWidth = Math.max(12, columns - 22);
-          const label = truncateText(item.feature, Math.max(8, maxLabelWidth - item.project.length - 4));
-          const project = truncateText(item.project, 16);
-          return (
-            <Box key={`${item.project}-${item.feature}`} justifyContent="space-between">
-              <Box>
-                <Text color={isSelected ? 'black' : isCurrent ? 'cyan' : 'white'} backgroundColor={isSelected ? 'yellow' : undefined}>
-                  {`${isSelected ? '>' : ' '} ${label}`}
-                </Text>
-                <Text color={isSelected ? 'black' : 'gray'} backgroundColor={isSelected ? 'yellow' : undefined}>{` [${project}]`}</Text>
-                {isCurrent ? <Text color="green">{'  live'}</Text> : null}
-              </Box>
-              <Box>
-                {modeOrder.map((mode) => (
-                  <Text
-                    key={mode}
-                    color={item.sessions[mode] ? 'black' : 'gray'}
-                    backgroundColor={item.sessions[mode] ? modeColor(mode) : undefined}
-                  >
-                    {`${modeBadge(mode, item.sessions[mode])} `}
-                  </Text>
-                ))}
-              </Box>
-            </Box>
-          );
-        })}
+        <Box>
+          <Text>{renderTileRow(visible.slice(0, tabsPerRow), selectedIndex, pageStart, currentBase, columns)}</Text>
+        </Box>
+        <Box>
+          <Text>{renderTileRow(visible.slice(tabsPerRow, tabsPerPage), selectedIndex, pageStart + tabsPerRow, currentBase, columns)}</Text>
+        </Box>
         <Box justifyContent="space-between">
-          <Text color="magenta">enter switch  1/2/3 mode  r refresh</Text>
+          <Text color="white">
+            {selectedItem ? `${truncateText(selectedItem.feature, 20)} [${truncateText(selectedItem.project, 16)}]` : 'no selection'}
+          </Text>
+          <Text color="gray">{selectedItem ? truncateText(selectedItem.branch, 18) : ''}</Text>
+        </Box>
+        <Box>
+          {selectedItem ? (
+            <Text>
+              {modeOrder.map((mode) => renderInlineMode(mode, selectedItem.sessions[mode], selectedActionMode === mode, mode === currentMode)).join('  ')}
+            </Text>
+          ) : (
+            <Text color="gray">no worktrees discovered</Text>
+          )}
+        </Box>
+        <Box>
+          <Text>{renderBottomActions(selectedActionMode, currentMode)}</Text>
+        </Box>
+        <Box justifyContent="space-between">
+          <Text color="magenta">click tile to switch current mode  1/2/3 open  x close selected mode</Text>
           <Text color="gray">esc back</Text>
         </Box>
       </Box>
@@ -263,20 +253,7 @@ export default function TmuxNavigatorApp(props: {sessionName: string}) {
   );
 }
 
-function modeFromHeaderClick(x: number): NavMode | null {
-  if (x >= 1 && x <= 10) return 'agent';
-  if (x >= 11 && x <= 20) return 'shell';
-  if (x >= 21 && x <= 28) return 'run';
-  return null;
-}
-
-function modeFromRowClick(x: number, columns: number): NavMode | null {
-  const rightStart = Math.max(1, columns - 11);
-  if (x < rightStart) return null;
-  if (x < rightStart + 4) return 'agent';
-  if (x < rightStart + 8) return 'shell';
-  return 'run';
-}
+const TAB_WIDTH = 22;
 
 function modeColor(mode: NavMode): 'green' | 'blue' | 'magenta' {
   if (mode === 'agent') return 'green';
@@ -290,17 +267,98 @@ function modePill(mode: NavMode): string {
   return ' 3 Run ';
 }
 
-function modeBadge(mode: NavMode, active: boolean): string {
-  if (!active) return ` ${modeLabel(mode)} `;
-  if (mode === 'agent') return ' A ';
-  if (mode === 'shell') return ' S ';
-  return ' R ';
-}
-
 function truncateText(value: string, width: number): string {
   if (value.length <= width) return value;
   if (width <= 3) return value.slice(0, width);
   return `${value.slice(0, width - 3)}...`;
+}
+
+function sessionState(tmux: TmuxService, sessionName: string, sessions: Set<string>): {exists: boolean; usable: boolean} {
+  const exists = sessions.has(sessionName);
+  return {
+    exists,
+    usable: exists ? tmux.hasUsableMainPane(sessionName) : false,
+  };
+}
+
+function renderTileRow(items: NavWorktree[], selectedIndex: number, baseIndex: number, currentBase: string, columns: number): string {
+  if (!items.length) return '';
+  const tabsPerRow = Math.max(1, Math.floor((columns - 2) / TAB_WIDTH));
+  return items
+    .slice(0, tabsPerRow)
+    .map((item, offset) => renderTile(
+      item,
+      baseIndex + offset === selectedIndex,
+      itemSessionBase(item) === currentBase
+    ))
+    .join(' ');
+}
+
+function renderTile(item: NavWorktree, selected: boolean, current: boolean): string {
+  const label = truncateText(item.feature, 11).padEnd(11, ' ');
+  const project = truncateText(item.project, 6).padEnd(6, ' ');
+  const badges = modeOrder.map((mode) => item.sessions[mode].usable ? modeLabel(mode) : item.sessions[mode].exists ? '!' : '-').join('');
+  const live = current ? '*' : ' ';
+  const content = `${live}${label} ${project} ${badges}`;
+  return selected ? `[${content}]` : ` ${content} `;
+}
+
+function renderInlineMode(mode: NavMode, state: {exists: boolean; usable: boolean}, selected: boolean, current: boolean): string {
+  const status = state.usable ? 'up' : state.exists ? 'stale' : 'off';
+  const prefix = selected ? '>' : ' ';
+  const live = current ? '*' : ' ';
+  return `${prefix}${live}${modePill(mode).trim()} ${status}`;
+}
+
+function renderBottomActions(selectedMode: NavMode, currentMode: NavMode): string {
+  return [
+    renderAction('agent', selectedMode === 'agent', currentMode === 'agent'),
+    renderAction('shell', selectedMode === 'shell', currentMode === 'shell'),
+    renderAction('run', selectedMode === 'run', currentMode === 'run'),
+    '[Close]',
+    '[Back]',
+  ].join(' ');
+}
+
+function renderAction(mode: NavMode, selected: boolean, current: boolean): string {
+  const currentMark = current ? '*' : ' ';
+  const selectedMark = selected ? '>' : ' ';
+  return `[${selectedMark}${currentMark}${modePill(mode).trim()}]`;
+}
+
+function itemSessionBase(item: NavWorktree): string {
+  return `dev-${item.project}-${item.feature}`;
+}
+
+function tileHitTarget(x: number, y: number, columns: number, visibleCount: number): number | null {
+  if (y < 3 || y > 4 || visibleCount === 0) return null;
+  const tabsPerRow = Math.max(1, Math.floor((columns - 2) / TAB_WIDTH));
+  const row = y - 3;
+  const localIndex = Math.floor((x - 1) / (TAB_WIDTH + 1));
+  if (localIndex < 0 || localIndex >= tabsPerRow) return null;
+  const absoluteLocal = row * tabsPerRow + localIndex;
+  if (absoluteLocal >= visibleCount) return null;
+  return absoluteLocal;
+}
+
+function bottomActionHit(x: number, y: number, columns: number): NavMode | 'close' | 'back' | null {
+  if (y !== 7) return null;
+  const labels: Array<{kind: NavMode | 'close' | 'back'; label: string}> = [
+    {kind: 'agent', label: '[ 1 Agent]'},
+    {kind: 'shell', label: '[ 2 Shell]'},
+    {kind: 'run', label: '[ 3 Run]'},
+    {kind: 'close', label: '[Close]'},
+    {kind: 'back', label: '[Back]'},
+  ];
+  let cursor = 1;
+  for (const item of labels) {
+    const start = cursor;
+    const end = start + item.label.length - 1;
+    if (x >= start && x <= end) return item.kind;
+    cursor = end + 2;
+    if (cursor > columns) break;
+  }
+  return null;
 }
 
 function thisRunSession(tmux: TmuxService, item: NavWorktree, exists: boolean): boolean {
@@ -330,4 +388,47 @@ function thisRunSession(tmux: TmuxService, item: NavWorktree, exists: boolean): 
   for (const cmd of pre) tmux.sendText(sessionName, cmd, {executeCommand: true});
   tmux.sendText(sessionName, mainCmd, {executeCommand: true});
   return true;
+}
+
+function ensureModeReady(
+  tmux: TmuxService,
+  item: NavWorktree,
+  mode: NavMode,
+  availableTools: AITool[]
+): string | null {
+  const targetSession = modeSessionName(tmux, item.project, item.feature, mode);
+  const exists = tmux.hasSession(targetSession);
+  const needsMainPane = exists && !tmux.hasUsableMainPane(targetSession);
+
+  if (!exists || needsMainPane) {
+    if (mode === 'agent') {
+      const remembered = getLastTool(item.path);
+      const tool = ((remembered && remembered !== 'none') ? remembered : (availableTools[0] || 'none')) as AITool;
+      if (!exists) {
+        if (tool === 'none') {
+          tmux.createSession(targetSession, item.path, true);
+        } else {
+          tmux.createSessionWithCommand(targetSession, item.path, aiLaunchCommand(tool), true);
+          setLastTool(tool, item.path);
+        }
+      } else if (tool !== 'none') {
+        tmux.ensureMainPane(targetSession, item.path, aiLaunchCommand(tool as Exclude<AITool, 'none'>));
+      } else {
+        tmux.ensureMainPane(targetSession, item.path);
+      }
+    } else if (mode === 'shell') {
+      if (!exists) tmux.createSession(targetSession, item.path, false);
+      else tmux.ensureMainPane(targetSession, item.path);
+    } else {
+      const configured = thisRunSession(tmux, item, exists);
+      if (!configured) return null;
+    }
+  }
+
+  return targetSession;
+}
+
+function fallbackModeForClose(mode: NavMode): NavMode {
+  if (mode === 'agent') return 'shell';
+  return 'agent';
 }

--- a/src/TmuxNavigatorApp.tsx
+++ b/src/TmuxNavigatorApp.tsx
@@ -144,21 +144,30 @@ export default function TmuxNavigatorApp(props: {sessionName: string}) {
     const item = items[index];
     if (!item) return;
     const targetSession = modeSessionName(tmux, item.project, item.feature, mode);
+    const exists = tmux.hasSession(targetSession);
+    const needsMainPane = exists && !tmux.hasUsableMainPane(targetSession);
 
-    if (!tmux.hasSession(targetSession)) {
+    if (!exists || needsMainPane) {
       if (mode === 'agent') {
         const remembered = getLastTool(item.path);
         const tool = ((remembered && remembered !== 'none') ? remembered : (availableTools[0] || 'none')) as AITool;
-        if (tool === 'none') {
-          tmux.createSession(targetSession, item.path, true);
+        if (!exists) {
+          if (tool === 'none') {
+            tmux.createSession(targetSession, item.path, true);
+          } else {
+            tmux.createSessionWithCommand(targetSession, item.path, aiLaunchCommand(tool), true);
+            setLastTool(tool, item.path);
+          }
+        } else if (tool !== 'none') {
+          tmux.ensureMainPane(targetSession, item.path, aiLaunchCommand(tool as Exclude<AITool, 'none'>));
         } else {
-          tmux.createSessionWithCommand(targetSession, item.path, aiLaunchCommand(tool), true);
-          setLastTool(tool, item.path);
+          tmux.ensureMainPane(targetSession, item.path);
         }
       } else if (mode === 'shell') {
-        tmux.createSession(targetSession, item.path, false);
+        if (!exists) tmux.createSession(targetSession, item.path, false);
+        else tmux.ensureMainPane(targetSession, item.path);
       } else {
-        const configured = thisRunSession(tmux, item);
+        const configured = thisRunSession(tmux, item, exists);
         if (!configured) return;
       }
     }
@@ -277,9 +286,9 @@ function truncateText(value: string, width: number): string {
   return `${value.slice(0, width - 3)}...`;
 }
 
-function thisRunSession(tmux: TmuxService, item: NavWorktree): boolean {
+function thisRunSession(tmux: TmuxService, item: NavWorktree, exists: boolean): boolean {
   const sessionName = tmux.runSessionName(item.project, item.feature);
-  tmux.createSession(sessionName, item.path, false);
+  if (!exists) tmux.createSession(sessionName, item.path, false);
   const configPath = path.join(getProjectsDirectory(), item.project, RUN_CONFIG_FILE);
   if (!fs.existsSync(configPath)) {
     return false;
@@ -294,6 +303,9 @@ function thisRunSession(tmux: TmuxService, item: NavWorktree): boolean {
   try { tmux.setSessionOption(sessionName, 'remain-on-exit', detachOnExit ? 'on' : 'off'); } catch {}
   if (!mainCmd || typeof mainCmd !== 'string' || mainCmd.trim().length === 0) {
     return false;
+  }
+  if (exists) {
+    tmux.ensureMainPane(sessionName, item.path);
   }
   for (const [k, v] of Object.entries(env)) {
     tmux.sendText(sessionName, `export ${k}=${JSON.stringify(String(v))}`, {executeCommand: true});

--- a/src/TmuxNavigatorApp.tsx
+++ b/src/TmuxNavigatorApp.tsx
@@ -202,12 +202,15 @@ export default function TmuxNavigatorApp(props: {sessionName: string}) {
     setStatusMessage(`closed ${mode} for ${item.feature}`);
   };
 
-  const tabsPerRow = Math.max(1, Math.floor((columns - 2) / TAB_WIDTH));
-  const tabsPerPage = tabsPerRow * 2;
-  const pageStart = Math.max(0, Math.floor(selectedIndex / tabsPerPage) * tabsPerPage);
-  const visible = items.slice(pageStart, pageStart + tabsPerPage);
+  const tileColumns = Math.min(3, Math.max(1, Math.floor((columns + 1) / (MIN_TILE_WIDTH + 1))));
+  const tileRows = rows >= 9 ? 2 : 1;
+  const visibleCount = Math.min(6, tileColumns * tileRows);
+  const tileWidth = Math.max(18, Math.floor((columns - Math.max(0, tileColumns - 1)) / tileColumns));
+  const pageStart = Math.max(0, Math.floor(selectedIndex / Math.max(1, visibleCount)) * Math.max(1, visibleCount));
+  const visible = items.slice(pageStart, pageStart + visibleCount);
   const selectedItem = items[selectedIndex] || null;
   const statusTone: 'cyan' | 'yellow' = items.length ? 'cyan' : 'yellow';
+  const tileGroups = Array.from({length: tileRows}, (_, row) => visible.slice(row * tileColumns, (row + 1) * tileColumns));
 
   return (
     <FullScreen enableAltScreen={false}>
@@ -217,15 +220,34 @@ export default function TmuxNavigatorApp(props: {sessionName: string}) {
           <Text color="gray">{truncateText(selectedItem ? `${selectedItem.feature} [${selectedItem.project}]` : 'no selection', Math.max(12, columns - 22))}</Text>
         </Box>
         <Box justifyContent="space-between">
-          <Text color="magenta">{`tiles ${pageStart + 1}-${Math.min(pageStart + visible.length, items.length)} of ${items.length}`}</Text>
+          <Text color="magenta">{`recent ${pageStart + 1}-${Math.min(pageStart + visible.length, items.length)} / ${items.length}`}</Text>
           <Text color={statusTone}>{truncateText(statusMessage, Math.max(16, Math.floor(columns / 2)))} </Text>
         </Box>
-        <Box>
-          <Text>{renderTileRow(visible.slice(0, tabsPerRow), selectedIndex, pageStart, currentBase, columns)}</Text>
-        </Box>
-        <Box>
-          <Text>{renderTileRow(visible.slice(tabsPerRow, tabsPerPage), selectedIndex, pageStart + tabsPerRow, currentBase, columns)}</Text>
-        </Box>
+        {tileGroups.map((group, rowIndex) => (
+          <Box key={`tile-row-${rowIndex}`} marginTop={rowIndex === 0 ? 0 : 0}>
+            {group.map((item, columnIndex) => {
+              const absoluteIndex = pageStart + (rowIndex * tileColumns) + columnIndex;
+              return (
+                <Box key={`${item.project}-${item.feature}`} marginRight={columnIndex === group.length - 1 ? 0 : 1} width={tileWidth} flexDirection="column">
+                  {renderTileLine(
+                    item,
+                    absoluteIndex === selectedIndex,
+                    itemSessionBase(item) === currentBase,
+                    tileWidth,
+                    0
+                  )}
+                  {renderTileLine(
+                    item,
+                    absoluteIndex === selectedIndex,
+                    itemSessionBase(item) === currentBase,
+                    tileWidth,
+                    1
+                  )}
+                </Box>
+              );
+            })}
+          </Box>
+        ))}
         <Box justifyContent="space-between">
           <Text color="white">
             {selectedItem ? `${truncateText(selectedItem.feature, 20)} [${truncateText(selectedItem.project, 16)}]` : 'no selection'}
@@ -234,7 +256,7 @@ export default function TmuxNavigatorApp(props: {sessionName: string}) {
         </Box>
         <Box>
           {selectedItem ? (
-            <Text>
+            <Text color="gray">
               {modeOrder.map((mode) => renderInlineMode(mode, selectedItem.sessions[mode], selectedActionMode === mode, mode === currentMode)).join('  ')}
             </Text>
           ) : (
@@ -242,10 +264,10 @@ export default function TmuxNavigatorApp(props: {sessionName: string}) {
           )}
         </Box>
         <Box>
-          <Text>{renderBottomActions(selectedActionMode, currentMode)}</Text>
+          {renderBottomActions(selectedItem, selectedActionMode, currentMode)}
         </Box>
         <Box justifyContent="space-between">
-          <Text color="magenta">click tile to switch current mode  1/2/3 open  x close selected mode</Text>
+          <Text color="magenta">click tile to open current mode  click bottom to switch/close</Text>
           <Text color="gray">esc back</Text>
         </Box>
       </Box>
@@ -253,7 +275,7 @@ export default function TmuxNavigatorApp(props: {sessionName: string}) {
   );
 }
 
-const TAB_WIDTH = 22;
+const MIN_TILE_WIDTH = 20;
 
 function modeColor(mode: NavMode): 'green' | 'blue' | 'magenta' {
   if (mode === 'agent') return 'green';
@@ -281,26 +303,26 @@ function sessionState(tmux: TmuxService, sessionName: string, sessions: Set<stri
   };
 }
 
-function renderTileRow(items: NavWorktree[], selectedIndex: number, baseIndex: number, currentBase: string, columns: number): string {
-  if (!items.length) return '';
-  const tabsPerRow = Math.max(1, Math.floor((columns - 2) / TAB_WIDTH));
-  return items
-    .slice(0, tabsPerRow)
-    .map((item, offset) => renderTile(
-      item,
-      baseIndex + offset === selectedIndex,
-      itemSessionBase(item) === currentBase
-    ))
-    .join(' ');
-}
+function renderTileLine(item: NavWorktree, selected: boolean, current: boolean, width: number, line: 0 | 1): JSX.Element {
+  const bg = selected ? 'yellow' : current ? 'cyan' : 'blue';
+  const fg = selected || current ? 'black' : 'white';
+  if (line === 0) {
+    const left = truncateText(item.feature, Math.max(8, width - 6));
+    const right = current ? 'LIVE' : '    ';
+    return (
+      <Text color={fg} backgroundColor={bg}>
+        {padTile(`${left}`, `${right}`, width)}
+      </Text>
+    );
+  }
 
-function renderTile(item: NavWorktree, selected: boolean, current: boolean): string {
-  const label = truncateText(item.feature, 11).padEnd(11, ' ');
-  const project = truncateText(item.project, 6).padEnd(6, ' ');
-  const badges = modeOrder.map((mode) => item.sessions[mode].usable ? modeLabel(mode) : item.sessions[mode].exists ? '!' : '-').join('');
-  const live = current ? '*' : ' ';
-  const content = `${live}${label} ${project} ${badges}`;
-  return selected ? `[${content}]` : ` ${content} `;
+  const project = truncateText(item.project, Math.max(5, width - 8));
+  const badges = modeOrder.map((mode) => compactModeState(mode, item.sessions[mode])).join(' ');
+  return (
+    <Text color={fg} backgroundColor={bg}>
+      {padTile(project, badges, width)}
+    </Text>
+  );
 }
 
 function renderInlineMode(mode: NavMode, state: {exists: boolean; usable: boolean}, selected: boolean, current: boolean): string {
@@ -310,20 +332,32 @@ function renderInlineMode(mode: NavMode, state: {exists: boolean; usable: boolea
   return `${prefix}${live}${modePill(mode).trim()} ${status}`;
 }
 
-function renderBottomActions(selectedMode: NavMode, currentMode: NavMode): string {
-  return [
-    renderAction('agent', selectedMode === 'agent', currentMode === 'agent'),
-    renderAction('shell', selectedMode === 'shell', currentMode === 'shell'),
-    renderAction('run', selectedMode === 'run', currentMode === 'run'),
-    '[Close]',
-    '[Back]',
-  ].join(' ');
+function renderBottomActions(
+  selectedItem: NavWorktree | null,
+  selectedMode: NavMode,
+  currentMode: NavMode
+): JSX.Element {
+  return (
+    <Box>
+      {modeOrder.map((mode, index) => (
+        <Text
+          key={mode}
+          color={selectedMode === mode ? 'black' : 'white'}
+          backgroundColor={selectedMode === mode ? modeColor(mode) : undefined}
+        >
+          {`${index === 0 ? '' : ' '}${renderActionLabel(mode, selectedItem?.sessions[mode], currentMode === mode)}`}
+        </Text>
+      ))}
+      <Text color="black" backgroundColor="red">{' Close '}</Text>
+      <Text color="black" backgroundColor="gray">{' Back '}</Text>
+    </Box>
+  );
 }
 
-function renderAction(mode: NavMode, selected: boolean, current: boolean): string {
-  const currentMark = current ? '*' : ' ';
-  const selectedMark = selected ? '>' : ' ';
-  return `[${selectedMark}${currentMark}${modePill(mode).trim()}]`;
+function renderActionLabel(mode: NavMode, state: {exists: boolean; usable: boolean} | undefined, current: boolean): string {
+  const label = modePill(mode).trim();
+  const status = state ? compactModeState(mode, state) : '--';
+  return `${current ? '*' : ' '}${label} ${status} `;
 }
 
 function itemSessionBase(item: NavWorktree): string {
@@ -331,24 +365,29 @@ function itemSessionBase(item: NavWorktree): string {
 }
 
 function tileHitTarget(x: number, y: number, columns: number, visibleCount: number): number | null {
-  if (y < 3 || y > 4 || visibleCount === 0) return null;
-  const tabsPerRow = Math.max(1, Math.floor((columns - 2) / TAB_WIDTH));
-  const row = y - 3;
-  const localIndex = Math.floor((x - 1) / (TAB_WIDTH + 1));
-  if (localIndex < 0 || localIndex >= tabsPerRow) return null;
-  const absoluteLocal = row * tabsPerRow + localIndex;
+  if (y < 3 || y > 6 || visibleCount === 0) return null;
+  const tileColumns = Math.min(3, Math.max(1, Math.floor((columns + 1) / (MIN_TILE_WIDTH + 1))));
+  const tileWidth = Math.max(18, Math.floor((columns - Math.max(0, tileColumns - 1)) / tileColumns));
+  const row = Math.floor((y - 3) / 2);
+  const rowY = (y - 3) % 2;
+  if (rowY < 0 || rowY > 1) return null;
+  const localIndex = Math.floor((x - 1) / (tileWidth + 1));
+  if (localIndex < 0 || localIndex >= tileColumns) return null;
+  const xOffset = (x - 1) % (tileWidth + 1);
+  if (xOffset >= tileWidth) return null;
+  const absoluteLocal = row * tileColumns + localIndex;
   if (absoluteLocal >= visibleCount) return null;
   return absoluteLocal;
 }
 
 function bottomActionHit(x: number, y: number, columns: number): NavMode | 'close' | 'back' | null {
-  if (y !== 7) return null;
+  if (y !== 9) return null;
   const labels: Array<{kind: NavMode | 'close' | 'back'; label: string}> = [
-    {kind: 'agent', label: '[ 1 Agent]'},
-    {kind: 'shell', label: '[ 2 Shell]'},
-    {kind: 'run', label: '[ 3 Run]'},
-    {kind: 'close', label: '[Close]'},
-    {kind: 'back', label: '[Back]'},
+    {kind: 'agent', label: ' 1 Agent up '},
+    {kind: 'shell', label: ' 2 Shell up '},
+    {kind: 'run', label: ' 3 Run up '},
+    {kind: 'close', label: ' Close '},
+    {kind: 'back', label: ' Back '},
   ];
   let cursor = 1;
   for (const item of labels) {
@@ -359,6 +398,20 @@ function bottomActionHit(x: number, y: number, columns: number): NavMode | 'clos
     if (cursor > columns) break;
   }
   return null;
+}
+
+function compactModeState(mode: NavMode, state: {exists: boolean; usable: boolean}): string {
+  if (state.usable) return modeLabel(mode);
+  if (state.exists) return '!';
+  return '-';
+}
+
+function padTile(left: string, right: string, width: number): string {
+  const innerWidth = Math.max(4, width);
+  const availableLeft = Math.max(1, innerWidth - right.length - 1);
+  const leftText = truncateText(left, availableLeft);
+  const gap = Math.max(1, innerWidth - leftText.length - right.length);
+  return `${leftText}${' '.repeat(gap)}${right}`;
 }
 
 function thisRunSession(tmux: TmuxService, item: NavWorktree, exists: boolean): boolean {

--- a/src/TmuxNavigatorApp.tsx
+++ b/src/TmuxNavigatorApp.tsx
@@ -1,5 +1,5 @@
 import React, {useEffect, useMemo, useState} from 'react';
-import {Box, Text, useApp, useStdin} from 'ink';
+import {Box, Text, useApp, useStdin, useStdout} from 'ink';
 import path from 'node:path';
 import fs from 'node:fs';
 import FullScreen from './components/common/FullScreen.js';
@@ -26,6 +26,7 @@ export default function TmuxNavigatorApp(props: {sessionName: string}) {
   const {sessionName} = props;
   const {exit} = useApp();
   const {stdin, setRawMode} = useStdin();
+  const {stdout} = useStdout();
   const {rows, columns} = useTerminalDimensions();
 
   const git = useMemo(() => new GitService(getProjectsDirectory()), []);
@@ -77,6 +78,22 @@ export default function TmuxNavigatorApp(props: {sessionName: string}) {
     return () => clearInterval(timer);
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  useEffect(() => {
+    if (!stdout?.isTTY) return;
+    try {
+      stdout.write('\x1b[?1000h');
+      stdout.write('\x1b[?1002h');
+      stdout.write('\x1b[?1006h');
+    } catch {}
+    return () => {
+      try {
+        stdout.write('\x1b[?1000l');
+        stdout.write('\x1b[?1002l');
+        stdout.write('\x1b[?1006l');
+      } catch {}
+    };
+  }, [stdout]);
 
   useEffect(() => {
     setRawMode(true);

--- a/src/TmuxNavigatorApp.tsx
+++ b/src/TmuxNavigatorApp.tsx
@@ -26,7 +26,7 @@ export default function TmuxNavigatorApp(props: {sessionName: string}) {
   const {sessionName} = props;
   const {exit} = useApp();
   const {stdin, setRawMode} = useStdin();
-  const {rows} = useTerminalDimensions();
+  const {rows, columns} = useTerminalDimensions();
 
   const git = useMemo(() => new GitService(getProjectsDirectory()), []);
   const tmux = useMemo(() => new TmuxService(), []);
@@ -82,6 +82,7 @@ export default function TmuxNavigatorApp(props: {sessionName: string}) {
     setRawMode(true);
     const handler = (buf: Buffer) => {
       const input = buf.toString('utf8');
+      if (handleMouseInput(input)) return;
       if (input === 'j' || input === '\u001b[B') setSelectedIndex((prev) => Math.min(prev + 1, Math.max(items.length - 1, 0)));
       else if (input === 'k' || input === '\u001b[A') setSelectedIndex((prev) => Math.max(prev - 1, 0));
       else if (input === 'r') void load();
@@ -101,8 +102,46 @@ export default function TmuxNavigatorApp(props: {sessionName: string}) {
     };
   }, [currentMode, exit, items.length, load, sessionName, setRawMode, stdin, tmux]);
 
-  const activate = async (mode: NavMode) => {
-    const item = items[selectedIndex];
+  const handleMouseInput = (input: string): boolean => {
+    const match = input.match(/\x1b\[<(\d+);(\d+);(\d+)([Mm])/);
+    if (!match) return false;
+
+    const button = Number(match[1]);
+    const x = Number(match[2]);
+    const y = Number(match[3]);
+    const eventType = match[4];
+
+    if (eventType !== 'M') return true;
+    if (button >= 64) return true;
+
+    if (y === 2) {
+      const mode = modeFromHeaderClick(x);
+      if (mode) {
+        void activate(mode);
+        return true;
+      }
+    }
+
+    const listRow = y - 3;
+    if (listRow >= 0 && listRow < visible.length) {
+      const absoluteIndex = start + listRow;
+      setSelectedIndex(absoluteIndex);
+      const clickedMode = modeFromRowClick(x, columns);
+      void activate(clickedMode || currentMode, absoluteIndex);
+      return true;
+    }
+
+    if (y === rows - 1) {
+      tmux.selectMainPane(sessionName);
+      exit();
+      return true;
+    }
+
+    return true;
+  };
+
+  const activate = async (mode: NavMode, index: number = selectedIndex) => {
+    const item = items[index];
     if (!item) return;
     const targetSession = modeSessionName(tmux, item.project, item.feature, mode);
 
@@ -129,30 +168,113 @@ export default function TmuxNavigatorApp(props: {sessionName: string}) {
     tmux.switchClient(targetSession);
   };
 
-  const visibleRows = Math.max(1, rows - 3);
+  const visibleRows = Math.max(1, rows - 4);
   const start = Math.max(0, Math.min(selectedIndex - Math.floor(visibleRows / 2), Math.max(0, items.length - visibleRows)));
   const visible = items.slice(start, start + visibleRows);
+  const selectedItem = items[selectedIndex] || null;
+  const statusTone: 'cyan' | 'yellow' = items.length ? 'cyan' : 'yellow';
 
   return (
     <FullScreen enableAltScreen={false}>
       <Box flexDirection="column" paddingX={1}>
-        <Text>{`devteam nav  current:${modeLabel(currentMode)}  ${statusMessage}`}</Text>
+        <Box justifyContent="space-between">
+          <Text color="black" backgroundColor="cyan">{' DEVTEAM NAV '}</Text>
+          <Text color="gray">{truncateText(selectedItem ? `${selectedItem.feature} [${selectedItem.project}]` : 'no selection', Math.max(12, columns - 22))}</Text>
+        </Box>
+        <Box justifyContent="space-between">
+          <Box>
+            {modeOrder.map((mode, index) => {
+              const active = mode === currentMode;
+              return (
+                <Text
+                  key={mode}
+                  color={active ? 'black' : 'gray'}
+                  backgroundColor={active ? modeColor(mode) : undefined}
+                >
+                  {`${index === 0 ? '' : ' '}${modePill(mode)}`}
+                </Text>
+              );
+            })}
+          </Box>
+          <Text color={statusTone}>{truncateText(statusMessage, Math.max(16, Math.floor(columns / 2)))} </Text>
+        </Box>
         {visible.map((item, offset) => {
           const absoluteIndex = start + offset;
           const isSelected = absoluteIndex === selectedIndex;
           const isCurrent = tmux.sessionName(item.project, item.feature) === currentBase;
-          const modeCells = modeOrder.map((mode) => item.sessions[mode] ? modeLabel(mode) : '-').join(' ');
-          const prefix = isSelected ? '>' : ' ';
-          const current = isCurrent ? '*' : ' ';
+          const maxLabelWidth = Math.max(12, columns - 22);
+          const label = truncateText(item.feature, Math.max(8, maxLabelWidth - item.project.length - 4));
+          const project = truncateText(item.project, 16);
           return (
-            <Text key={`${item.project}-${item.feature}`}>
-              {`${prefix}${current} ${item.feature} [${item.project}]  ${modeCells}`}
-            </Text>
+            <Box key={`${item.project}-${item.feature}`} justifyContent="space-between">
+              <Box>
+                <Text color={isSelected ? 'black' : isCurrent ? 'cyan' : 'white'} backgroundColor={isSelected ? 'yellow' : undefined}>
+                  {`${isSelected ? '>' : ' '} ${label}`}
+                </Text>
+                <Text color={isSelected ? 'black' : 'gray'} backgroundColor={isSelected ? 'yellow' : undefined}>{` [${project}]`}</Text>
+                {isCurrent ? <Text color="green">{'  live'}</Text> : null}
+              </Box>
+              <Box>
+                {modeOrder.map((mode) => (
+                  <Text
+                    key={mode}
+                    color={item.sessions[mode] ? 'black' : 'gray'}
+                    backgroundColor={item.sessions[mode] ? modeColor(mode) : undefined}
+                  >
+                    {`${modeBadge(mode, item.sessions[mode])} `}
+                  </Text>
+                ))}
+              </Box>
+            </Box>
           );
         })}
+        <Box justifyContent="space-between">
+          <Text color="magenta">enter switch  1/2/3 mode  r refresh</Text>
+          <Text color="gray">esc back</Text>
+        </Box>
       </Box>
     </FullScreen>
   );
+}
+
+function modeFromHeaderClick(x: number): NavMode | null {
+  if (x >= 1 && x <= 10) return 'agent';
+  if (x >= 11 && x <= 20) return 'shell';
+  if (x >= 21 && x <= 28) return 'run';
+  return null;
+}
+
+function modeFromRowClick(x: number, columns: number): NavMode | null {
+  const rightStart = Math.max(1, columns - 11);
+  if (x < rightStart) return null;
+  if (x < rightStart + 4) return 'agent';
+  if (x < rightStart + 8) return 'shell';
+  return 'run';
+}
+
+function modeColor(mode: NavMode): 'green' | 'blue' | 'magenta' {
+  if (mode === 'agent') return 'green';
+  if (mode === 'shell') return 'blue';
+  return 'magenta';
+}
+
+function modePill(mode: NavMode): string {
+  if (mode === 'agent') return ' 1 Agent ';
+  if (mode === 'shell') return ' 2 Shell ';
+  return ' 3 Run ';
+}
+
+function modeBadge(mode: NavMode, active: boolean): string {
+  if (!active) return ` ${modeLabel(mode)} `;
+  if (mode === 'agent') return ' A ';
+  if (mode === 'shell') return ' S ';
+  return ' R ';
+}
+
+function truncateText(value: string, width: number): string {
+  if (value.length <= width) return value;
+  if (width <= 3) return value.slice(0, width);
+  return `${value.slice(0, width - 3)}...`;
 }
 
 function thisRunSession(tmux: TmuxService, item: NavWorktree): boolean {

--- a/src/TmuxNavigatorApp.tsx
+++ b/src/TmuxNavigatorApp.tsx
@@ -318,7 +318,8 @@ export default function TmuxNavigatorApp(props: {sessionName: string}) {
 const STATUS_CHIP_WIDTH = 13;
 const AGENT_CELL_WIDTH = 5;
 const STATUS_AGENT_WIDTH = STATUS_CHIP_WIDTH + 1 + AGENT_CELL_WIDTH;
-const MIN_TILE_WIDTH = 30;
+const MIN_TILE_WIDTH = 24;
+const MAX_TILE_COLUMNS = 3;
 const TILE_LINE_COUNT = 3;
 const SUMMARY_LINE_Y = 1;
 const ACTION_LINE_Y = 2;
@@ -332,15 +333,22 @@ export type LayoutInfo = {
 };
 
 export function computeLayout(columns: number, rows: number, itemCount: number, selectedIndex: number): LayoutInfo {
-  const tileColumns = Math.min(3, Math.max(1, Math.floor((columns + 1) / (MIN_TILE_WIDTH + 1))));
+  const tileColumns = chooseTileColumns(columns);
   const tileRows = rows >= 8 ? 2 : 1;
   const visibleCount = Math.min(6, Math.max(1, tileColumns * tileRows));
-  const computedWidth = Math.floor((columns - Math.max(0, tileColumns - 1)) / tileColumns);
-  const tileWidth = Math.max(18, Math.min(columns, Math.max(MIN_TILE_WIDTH, computedWidth)));
+  const tileWidth = Math.max(1, Math.floor((columns - Math.max(0, tileColumns - 1)) / tileColumns));
   const pageStart = itemCount === 0
     ? 0
     : Math.max(0, Math.floor(selectedIndex / visibleCount) * visibleCount);
   return {tileColumns, tileRows, visibleCount, tileWidth, pageStart};
+}
+
+function chooseTileColumns(columns: number): number {
+  for (let candidate = Math.min(MAX_TILE_COLUMNS, Math.max(1, columns)); candidate >= 1; candidate--) {
+    const width = Math.floor((columns - Math.max(0, candidate - 1)) / candidate);
+    if (width >= MIN_TILE_WIDTH) return candidate;
+  }
+  return 1;
 }
 
 function modeColor(mode: NavMode): 'green' | 'blue' | 'magenta' {
@@ -372,11 +380,11 @@ function sessionState(tmux: TmuxService, sessionName: string, sessions: Set<stri
 function renderTileHeader(item: NavWorktree, selected: boolean, current: boolean, width: number): JSX.Element {
   const statusDisplay = getTileStatusDisplay(item);
   const leftWidth = statusDisplay.spanAgent ? STATUS_AGENT_WIDTH : STATUS_CHIP_WIDTH;
-  const metaWidth = Math.max(8, width - leftWidth - 1);
+  const metaWidth = Math.max(1, width - leftWidth - 1);
   const metaBg = selected ? 'yellow' : current ? 'cyan' : 'gray';
   const metaFg = selected || current ? 'black' : 'white';
   const right = current ? 'LIVE' : `${item.worktree.session?.attached ? 'ATTN' : 'NAV '}`;
-  const left = truncateText(item.project, Math.max(5, metaWidth - right.length - 1));
+  const left = truncateText(item.project, Math.max(1, metaWidth - stringDisplayWidth(right) - 1));
   return (
     <Box>
       {statusDisplay.spanAgent ? (
@@ -394,14 +402,18 @@ function renderTileHeader(item: NavWorktree, selected: boolean, current: boolean
             fg={statusDisplay.fg}
             width={STATUS_CHIP_WIDTH}
           />
-          <Text color={statusDisplay.agentFg}>
-            {padCell(statusDisplay.agentText, AGENT_CELL_WIDTH)}
-          </Text>
+          <Box width={AGENT_CELL_WIDTH}>
+            <Text color={statusDisplay.agentFg}>
+              {padCell(statusDisplay.agentText, AGENT_CELL_WIDTH)}
+            </Text>
+          </Box>
         </>
       )}
-      <Text color={metaFg} backgroundColor={metaBg}>
-        {padTile(left, right, metaWidth)}
-      </Text>
+      <Box width={metaWidth}>
+        <Text color={metaFg} backgroundColor={metaBg}>
+          {padTile(left, right, metaWidth)}
+        </Text>
+      </Box>
     </Box>
   );
 }

--- a/src/TmuxNavigatorApp.tsx
+++ b/src/TmuxNavigatorApp.tsx
@@ -4,14 +4,20 @@ import path from 'node:path';
 import fs from 'node:fs';
 import FullScreen from './components/common/FullScreen.js';
 import {GitService} from './services/GitService.js';
+import {GitHubService} from './services/GitHubService.js';
 import {TmuxService} from './services/TmuxService.js';
 import {getProjectsDirectory, isAppIntervalsEnabled} from './config.js';
 import {aiLaunchCommand, RUN_CONFIG_FILE} from './constants.js';
 import {detectAvailableAITools} from './shared/utils/commandExecutor.js';
 import {getLastTool, setLastTool} from './shared/utils/aiSessionMemory.js';
 import {baseSessionName, modeLabel, modeOrder, modeSessionName, sessionMode, type NavMode} from './shared/utils/tmuxNav.js';
+import {PRStatus, SessionInfo, WorktreeInfo} from './models.js';
 import type {AITool} from './models.js';
 import {useTerminalDimensions} from './hooks/useTerminalDimensions.js';
+import StatusChip from './components/common/StatusChip.js';
+import {getStatusMeta} from './components/views/MainView/highlight.js';
+import {formatDiffStats, formatGitChanges, formatPRStatus} from './components/views/MainView/utils.js';
+import {stringDisplayWidth} from './shared/utils/formatting.js';
 
 type NavWorktree = {
   project: string;
@@ -19,6 +25,11 @@ type NavWorktree = {
   path: string;
   branch: string;
   lastCommitTs: number;
+  worktree: WorktreeInfo;
+  statusMeta: {label: string; bg: string; fg: string};
+  diffText: string;
+  changesText: string;
+  prText: string;
   sessions: Record<NavMode, {exists: boolean; usable: boolean}>;
 };
 
@@ -30,6 +41,7 @@ export default function TmuxNavigatorApp(props: {sessionName: string}) {
   const {rows, columns} = useTerminalDimensions();
 
   const git = useMemo(() => new GitService(getProjectsDirectory()), []);
+  const github = useMemo(() => new GitHubService(), []);
   const tmux = useMemo(() => new TmuxService(), []);
   const availableTools = useMemo(() => detectAvailableAITools(), []);
   const currentMode = sessionMode(sessionName);
@@ -43,31 +55,76 @@ export default function TmuxNavigatorApp(props: {sessionName: string}) {
   const load = async () => {
     const projects = git.discoverProjects();
     const sessions = new Set(await tmux.listSessions());
-    const next: NavWorktree[] = [];
+    const discovered: Array<{
+      project: string;
+      feature: string;
+      path: string;
+      branch: string;
+      last_commit_ts: number;
+    }> = [];
 
     for (const project of projects) {
       const worktrees = await git.getWorktreesForProject(project);
-      for (const worktree of worktrees) {
-        next.push({
-          project: worktree.project,
-          feature: worktree.feature,
-          path: worktree.path,
-          branch: worktree.branch,
-          lastCommitTs: worktree.last_commit_ts || 0,
-          sessions: {
-            agent: sessionState(tmux, tmux.sessionName(worktree.project, worktree.feature), sessions),
-            shell: sessionState(tmux, tmux.shellSessionName(worktree.project, worktree.feature), sessions),
-            run: sessionState(tmux, tmux.runSessionName(worktree.project, worktree.feature), sessions),
-          }
-        });
-      }
+      discovered.push(...worktrees);
     }
+
+    const prByPath = await github.batchGetPRStatusForWorktreesAsync(
+      discovered.map((worktree) => ({project: worktree.project, path: worktree.path})),
+      true
+    );
+
+    const next = await Promise.all(discovered.map(async (worktree) => {
+      const agentSession = tmux.sessionName(worktree.project, worktree.feature);
+      const attached = sessions.has(agentSession);
+      const [gitStatus, aiResult] = await Promise.all([
+        git.getGitStatus(worktree.path),
+        attached
+          ? tmux.getAIStatus(agentSession)
+          : Promise.resolve({tool: 'none' as const, status: 'not_running' as const}),
+      ]);
+      const pr = prByPath[worktree.path] || new PRStatus({loadingStatus: 'not_checked'});
+      const info = new WorktreeInfo({
+        project: worktree.project,
+        feature: worktree.feature,
+        path: worktree.path,
+        branch: worktree.branch,
+        git: gitStatus,
+        pr,
+        session: new SessionInfo({
+          session_name: agentSession,
+          attached,
+          ai_status: aiResult.status,
+          ai_tool: aiResult.tool,
+        }),
+        last_commit_ts: worktree.last_commit_ts || 0,
+      });
+      return {
+        project: worktree.project,
+        feature: worktree.feature,
+        path: worktree.path,
+        branch: worktree.branch,
+        lastCommitTs: worktree.last_commit_ts || 0,
+        worktree: info,
+        statusMeta: getStatusMeta(info, pr),
+        diffText: formatDiffStats(info.git?.base_added_lines || 0, info.git?.base_deleted_lines || 0),
+        changesText: formatGitChanges(info.git?.ahead || 0, info.git?.behind || 0),
+        prText: formatPRStatus(pr) || '-',
+        sessions: {
+          agent: sessionState(tmux, agentSession, sessions),
+          shell: sessionState(tmux, tmux.shellSessionName(worktree.project, worktree.feature), sessions),
+          run: sessionState(tmux, tmux.runSessionName(worktree.project, worktree.feature), sessions),
+        }
+      };
+    }));
 
     next.sort((a, b) => (b.lastCommitTs || 0) - (a.lastCommitTs || 0) || `${a.project}/${a.feature}`.localeCompare(`${b.project}/${b.feature}`));
     setItems(next);
 
-    const idx = next.findIndex((item) => tmux.sessionName(item.project, item.feature) === currentBase);
-    if (idx >= 0) setSelectedIndex(idx);
+    const currentSessionIndex = next.findIndex((item) => tmux.sessionName(item.project, item.feature) === currentBase);
+    setSelectedIndex((prev) => {
+      if (currentSessionIndex >= 0) return currentSessionIndex;
+      return Math.max(0, Math.min(prev, next.length - 1));
+    });
     setStatusMessage(next.length ? 'click tile or mode  x closes selected mode  esc back' : 'no worktrees found');
   };
 
@@ -113,7 +170,7 @@ export default function TmuxNavigatorApp(props: {sessionName: string}) {
       else if (input === '2') { setSelectedActionMode('shell'); void activate('shell'); }
       else if (input === '3') { setSelectedActionMode('run'); void activate('run'); }
       else if (input === 'x' || input === 'X') void closeMode(selectedActionMode);
-      else if (input === '\r' || input === '\n') void activate(currentMode);
+      else if (input === '\r' || input === '\n') void activate(selectedActionMode);
       else if (input === '\u001b' || input === 'q') {
         tmux.selectMainPane(sessionName);
         exit();
@@ -138,15 +195,16 @@ export default function TmuxNavigatorApp(props: {sessionName: string}) {
     if (eventType !== 'M') return true;
     if (button >= 64) return true;
 
-    const tileHit = tileHitTarget(x, y, columns, visible.length);
+    const layout = computeLayout(columns, rows, items.length, selectedIndex);
+    const tileHit = tileHitTarget(x, y, layout);
     if (tileHit !== null) {
-      const absoluteIndex = pageStart + tileHit;
+      const absoluteIndex = layout.pageStart + tileHit;
       setSelectedIndex(absoluteIndex);
-      void activate(currentMode, absoluteIndex);
+      void activate(selectedActionMode, absoluteIndex);
       return true;
     }
 
-    const action = bottomActionHit(x, y, columns);
+    const action = bottomActionHit(x, y, columns, layout, items[selectedIndex] || null, currentMode);
     if (action === 'back') {
       tmux.selectMainPane(sessionName);
       exit();
@@ -202,43 +260,38 @@ export default function TmuxNavigatorApp(props: {sessionName: string}) {
     setStatusMessage(`closed ${mode} for ${item.feature}`);
   };
 
-  const tileColumns = Math.min(3, Math.max(1, Math.floor((columns + 1) / (MIN_TILE_WIDTH + 1))));
-  const tileRows = rows >= 9 ? 2 : 1;
-  const visibleCount = Math.min(6, tileColumns * tileRows);
-  const tileWidth = Math.max(18, Math.floor((columns - Math.max(0, tileColumns - 1)) / tileColumns));
-  const pageStart = Math.max(0, Math.floor(selectedIndex / Math.max(1, visibleCount)) * Math.max(1, visibleCount));
-  const visible = items.slice(pageStart, pageStart + visibleCount);
+  const layout = computeLayout(columns, rows, items.length, selectedIndex);
+  const visible = items.slice(layout.pageStart, layout.pageStart + layout.visibleCount);
   const selectedItem = items[selectedIndex] || null;
-  const statusTone: 'cyan' | 'yellow' = items.length ? 'cyan' : 'yellow';
-  const tileGroups = Array.from({length: tileRows}, (_, row) => visible.slice(row * tileColumns, (row + 1) * tileColumns));
+  const tileGroups = Array.from({length: layout.tileRows}, (_, row) => visible.slice(row * layout.tileColumns, (row + 1) * layout.tileColumns));
 
   return (
     <FullScreen enableAltScreen={false}>
       <Box flexDirection="column" paddingX={1}>
-        <Box justifyContent="space-between">
-          <Text color="magenta">{`recent ${pageStart + 1}-${Math.min(pageStart + visible.length, items.length)} / ${items.length}`}</Text>
-          <Text color={statusTone}>{truncateText(selectedItem ? `${selectedItem.feature} [${selectedItem.project}]` : statusMessage, Math.max(16, Math.floor(columns / 2)))} </Text>
-        </Box>
         {tileGroups.map((group, rowIndex) => (
-          <Box key={`tile-row-${rowIndex}`} marginTop={rowIndex === 0 ? 0 : 0}>
+          <Box key={`tile-row-${rowIndex}`}>
             {group.map((item, columnIndex) => {
-              const absoluteIndex = pageStart + (rowIndex * tileColumns) + columnIndex;
+              const absoluteIndex = layout.pageStart + (rowIndex * layout.tileColumns) + columnIndex;
               return (
-                <Box key={`${item.project}-${item.feature}`} marginRight={columnIndex === group.length - 1 ? 0 : 1} width={tileWidth} flexDirection="column">
-                  {renderTileLine(
+                <Box
+                  key={`${item.project}-${item.feature}`}
+                  marginRight={columnIndex === group.length - 1 ? 0 : 1}
+                  width={layout.tileWidth}
+                  flexDirection="column"
+                >
+                  {renderTileHeader(
                     item,
                     absoluteIndex === selectedIndex,
                     itemSessionBase(item) === currentBase,
-                    tileWidth,
-                    0
+                    layout.tileWidth
                   )}
-                  {renderTileLine(
+                  {renderTileFeatureLine(
                     item,
                     absoluteIndex === selectedIndex,
                     itemSessionBase(item) === currentBase,
-                    tileWidth,
-                    1
+                    layout.tileWidth
                   )}
+                  {renderTileMetricsLine(item, absoluteIndex === selectedIndex, itemSessionBase(item) === currentBase, layout.tileWidth)}
                 </Box>
               );
             })}
@@ -246,9 +299,13 @@ export default function TmuxNavigatorApp(props: {sessionName: string}) {
         ))}
         <Box justifyContent="space-between">
           <Text color="white">
-            {selectedItem ? `${truncateText(selectedItem.feature, 20)} [${truncateText(selectedItem.project, 16)}]` : 'no selection'}
+            {selectedItem
+              ? `${truncateText(selectedItem.feature, 24)} [${truncateText(selectedItem.project, 16)}]`
+              : statusMessage}
           </Text>
-          <Text color="gray">{selectedItem ? truncateText(selectedItem.branch, 18) : ''}</Text>
+          <Text color="gray">
+            {selectedItem ? truncateText(`pr ${selectedItem.prText}  diff ${selectedItem.diffText}  sync ${selectedItem.changesText}`, Math.max(20, Math.floor(columns / 2))) : ''}
+          </Text>
         </Box>
         <Box>
           {renderBottomActions(selectedItem, selectedActionMode, currentMode)}
@@ -258,7 +315,31 @@ export default function TmuxNavigatorApp(props: {sessionName: string}) {
   );
 }
 
-const MIN_TILE_WIDTH = 20;
+const STATUS_CHIP_WIDTH = 13;
+const MIN_TILE_WIDTH = 30;
+const TILE_LINE_COUNT = 3;
+const SUMMARY_LINE_Y = 1;
+const ACTION_LINE_Y = 2;
+
+export type LayoutInfo = {
+  tileColumns: number;
+  tileRows: number;
+  visibleCount: number;
+  tileWidth: number;
+  pageStart: number;
+};
+
+export function computeLayout(columns: number, rows: number, itemCount: number, selectedIndex: number): LayoutInfo {
+  const tileColumns = Math.min(3, Math.max(1, Math.floor((columns + 1) / (MIN_TILE_WIDTH + 1))));
+  const tileRows = rows >= 8 ? 2 : 1;
+  const visibleCount = Math.min(6, Math.max(1, tileColumns * tileRows));
+  const computedWidth = Math.floor((columns - Math.max(0, tileColumns - 1)) / tileColumns);
+  const tileWidth = Math.max(18, Math.min(columns, Math.max(MIN_TILE_WIDTH, computedWidth)));
+  const pageStart = itemCount === 0
+    ? 0
+    : Math.max(0, Math.floor(selectedIndex / visibleCount) * visibleCount);
+  return {tileColumns, tileRows, visibleCount, tileWidth, pageStart};
+}
 
 function modeColor(mode: NavMode): 'green' | 'blue' | 'magenta' {
   if (mode === 'agent') return 'green';
@@ -273,7 +354,7 @@ function modePill(mode: NavMode): string {
 }
 
 function truncateText(value: string, width: number): string {
-  if (value.length <= width) return value;
+  if (stringDisplayWidth(value) <= width) return value;
   if (width <= 3) return value.slice(0, width);
   return `${value.slice(0, width - 3)}...`;
 }
@@ -286,24 +367,47 @@ function sessionState(tmux: TmuxService, sessionName: string, sessions: Set<stri
   };
 }
 
-function renderTileLine(item: NavWorktree, selected: boolean, current: boolean, width: number, line: 0 | 1): JSX.Element {
+function renderTileHeader(item: NavWorktree, selected: boolean, current: boolean, width: number): JSX.Element {
+  const metaWidth = Math.max(8, width - STATUS_CHIP_WIDTH - 1);
+  const metaBg = selected ? 'yellow' : current ? 'cyan' : 'gray';
+  const metaFg = selected || current ? 'black' : 'white';
+  const right = current ? 'LIVE' : `${item.worktree.session?.attached ? 'ATTN' : 'NAV '}`;
+  const left = truncateText(item.project, Math.max(5, metaWidth - right.length - 1));
+  return (
+    <Box>
+      <StatusChip
+        label={item.statusMeta.label || ''}
+        color={item.statusMeta.bg}
+        fg={item.statusMeta.fg}
+        width={STATUS_CHIP_WIDTH}
+      />
+      <Text color={metaFg} backgroundColor={metaBg}>
+        {padTile(left, right, metaWidth)}
+      </Text>
+    </Box>
+  );
+}
+
+function renderTileFeatureLine(item: NavWorktree, selected: boolean, current: boolean, width: number): JSX.Element {
   const bg = selected ? 'yellow' : current ? 'cyan' : 'blue';
   const fg = selected || current ? 'black' : 'white';
-  if (line === 0) {
-    const left = truncateText(item.feature, Math.max(8, width - 6));
-    const right = current ? 'LIVE' : '    ';
-    return (
-      <Text color={fg} backgroundColor={bg}>
-        {padTile(`${left}`, `${right}`, width)}
-      </Text>
-    );
-  }
-
-  const project = truncateText(item.project, Math.max(5, width - 8));
-  const badges = modeOrder.map((mode) => compactModeState(mode, item.sessions[mode])).join(' ');
+  const left = truncateText(item.feature, Math.max(8, width - 10));
+  const right = item.branch && item.branch !== item.feature ? truncateText(item.branch.replace(/^refs\/heads\//, ''), 8) : '';
   return (
     <Text color={fg} backgroundColor={bg}>
-      {padTile(project, badges, width)}
+      {padTile(left, right, width)}
+    </Text>
+  );
+}
+
+function renderTileMetricsLine(item: NavWorktree, selected: boolean, current: boolean, width: number): JSX.Element {
+  const bg = selected ? 'yellow' : current ? 'cyan' : 'black';
+  const fg = selected || current ? 'black' : 'white';
+  const left = `${modeStatusSummary(item)} ${item.diffText}`;
+  const right = `${item.changesText} ${item.prText}`.trim();
+  return (
+    <Text color={fg} backgroundColor={bg}>
+      {padTile(left, right, width)}
     </Text>
   );
 }
@@ -330,7 +434,7 @@ function renderBottomActions(
   );
 }
 
-function renderActionLabel(mode: NavMode, state: {exists: boolean; usable: boolean} | undefined, current: boolean): string {
+export function renderActionLabel(mode: NavMode, state: {exists: boolean; usable: boolean} | undefined, current: boolean): string {
   const label = modePill(mode).trim();
   const status = state ? compactModeState(mode, state) : '--';
   return `${current ? '*' : ' '}${label} ${status} `;
@@ -340,28 +444,34 @@ function itemSessionBase(item: NavWorktree): string {
   return `dev-${item.project}-${item.feature}`;
 }
 
-function tileHitTarget(x: number, y: number, columns: number, visibleCount: number): number | null {
-  if (y < 3 || y > 6 || visibleCount === 0) return null;
-  const tileColumns = Math.min(3, Math.max(1, Math.floor((columns + 1) / (MIN_TILE_WIDTH + 1))));
-  const tileWidth = Math.max(18, Math.floor((columns - Math.max(0, tileColumns - 1)) / tileColumns));
-  const row = Math.floor((y - 3) / 2);
-  const rowY = (y - 3) % 2;
-  if (rowY < 0 || rowY > 1) return null;
-  const localIndex = Math.floor((x - 1) / (tileWidth + 1));
-  if (localIndex < 0 || localIndex >= tileColumns) return null;
-  const xOffset = (x - 1) % (tileWidth + 1);
-  if (xOffset >= tileWidth) return null;
-  const absoluteLocal = row * tileColumns + localIndex;
-  if (absoluteLocal >= visibleCount) return null;
+export function tileHitTarget(x: number, y: number, layout: LayoutInfo): number | null {
+  const maxTileY = layout.tileRows * TILE_LINE_COUNT;
+  if (y < 1 || y > maxTileY || layout.visibleCount === 0) return null;
+  const row = Math.floor((y - 1) / TILE_LINE_COUNT);
+  const localIndex = Math.floor((x - 1) / (layout.tileWidth + 1));
+  if (localIndex < 0 || localIndex >= layout.tileColumns) return null;
+  const xOffset = (x - 1) % (layout.tileWidth + 1);
+  if (xOffset >= layout.tileWidth) return null;
+  const absoluteLocal = row * layout.tileColumns + localIndex;
+  if (absoluteLocal >= layout.visibleCount) return null;
   return absoluteLocal;
 }
 
-function bottomActionHit(x: number, y: number, columns: number): NavMode | 'close' | 'back' | null {
-  if (y !== 9) return null;
+export function bottomActionHit(
+  x: number,
+  y: number,
+  columns: number,
+  layout: LayoutInfo,
+  selectedItem: NavWorktree | null,
+  currentMode: NavMode
+): NavMode | 'close' | 'back' | null {
+  const summaryY = (layout.tileRows * TILE_LINE_COUNT) + SUMMARY_LINE_Y;
+  const actionY = summaryY + ACTION_LINE_Y - 1;
+  if (y !== actionY) return null;
   const labels: Array<{kind: NavMode | 'close' | 'back'; label: string}> = [
-    {kind: 'agent', label: ' 1 Agent up '},
-    {kind: 'shell', label: ' 2 Shell up '},
-    {kind: 'run', label: ' 3 Run up '},
+    {kind: 'agent', label: renderActionLabel('agent', selectedItem?.sessions.agent, currentMode === 'agent')},
+    {kind: 'shell', label: renderActionLabel('shell', selectedItem?.sessions.shell, currentMode === 'shell')},
+    {kind: 'run', label: renderActionLabel('run', selectedItem?.sessions.run, currentMode === 'run')},
     {kind: 'close', label: ' Close '},
     {kind: 'back', label: ' Back '},
   ];
@@ -376,10 +486,14 @@ function bottomActionHit(x: number, y: number, columns: number): NavMode | 'clos
   return null;
 }
 
-function compactModeState(mode: NavMode, state: {exists: boolean; usable: boolean}): string {
+export function compactModeState(mode: NavMode, state: {exists: boolean; usable: boolean}): string {
   if (state.usable) return modeLabel(mode);
   if (state.exists) return '!';
   return '-';
+}
+
+export function modeStatusSummary(item: NavWorktree): string {
+  return modeOrder.map((mode) => `${modeLabel(mode)}${compactModeState(mode, item.sessions[mode])}`).join(' ');
 }
 
 function padTile(left: string, right: string, width: number): string {

--- a/src/TmuxNavigatorApp.tsx
+++ b/src/TmuxNavigatorApp.tsx
@@ -1,0 +1,182 @@
+import React, {useEffect, useMemo, useState} from 'react';
+import {Box, Text, useApp, useStdin} from 'ink';
+import path from 'node:path';
+import fs from 'node:fs';
+import FullScreen from './components/common/FullScreen.js';
+import {GitService} from './services/GitService.js';
+import {TmuxService} from './services/TmuxService.js';
+import {getProjectsDirectory, isAppIntervalsEnabled} from './config.js';
+import {aiLaunchCommand, RUN_CONFIG_FILE} from './constants.js';
+import {detectAvailableAITools} from './shared/utils/commandExecutor.js';
+import {getLastTool, setLastTool} from './shared/utils/aiSessionMemory.js';
+import {baseSessionName, modeLabel, modeOrder, modeSessionName, sessionMode, type NavMode} from './shared/utils/tmuxNav.js';
+import type {AITool} from './models.js';
+import {useTerminalDimensions} from './hooks/useTerminalDimensions.js';
+
+type NavWorktree = {
+  project: string;
+  feature: string;
+  path: string;
+  branch: string;
+  lastCommitTs: number;
+  sessions: Record<NavMode, boolean>;
+};
+
+export default function TmuxNavigatorApp(props: {sessionName: string}) {
+  const {sessionName} = props;
+  const {exit} = useApp();
+  const {stdin, setRawMode} = useStdin();
+  const {rows} = useTerminalDimensions();
+
+  const git = useMemo(() => new GitService(getProjectsDirectory()), []);
+  const tmux = useMemo(() => new TmuxService(), []);
+  const availableTools = useMemo(() => detectAvailableAITools(), []);
+
+  const [items, setItems] = useState<NavWorktree[]>([]);
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const [statusMessage, setStatusMessage] = useState<string>('loading...');
+
+  const currentMode = sessionMode(sessionName);
+  const currentBase = baseSessionName(sessionName);
+
+  const load = async () => {
+    const projects = git.discoverProjects();
+    const sessions = new Set(await tmux.listSessions());
+    const next: NavWorktree[] = [];
+
+    for (const project of projects) {
+      const worktrees = await git.getWorktreesForProject(project);
+      for (const worktree of worktrees) {
+        next.push({
+          project: worktree.project,
+          feature: worktree.feature,
+          path: worktree.path,
+          branch: worktree.branch,
+          lastCommitTs: worktree.last_commit_ts || 0,
+          sessions: {
+            agent: sessions.has(tmux.sessionName(worktree.project, worktree.feature)),
+            shell: sessions.has(tmux.shellSessionName(worktree.project, worktree.feature)),
+            run: sessions.has(tmux.runSessionName(worktree.project, worktree.feature)),
+          }
+        });
+      }
+    }
+
+    next.sort((a, b) => (b.lastCommitTs || 0) - (a.lastCommitTs || 0) || `${a.project}/${a.feature}`.localeCompare(`${b.project}/${b.feature}`));
+    setItems(next);
+
+    const idx = next.findIndex((item) => tmux.sessionName(item.project, item.feature) === currentBase);
+    if (idx >= 0) setSelectedIndex(idx);
+    setStatusMessage(next.length ? 'enter switch  1/2/3 modes  esc focus main' : 'no worktrees found');
+  };
+
+  useEffect(() => {
+    void load();
+    if (!isAppIntervalsEnabled()) return;
+    const timer = setInterval(() => { void load(); }, 5000);
+    return () => clearInterval(timer);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
+    setRawMode(true);
+    const handler = (buf: Buffer) => {
+      const input = buf.toString('utf8');
+      if (input === 'j' || input === '\u001b[B') setSelectedIndex((prev) => Math.min(prev + 1, Math.max(items.length - 1, 0)));
+      else if (input === 'k' || input === '\u001b[A') setSelectedIndex((prev) => Math.max(prev - 1, 0));
+      else if (input === 'r') void load();
+      else if (input === '1') void activate('agent');
+      else if (input === '2') void activate('shell');
+      else if (input === '3') void activate('run');
+      else if (input === '\r' || input === '\n') void activate(currentMode);
+      else if (input === '\u001b' || input === 'q') {
+        tmux.selectMainPane(sessionName);
+        exit();
+      }
+    };
+    stdin.on('data', handler);
+    return () => {
+      stdin.off('data', handler);
+      setRawMode(false);
+    };
+  }, [currentMode, exit, items.length, load, sessionName, setRawMode, stdin, tmux]);
+
+  const activate = async (mode: NavMode) => {
+    const item = items[selectedIndex];
+    if (!item) return;
+    const targetSession = modeSessionName(tmux, item.project, item.feature, mode);
+
+    if (!tmux.hasSession(targetSession)) {
+      if (mode === 'agent') {
+        const remembered = getLastTool(item.path);
+        const tool = ((remembered && remembered !== 'none') ? remembered : (availableTools[0] || 'none')) as AITool;
+        if (tool === 'none') {
+          tmux.createSession(targetSession, item.path, true);
+        } else {
+          tmux.createSessionWithCommand(targetSession, item.path, aiLaunchCommand(tool), true);
+          setLastTool(tool, item.path);
+        }
+      } else if (mode === 'shell') {
+        tmux.createSession(targetSession, item.path, false);
+      } else {
+        const configured = thisRunSession(tmux, item);
+        if (!configured) return;
+      }
+    }
+
+    tmux.prepareSessionNavigator(targetSession);
+    tmux.selectMainPane(targetSession);
+    tmux.switchClient(targetSession);
+  };
+
+  const visibleRows = Math.max(1, rows - 3);
+  const start = Math.max(0, Math.min(selectedIndex - Math.floor(visibleRows / 2), Math.max(0, items.length - visibleRows)));
+  const visible = items.slice(start, start + visibleRows);
+
+  return (
+    <FullScreen enableAltScreen={false}>
+      <Box flexDirection="column" paddingX={1}>
+        <Text>{`devteam nav  current:${modeLabel(currentMode)}  ${statusMessage}`}</Text>
+        {visible.map((item, offset) => {
+          const absoluteIndex = start + offset;
+          const isSelected = absoluteIndex === selectedIndex;
+          const isCurrent = tmux.sessionName(item.project, item.feature) === currentBase;
+          const modeCells = modeOrder.map((mode) => item.sessions[mode] ? modeLabel(mode) : '-').join(' ');
+          const prefix = isSelected ? '>' : ' ';
+          const current = isCurrent ? '*' : ' ';
+          return (
+            <Text key={`${item.project}-${item.feature}`}>
+              {`${prefix}${current} ${item.feature} [${item.project}]  ${modeCells}`}
+            </Text>
+          );
+        })}
+      </Box>
+    </FullScreen>
+  );
+}
+
+function thisRunSession(tmux: TmuxService, item: NavWorktree): boolean {
+  const sessionName = tmux.runSessionName(item.project, item.feature);
+  tmux.createSession(sessionName, item.path, false);
+  const configPath = path.join(getProjectsDirectory(), item.project, RUN_CONFIG_FILE);
+  if (!fs.existsSync(configPath)) {
+    return false;
+  }
+
+  const cfg = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+  const exec = (cfg?.executionInstructions ?? {}) as any;
+  const mainCmd = exec.mainCommand as string | undefined;
+  const pre: string[] = Array.isArray(exec.preRunCommands) ? exec.preRunCommands.filter(Boolean) : [];
+  const env: Record<string, string> = (exec.environmentVariables && typeof exec.environmentVariables === 'object') ? exec.environmentVariables : {};
+  const detachOnExit: boolean = !!exec.detachOnExit;
+  try { tmux.setSessionOption(sessionName, 'remain-on-exit', detachOnExit ? 'on' : 'off'); } catch {}
+  if (!mainCmd || typeof mainCmd !== 'string' || mainCmd.trim().length === 0) {
+    return false;
+  }
+  for (const [k, v] of Object.entries(env)) {
+    tmux.sendText(sessionName, `export ${k}=${JSON.stringify(String(v))}`, {executeCommand: true});
+  }
+  for (const cmd of pre) tmux.sendText(sessionName, cmd, {executeCommand: true});
+  tmux.sendText(sessionName, mainCmd, {executeCommand: true});
+  return true;
+}

--- a/src/TmuxNavigatorApp.tsx
+++ b/src/TmuxNavigatorApp.tsx
@@ -16,7 +16,7 @@ import type {AITool} from './models.js';
 import {useTerminalDimensions} from './hooks/useTerminalDimensions.js';
 import StatusChip from './components/common/StatusChip.js';
 import {getStatusMeta} from './components/views/MainView/highlight.js';
-import {formatDiffStats, formatGitChanges, formatPRStatus} from './components/views/MainView/utils.js';
+import {formatDiffStats, formatGitChanges, formatPRStatus, getAISymbol} from './components/views/MainView/utils.js';
 import {stringDisplayWidth} from './shared/utils/formatting.js';
 
 type NavWorktree = {
@@ -316,6 +316,8 @@ export default function TmuxNavigatorApp(props: {sessionName: string}) {
 }
 
 const STATUS_CHIP_WIDTH = 13;
+const AGENT_CELL_WIDTH = 5;
+const STATUS_AGENT_WIDTH = STATUS_CHIP_WIDTH + 1 + AGENT_CELL_WIDTH;
 const MIN_TILE_WIDTH = 30;
 const TILE_LINE_COUNT = 3;
 const SUMMARY_LINE_Y = 1;
@@ -368,19 +370,35 @@ function sessionState(tmux: TmuxService, sessionName: string, sessions: Set<stri
 }
 
 function renderTileHeader(item: NavWorktree, selected: boolean, current: boolean, width: number): JSX.Element {
-  const metaWidth = Math.max(8, width - STATUS_CHIP_WIDTH - 1);
+  const statusDisplay = getTileStatusDisplay(item);
+  const leftWidth = statusDisplay.spanAgent ? STATUS_AGENT_WIDTH : STATUS_CHIP_WIDTH;
+  const metaWidth = Math.max(8, width - leftWidth - 1);
   const metaBg = selected ? 'yellow' : current ? 'cyan' : 'gray';
   const metaFg = selected || current ? 'black' : 'white';
   const right = current ? 'LIVE' : `${item.worktree.session?.attached ? 'ATTN' : 'NAV '}`;
   const left = truncateText(item.project, Math.max(5, metaWidth - right.length - 1));
   return (
     <Box>
-      <StatusChip
-        label={item.statusMeta.label || ''}
-        color={item.statusMeta.bg}
-        fg={item.statusMeta.fg}
-        width={STATUS_CHIP_WIDTH}
-      />
+      {statusDisplay.spanAgent ? (
+        <StatusChip
+          label={statusDisplay.label}
+          color={statusDisplay.bg}
+          fg={statusDisplay.fg}
+          width={STATUS_AGENT_WIDTH}
+        />
+      ) : (
+        <>
+          <StatusChip
+            label={statusDisplay.label}
+            color={statusDisplay.bg}
+            fg={statusDisplay.fg}
+            width={STATUS_CHIP_WIDTH}
+          />
+          <Text color={statusDisplay.agentFg}>
+            {padCell(statusDisplay.agentText, AGENT_CELL_WIDTH)}
+          </Text>
+        </>
+      )}
       <Text color={metaFg} backgroundColor={metaBg}>
         {padTile(left, right, metaWidth)}
       </Text>
@@ -496,12 +514,52 @@ export function modeStatusSummary(item: NavWorktree): string {
   return modeOrder.map((mode) => `${modeLabel(mode)}${compactModeState(mode, item.sessions[mode])}`).join(' ');
 }
 
+type TileStatusDisplay = {
+  spanAgent: boolean;
+  label: string;
+  bg: string;
+  fg: string;
+  agentText: string;
+  agentFg: string;
+};
+
+function getTileStatusDisplay(item: NavWorktree): TileStatusDisplay {
+  const aiText = getAISymbol(item.worktree.session?.ai_status || '', item.worktree.session?.attached || false);
+  const aiStatus = item.worktree.session?.ai_status || 'not_running';
+  if (aiStatus === 'working' || aiStatus === 'waiting') {
+    return {
+      spanAgent: true,
+      label: `${item.statusMeta.label} ${aiText}`.trim(),
+      bg: item.statusMeta.bg,
+      fg: item.statusMeta.fg,
+      agentText: aiText,
+      agentFg: 'white',
+    };
+  }
+  return {
+    spanAgent: false,
+    label: item.statusMeta.label || '',
+    bg: item.statusMeta.bg,
+    fg: item.statusMeta.fg,
+    agentText: aiText,
+    agentFg: aiText === '-' ? 'gray' : 'white',
+  };
+}
+
 function padTile(left: string, right: string, width: number): string {
   const innerWidth = Math.max(4, width);
-  const availableLeft = Math.max(1, innerWidth - right.length - 1);
+  const availableLeft = Math.max(1, innerWidth - stringDisplayWidth(right) - 1);
   const leftText = truncateText(left, availableLeft);
-  const gap = Math.max(1, innerWidth - leftText.length - right.length);
+  const gap = Math.max(1, innerWidth - stringDisplayWidth(leftText) - stringDisplayWidth(right));
   return `${leftText}${' '.repeat(gap)}${right}`;
+}
+
+function padCell(text: string, width: number): string {
+  const visible = truncateText(text, width);
+  const pad = Math.max(0, width - stringDisplayWidth(visible));
+  const left = Math.floor(pad / 2);
+  const right = pad - left;
+  return `${' '.repeat(left)}${visible}${' '.repeat(right)}`;
 }
 
 function thisRunSession(tmux: TmuxService, item: NavWorktree, exists: boolean): boolean {

--- a/src/TmuxNavigatorApp.tsx
+++ b/src/TmuxNavigatorApp.tsx
@@ -255,20 +255,7 @@ export default function TmuxNavigatorApp(props: {sessionName: string}) {
           <Text color="gray">{selectedItem ? truncateText(selectedItem.branch, 18) : ''}</Text>
         </Box>
         <Box>
-          {selectedItem ? (
-            <Text color="gray">
-              {modeOrder.map((mode) => renderInlineMode(mode, selectedItem.sessions[mode], selectedActionMode === mode, mode === currentMode)).join('  ')}
-            </Text>
-          ) : (
-            <Text color="gray">no worktrees discovered</Text>
-          )}
-        </Box>
-        <Box>
           {renderBottomActions(selectedItem, selectedActionMode, currentMode)}
-        </Box>
-        <Box justifyContent="space-between">
-          <Text color="magenta">click tile to open current mode  click bottom to switch/close</Text>
-          <Text color="gray">esc back</Text>
         </Box>
       </Box>
     </FullScreen>
@@ -323,13 +310,6 @@ function renderTileLine(item: NavWorktree, selected: boolean, current: boolean, 
       {padTile(project, badges, width)}
     </Text>
   );
-}
-
-function renderInlineMode(mode: NavMode, state: {exists: boolean; usable: boolean}, selected: boolean, current: boolean): string {
-  const status = state.usable ? 'up' : state.exists ? 'stale' : 'off';
-  const prefix = selected ? '>' : ' ';
-  const live = current ? '*' : ' ';
-  return `${prefix}${live}${modePill(mode).trim()} ${status}`;
 }
 
 function renderBottomActions(

--- a/src/TmuxNavigatorApp.tsx
+++ b/src/TmuxNavigatorApp.tsx
@@ -216,12 +216,8 @@ export default function TmuxNavigatorApp(props: {sessionName: string}) {
     <FullScreen enableAltScreen={false}>
       <Box flexDirection="column" paddingX={1}>
         <Box justifyContent="space-between">
-          <Text color="black" backgroundColor="cyan">{' DEVTEAM NAV '}</Text>
-          <Text color="gray">{truncateText(selectedItem ? `${selectedItem.feature} [${selectedItem.project}]` : 'no selection', Math.max(12, columns - 22))}</Text>
-        </Box>
-        <Box justifyContent="space-between">
           <Text color="magenta">{`recent ${pageStart + 1}-${Math.min(pageStart + visible.length, items.length)} / ${items.length}`}</Text>
-          <Text color={statusTone}>{truncateText(statusMessage, Math.max(16, Math.floor(columns / 2)))} </Text>
+          <Text color={statusTone}>{truncateText(selectedItem ? `${selectedItem.feature} [${selectedItem.project}]` : statusMessage, Math.max(16, Math.floor(columns / 2)))} </Text>
         </Box>
         {tileGroups.map((group, rowIndex) => (
           <Box key={`tile-row-${rowIndex}`} marginTop={rowIndex === 0 ? 0 : 0}>

--- a/src/bootstrap.tsx
+++ b/src/bootstrap.tsx
@@ -1,13 +1,19 @@
 import {render} from 'ink';
 import React from 'react';
 import App from './App.js';
+import TmuxNavigatorApp from './TmuxNavigatorApp.js';
 import {reinitializeMemoryLogging} from './shared/utils/logger.js';
 import {SESSION_PREFIX} from './constants.js';
 import {runCommandQuickAsync, runCommandQuick, getCleanEnvironment} from './shared/utils/commandExecutor.js';
+import {getTmuxNavigatorSession, isTmuxNavigatorMode} from './config.js';
 
 
 export function run() {
-  const {waitUntilExit} = render(<App />);
+  const navSession = getTmuxNavigatorSession();
+  const root = (isTmuxNavigatorMode() && navSession)
+    ? <TmuxNavigatorApp sessionName={navSession} />
+    : <App />;
+  const {waitUntilExit} = render(root);
   
   // Re-initialize logging after Ink's render() to ensure our overrides work
   reinitializeMemoryLogging();

--- a/src/config.ts
+++ b/src/config.ts
@@ -23,6 +23,17 @@ function parseProjectsDirectory(): string {
   return process.cwd();
 }
 
+function hasFlag(flag: string): boolean {
+  return process.argv.slice(2).includes(flag);
+}
+
+function readFlagValue(flag: string): string | null {
+  const args = process.argv.slice(2);
+  const index = args.findIndex((arg) => arg === flag);
+  if (index === -1 || index + 1 >= args.length) return null;
+  return args[index + 1];
+}
+
 // Compute configuration once on startup
 export const PROJECTS_DIRECTORY = parseProjectsDirectory();
 
@@ -39,4 +50,12 @@ export function getProjectsDirectory(): string {
  */
 export function isAppIntervalsEnabled(): boolean {
   return process.env.NO_APP_INTERVALS !== '1';
+}
+
+export function isTmuxNavigatorMode(): boolean {
+  return hasFlag('--tmux-nav');
+}
+
+export function getTmuxNavigatorSession(): string | null {
+  return readFlagValue('--tmux-nav-session');
 }

--- a/src/services/TmuxService.ts
+++ b/src/services/TmuxService.ts
@@ -198,6 +198,7 @@ export class TmuxService {
     if (mainPane) {
       runCommand(['tmux', 'select-pane', '-t', mainPane.id, '-T', MAIN_PANE_TITLE], { env: this.tmuxEnv });
       this.setSessionOption(sessionName, '@devteam_main_pane', mainPane.id);
+      this.enforceNavigatorLayout(sessionName);
       return;
     }
 
@@ -219,6 +220,7 @@ export class TmuxService {
     if (created) {
       runCommand(['tmux', 'select-pane', '-t', created, '-T', MAIN_PANE_TITLE], { env: this.tmuxEnv });
       this.setSessionOption(sessionName, '@devteam_main_pane', created);
+      this.enforceNavigatorLayout(sessionName);
     }
   }
 
@@ -269,6 +271,8 @@ export class TmuxService {
     if (mainPane.id) {
       this.setSessionOption(sessionName, '@devteam_main_pane', mainPane.id);
     }
+
+    this.enforceNavigatorLayout(sessionName);
 
     this.setSessionOption(sessionName, 'status', 'off');
     this.setSessionOption(sessionName, 'pane-border-status', 'off');
@@ -584,6 +588,13 @@ export class TmuxService {
         const [id = '', index = '0', title = '', currentCommand = ''] = line.split('\t');
         return {id, index, title, currentCommand};
       });
+  }
+
+  private enforceNavigatorLayout(sessionName: string): void {
+    const navPane = this.getSessionOptionValue(sessionName, '@devteam_nav_pane');
+    if (!navPane) return;
+    runCommand(['tmux', 'select-layout', '-t', `${sessionName}:0`, 'main-horizontal'], { env: this.tmuxEnv });
+    runCommand(['tmux', 'resize-pane', '-t', navPane, '-y', String(NAV_PANE_HEIGHT)], { env: this.tmuxEnv });
   }
 }
 

--- a/src/services/TmuxService.ts
+++ b/src/services/TmuxService.ts
@@ -185,6 +185,43 @@ export class TmuxService {
     if (navPane) runCommand(['tmux', 'select-pane', '-t', navPane], { env: this.tmuxEnv });
   }
 
+  hasUsableMainPane(sessionName: string): boolean {
+    const panes = this.listPaneDetailsSync(sessionName);
+    return panes.some((pane) => pane.title !== NAV_PANE_TITLE && pane.id !== this.getSessionOptionValue(sessionName, '@devteam_nav_pane'));
+  }
+
+  ensureMainPane(sessionName: string, cwd: string, command?: string): void {
+    const panes = this.listPaneDetailsSync(sessionName);
+    const navPane = panes.find((pane) => pane.title === NAV_PANE_TITLE);
+    const mainPane = panes.find((pane) => pane.title !== NAV_PANE_TITLE);
+
+    if (mainPane) {
+      runCommand(['tmux', 'select-pane', '-t', mainPane.id, '-T', MAIN_PANE_TITLE], { env: this.tmuxEnv });
+      this.setSessionOption(sessionName, '@devteam_main_pane', mainPane.id);
+      return;
+    }
+
+    const anchor = navPane?.id || `${sessionName}:0.0`;
+    const created = runCommandQuick([
+      'tmux',
+      'split-window',
+      '-vf',
+      '-t',
+      anchor,
+      '-c',
+      cwd,
+      '-P',
+      '-F',
+      '#{pane_id}',
+      command || (process.env.SHELL || '/bin/bash'),
+    ], undefined, this.tmuxEnv);
+
+    if (created) {
+      runCommand(['tmux', 'select-pane', '-t', created, '-T', MAIN_PANE_TITLE], { env: this.tmuxEnv });
+      this.setSessionOption(sessionName, '@devteam_main_pane', created);
+    }
+  }
+
   prepareSessionNavigator(sessionName: string): void {
     if (!this.hasSession(sessionName)) return;
 

--- a/src/services/TmuxService.ts
+++ b/src/services/TmuxService.ts
@@ -8,7 +8,7 @@ import {getProjectsDirectory} from '../config.js';
 
 const NAV_PANE_TITLE = 'devteam-nav';
 const MAIN_PANE_TITLE = 'devteam-main';
-const NAV_PANE_HEIGHT = 8;
+const NAV_PANE_HEIGHT = 11;
 
 export class TmuxService {
   private aiToolService: AIToolService;

--- a/src/services/TmuxService.ts
+++ b/src/services/TmuxService.ts
@@ -4,7 +4,11 @@ import {logDebug} from '../shared/utils/logger.js';
 import {Timer} from '../shared/utils/timing.js';
 import {AIStatus, AITool} from '../models.js';
 import {AIToolService} from './AIToolService.js';
+import {getProjectsDirectory} from '../config.js';
 
+const NAV_PANE_TITLE = 'devteam-nav';
+const MAIN_PANE_TITLE = 'devteam-main';
+const NAV_PANE_HEIGHT = 8;
 
 export class TmuxService {
   private aiToolService: AIToolService;
@@ -25,6 +29,10 @@ export class TmuxService {
   sessionName(project: string, feature: string): string {
     const name = `${SESSION_PREFIX}${project}-${feature}`;
     return this.sanitizeSessionName(name);
+  }
+
+  workspaceSessionName(sessionName: string): string {
+    return this.sanitizeSessionName(`${SESSION_PREFIX}workspace-${this.getBaseSessionName(sessionName).slice(SESSION_PREFIX.length)}`);
   }
 
   shellSessionName(project: string, feature: string): string {
@@ -110,16 +118,17 @@ export class TmuxService {
     executeCommand?: boolean;
   } = {}): void {
     const { addNewline = false, executeCommand = false } = options;
+    const target = this.getMainPaneTarget(session);
     
     if (executeCommand) {
       // Send as command and execute with Enter
-      runCommand(['tmux', 'send-keys', '-t', `${session}:0.0`, text, 'C-m'], { env: this.tmuxEnv });
+      runCommand(['tmux', 'send-keys', '-t', target, text, 'C-m'], { env: this.tmuxEnv });
     } else if (addNewline) {
       // Send text with newline character
-      runCommand(['tmux', 'send-keys', '-t', `${session}:0.0`, text + '\n'], { env: this.tmuxEnv });
+      runCommand(['tmux', 'send-keys', '-t', target, text + '\n'], { env: this.tmuxEnv });
     } else {
       // Send text as-is
-      runCommand(['tmux', 'send-keys', '-t', `${session}:0.0`, text], { env: this.tmuxEnv });
+      runCommand(['tmux', 'send-keys', '-t', target, text], { env: this.tmuxEnv });
     }
   }
 
@@ -134,18 +143,19 @@ export class TmuxService {
     endWithExecute?: boolean;
   } = {}): void {
     const { endWithAltEnter = false, endWithExecute = false } = options;
+    const target = this.getMainPaneTarget(session);
     
     lines.forEach((line) => {
       this.sendText(session, line);
       if (endWithAltEnter) {
         // Use Alt+Enter for multi-line input (like Claude input)
-        runCommand(['tmux', 'send-keys', '-t', `${session}:0.0`, 'Escape', 'Enter'], { env: this.tmuxEnv });
+        runCommand(['tmux', 'send-keys', '-t', target, 'Escape', 'Enter'], { env: this.tmuxEnv });
       }
     });
     
     if (endWithExecute) {
       // Final execute command
-      runCommand(['tmux', 'send-keys', '-t', `${session}:0.0`, 'C-m'], { env: this.tmuxEnv });
+      runCommand(['tmux', 'send-keys', '-t', target, 'C-m'], { env: this.tmuxEnv });
     }
   }
 
@@ -155,11 +165,78 @@ export class TmuxService {
    * @param keys Key combination (e.g., 'Escape', 'Enter', 'C-m')
    */
   sendSpecialKeys(session: string, ...keys: string[]): void {
-    runCommand(['tmux', 'send-keys', '-t', `${session}:0.0`, ...keys], { env: this.tmuxEnv });
+    runCommand(['tmux', 'send-keys', '-t', this.getMainPaneTarget(session), ...keys], { env: this.tmuxEnv });
   }
 
   attachSessionInteractive(sessionName: string): void {
     runInteractive('tmux', ['attach-session', '-t', sessionName]);
+  }
+
+  switchClient(sessionName: string): void {
+    runCommand(['tmux', 'switch-client', '-t', sessionName], { env: this.tmuxEnv });
+  }
+
+  selectMainPane(sessionName: string): void {
+    runCommand(['tmux', 'select-pane', '-t', this.getMainPaneTarget(sessionName)], { env: this.tmuxEnv });
+  }
+
+  focusNavigatorPane(sessionName: string): void {
+    const navPane = this.getSessionOptionValue(sessionName, '@devteam_nav_pane');
+    if (navPane) runCommand(['tmux', 'select-pane', '-t', navPane], { env: this.tmuxEnv });
+  }
+
+  prepareSessionNavigator(sessionName: string): void {
+    if (!this.hasSession(sessionName)) return;
+
+    const panes = this.listPaneDetailsSync(sessionName);
+    let navPane = panes.find((pane) => pane.title === NAV_PANE_TITLE);
+    let mainPane = panes.find((pane) => pane.title === MAIN_PANE_TITLE) || panes.find((pane) => pane.title !== NAV_PANE_TITLE) || panes[0];
+    if (!mainPane) return;
+
+    runCommand(['tmux', 'select-pane', '-t', mainPane.id, '-T', MAIN_PANE_TITLE], { env: this.tmuxEnv });
+
+    if (!navPane) {
+      const cwd = runCommandQuick(['tmux', 'display-message', '-p', '-t', mainPane.id, '#{pane_current_path}'], undefined, this.tmuxEnv) || getProjectsDirectory();
+      navPane = {
+        id: runCommandQuick([
+          'tmux',
+          'split-window',
+          '-bf',
+          '-t',
+          mainPane.id,
+          '-l',
+          String(NAV_PANE_HEIGHT),
+          '-c',
+          cwd,
+          '-P',
+          '-F',
+          '#{pane_id}',
+          this.getNavigatorCommand(sessionName),
+        ], undefined, this.tmuxEnv),
+        index: '0',
+        title: NAV_PANE_TITLE,
+        currentCommand: 'node',
+      };
+      if (navPane.id) {
+        runCommand(['tmux', 'select-pane', '-t', navPane.id, '-T', NAV_PANE_TITLE], { env: this.tmuxEnv });
+      }
+    } else {
+      runCommand(['tmux', 'respawn-pane', '-k', '-t', navPane.id, this.getNavigatorCommand(sessionName)], { env: this.tmuxEnv });
+      runCommand(['tmux', 'select-pane', '-t', navPane.id, '-T', NAV_PANE_TITLE], { env: this.tmuxEnv });
+    }
+
+    if (navPane?.id) {
+      runCommand(['tmux', 'resize-pane', '-t', navPane.id, '-y', String(NAV_PANE_HEIGHT)], { env: this.tmuxEnv });
+      this.setSessionOption(sessionName, '@devteam_nav_pane', navPane.id);
+    }
+    if (mainPane.id) {
+      this.setSessionOption(sessionName, '@devteam_main_pane', mainPane.id);
+    }
+
+    this.setSessionOption(sessionName, 'status', 'off');
+    this.setSessionOption(sessionName, 'pane-border-status', 'off');
+    this.setSessionOption(sessionName, 'mouse', 'on');
+    this.selectMainPane(sessionName);
   }
 
   configureSessionUI(session: string): void {
@@ -176,6 +253,7 @@ export class TmuxService {
       this.setSessionOption(session, 'status-justify', 'left');
       this.setSessionOption(session, 'status-left-length', '0');
       this.setSessionOption(session, 'status-right-length', '0');
+      this.setSessionOption(session, 'status', 'on');
       this.setSessionOption(session, 'status-left', '');
       this.setSessionOption(session, 'status-right', '');
       this.setSessionOption(session, 'status-interval', '5');
@@ -204,6 +282,7 @@ export class TmuxService {
         'tmux', 'set-option', '-t', session, 'status-format[0]',
         this.buildTopTabsFormat(session, families)
       ], { env: this.tmuxEnv });
+      runCommand(['tmux', 'set-option', '-u', '-t', session, 'status-format[1]'], { env: this.tmuxEnv });
       this.setSessionOption(session, 'pane-border-format', this.buildBottomTabsFormat(session, family));
     } catch (err) {
       // eslint-disable-next-line no-console
@@ -215,13 +294,7 @@ export class TmuxService {
    * Attach to a session with clickable status bar controls enabled.
    */
   attachSessionWithControls(sessionName: string): void {
-    const sessions = this.listManagedSessionsSync();
-    for (const session of sessions) {
-      this.configureSessionUI(session.name);
-    }
-    if (!sessions.some((session) => session.name === sessionName)) {
-      this.configureSessionUI(sessionName);
-    }
+    this.prepareSessionNavigator(sessionName);
     this.attachSessionInteractive(sessionName);
   }
 
@@ -250,7 +323,7 @@ export class TmuxService {
   // Private helper methods
   private async findAIPaneTarget(session: string): Promise<string | null> {
     const panes = await this.listPanes(session);
-    if (!panes) return `${session}:0.0`;
+    if (!panes) return this.getMainPaneTarget(session);
     
     const lines = panes.split('\n').filter(Boolean);
     
@@ -264,8 +337,9 @@ export class TmuxService {
     }
     
     // Fallback to first pane
-    const firstIdx = lines[0]?.split(' ')[0] || '0.0';
-    return `${session}:${firstIdx}`;
+    const firstIdx = lines[0]?.split(' ')[0];
+    if (firstIdx) return `${session}:${firstIdx}`;
+    return this.getMainPaneTarget(session);
   }
 
 
@@ -289,24 +363,24 @@ export class TmuxService {
       runCommand(['tmux', 'bind-key', '-n', key, ...args], { env: this.tmuxEnv });
     };
 
-    bind('MouseDown1Status', [
+    const statusBinding = [
       'run-shell',
       '-b',
       'range="#{mouse_status_range}"; ' +
         'role="#{@devteam_current_role}"; ' +
         'case "$range" in ' +
-        '$*) base="$(tmux display-message -p -t "$range" "#{session_name}")"; ' +
+        'dt:switch:*) base="${range#dt:switch:}"; ' +
             'target="$base"; ' +
             'if [ "$role" = "shell" ] && tmux has-session -t "=${base}-shell" 2>/dev/null; then target="${base}-shell"; fi; ' +
             'if [ "$role" = "run" ] && tmux has-session -t "=${base}-run" 2>/dev/null; then target="${base}-run"; fi; ' +
             'tmux switch-client -t "$target" ;; ' +
         'esac'
-    ]);
+    ];
 
-    bind('MouseDown1Border', [
+    const borderBinding = [
       'run-shell',
       '-b',
-      'word="#{mouse_word}"; ' +
+      'word="$(printf %s "#{mouse_word}" | tr "[:upper:]" "[:lower:]")"; ' +
         'case "$word" in ' +
         'agent) target="#{@devteam_agent_session}" ;; ' +
         'shell) target="#{@devteam_shell_session}" ;; ' +
@@ -318,7 +392,24 @@ export class TmuxService {
         'else ' +
           'tmux display-message "Open $word from devteam first"; ' +
         'fi'
-    ]);
+    ];
+
+    for (const key of [
+      'MouseDown1Status',
+      'MouseDown1StatusLeft',
+      'MouseDown1StatusRight',
+      'MouseDown1StatusDefault',
+      'MouseUp1Status',
+      'MouseUp1StatusLeft',
+      'MouseUp1StatusRight',
+      'MouseUp1StatusDefault',
+    ]) {
+      bind(key, statusBinding);
+    }
+
+    for (const key of ['MouseDown1Border', 'MouseUp1Border']) {
+      bind(key, borderBinding);
+    }
   }
 
   private listManagedSessionsSync(): TmuxManagedSession[] {
@@ -373,13 +464,12 @@ export class TmuxService {
       .sort((a, b) => b.lastAttached - a.lastAttached || a.displayName.localeCompare(b.displayName))
       .map((family) => {
         const active = family.base === currentBase;
-        const id = family.agent?.id || family.shell?.id || family.run?.id || '';
         const label = this.trimLabel(family.displayName, 28);
         const style = active
           ? '#[fg=colour235,bg=colour45,bold]'
           : '#[fg=colour252,bg=colour238]';
         const spacer = active ? '#[fg=colour45,bg=colour235]' : '#[fg=colour238,bg=colour235]';
-        return `#[range=user|${id}]${style} ${label} ${spacer} `;
+        return `#[range=user|dt:switch:${family.base}]${style} ${label} ${spacer} `;
       })
       .join('');
 
@@ -422,6 +512,42 @@ export class TmuxService {
     if (label.length <= maxLength) return label;
     return `${label.slice(0, Math.max(0, maxLength - 3))}...`;
   }
+
+  private getNavigatorCommand(sessionName: string): string {
+    const cliEntry = process.argv[1] || 'devteam';
+    return `${JSON.stringify(process.execPath)} ${JSON.stringify(cliEntry)} --dir ${JSON.stringify(getProjectsDirectory())} --tmux-nav --tmux-nav-session ${JSON.stringify(sessionName)}`;
+  }
+
+  private getMainPaneTarget(session: string): string {
+    const stored = this.getSessionOptionValue(session, '@devteam_main_pane');
+    if (stored) return stored;
+    const panes = this.listPaneDetailsSync(session);
+    const main = panes.find((pane) => pane.title === MAIN_PANE_TITLE) || panes.find((pane) => pane.title !== NAV_PANE_TITLE) || panes[0];
+    return main?.id || `${session}:0.0`;
+  }
+
+  private getSessionOptionValue(session: string, option: string): string {
+    return runCommandQuick(['tmux', 'show-options', '-v', '-t', session, option], undefined, this.tmuxEnv) || '';
+  }
+
+  private listPaneDetailsSync(session: string): TmuxPaneInfo[] {
+    const output = runCommandQuick([
+      'tmux',
+      'list-panes',
+      '-t',
+      `=${session}:0`,
+      '-F',
+      '#{pane_id}\t#{pane_index}\t#{pane_title}\t#{pane_current_command}'
+    ], undefined, this.tmuxEnv);
+    if (!output) return [];
+    return output
+      .split('\n')
+      .filter(Boolean)
+      .map((line) => {
+        const [id = '', index = '0', title = '', currentCommand = ''] = line.split('\t');
+        return {id, index, title, currentCommand};
+      });
+  }
 }
 
 type TmuxSessionRole = 'agent' | 'shell' | 'run';
@@ -441,4 +567,11 @@ type TmuxSessionFamily = {
   agent?: TmuxManagedSession;
   shell?: TmuxManagedSession;
   run?: TmuxManagedSession;
+};
+
+type TmuxPaneInfo = {
+  id: string;
+  index: string;
+  title: string;
+  currentCommand: string;
 };

--- a/src/services/TmuxService.ts
+++ b/src/services/TmuxService.ts
@@ -162,35 +162,49 @@ export class TmuxService {
     runInteractive('tmux', ['attach-session', '-t', sessionName]);
   }
 
-  /**
-   * Configure a tmux session with mouse support and a clickable status bar
-   * that exposes Detach and Kill actions.
-   * Uses tmux status-format ranges (tmux 3.2+) and MouseDown1Status binding.
-   */
   configureSessionUI(session: string): void {
     try {
-      // Ensure mouse is enabled and status is visible
+      const sessions = this.listManagedSessionsSync();
+      const families = this.buildSessionFamilies(sessions);
+      const family = families.get(this.getBaseSessionName(session));
+
+      this.bindMouseNavigation();
       this.setSessionOption(session, 'mouse', 'on');
-      // Ensure status bar is visible
       this.setSessionOption(session, 'status', 'on');
-      this.setSessionOption(session, 'status-position', 'bottom');
-      this.setSessionOption(session, 'status-style', 'fg=white,bold,bg=black');
+      this.setSessionOption(session, 'status-position', 'top');
+      this.setSessionOption(session, 'status-style', 'fg=colour252,bg=colour235');
+      this.setSessionOption(session, 'status-justify', 'left');
+      this.setSessionOption(session, 'status-left-length', '0');
+      this.setSessionOption(session, 'status-right-length', '0');
+      this.setSessionOption(session, 'status-left', '');
+      this.setSessionOption(session, 'status-right', '');
       this.setSessionOption(session, 'status-interval', '5');
+      this.setSessionOption(session, 'pane-border-status', 'bottom');
+      this.setSessionOption(session, 'pane-border-style', 'fg=colour238');
+      this.setSessionOption(session, 'pane-active-border-style', 'fg=colour39');
+
+      if (!family) {
+        runCommand([
+          'tmux', 'set-option', '-t', session, 'status-format[0]',
+          ' #[align=left] devteam #[align=right] Ctrl+b d to detach '
+        ], { env: this.tmuxEnv });
+        this.setSessionOption(session, 'pane-border-format', ' #[fg=colour245]agent shell run#[default] ');
+        return;
+      }
+
+      this.setSessionOption(session, '@devteam_base_session', family.base);
+      this.setSessionOption(session, '@devteam_agent_session', family.base);
+      this.setSessionOption(session, '@devteam_shell_session', family.shell?.name || `${family.base}-shell`);
+      this.setSessionOption(session, '@devteam_run_session', family.run?.name || `${family.base}-run`);
+      this.setSessionOption(session, '@devteam_current_role', this.getSessionRole(session));
+      this.setSessionOption(session, '@devteam_shell_available', family.shell ? '1' : '0');
+      this.setSessionOption(session, '@devteam_run_available', family.run ? '1' : '0');
+
       runCommand([
         'tmux', 'set-option', '-t', session, 'status-format[0]',
-        ' #[align=right]Click here to return to devteam (or press Ctrl+b, then d) '
+        this.buildTopTabsFormat(session, families)
       ], { env: this.tmuxEnv });
-
-      const bind = (key: string, args: string[]) => {
-        try { runCommand(['tmux', 'unbind-key', '-n', key], { env: this.tmuxEnv }); } catch {}
-        runCommand(['tmux', 'bind-key', '-n', key, ...args], { env: this.tmuxEnv });
-      };
-
-      // Bind MouseUp (release) on all status regions to detach immediately (no menu)
-      for (const k of ['MouseUp1Status', 'MouseUp1StatusLeft', 'MouseUp1StatusRight', 'MouseUp1StatusDefault']) {
-        bind(k, ['detach-client']);
-      }
-      // No debug messages bound
+      this.setSessionOption(session, 'pane-border-format', this.buildBottomTabsFormat(session, family));
     } catch (err) {
       // eslint-disable-next-line no-console
       console.error('Failed to configure tmux session UI:', err);
@@ -201,7 +215,13 @@ export class TmuxService {
    * Attach to a session with clickable status bar controls enabled.
    */
   attachSessionWithControls(sessionName: string): void {
-    this.configureSessionUI(sessionName);
+    const sessions = this.listManagedSessionsSync();
+    for (const session of sessions) {
+      this.configureSessionUI(session.name);
+    }
+    if (!sessions.some((session) => session.name === sessionName)) {
+      this.configureSessionUI(sessionName);
+    }
     this.attachSessionInteractive(sessionName);
   }
 
@@ -258,4 +278,167 @@ export class TmuxService {
     // Check if there's a matching worktree
     return validWorktrees.some((wt) => wt.includes(suffix));
   }
+
+  private bindMouseNavigation(): void {
+    const unbind = (key: string) => {
+      try { runCommand(['tmux', 'unbind-key', '-n', key], { env: this.tmuxEnv }); } catch {}
+    };
+
+    const bind = (key: string, args: string[]) => {
+      unbind(key);
+      runCommand(['tmux', 'bind-key', '-n', key, ...args], { env: this.tmuxEnv });
+    };
+
+    bind('MouseDown1Status', [
+      'run-shell',
+      '-b',
+      'range="#{mouse_status_range}"; ' +
+        'role="#{@devteam_current_role}"; ' +
+        'case "$range" in ' +
+        '$*) base="$(tmux display-message -p -t "$range" "#{session_name}")"; ' +
+            'target="$base"; ' +
+            'if [ "$role" = "shell" ] && tmux has-session -t "=${base}-shell" 2>/dev/null; then target="${base}-shell"; fi; ' +
+            'if [ "$role" = "run" ] && tmux has-session -t "=${base}-run" 2>/dev/null; then target="${base}-run"; fi; ' +
+            'tmux switch-client -t "$target" ;; ' +
+        'esac'
+    ]);
+
+    bind('MouseDown1Border', [
+      'run-shell',
+      '-b',
+      'word="#{mouse_word}"; ' +
+        'case "$word" in ' +
+        'agent) target="#{@devteam_agent_session}" ;; ' +
+        'shell) target="#{@devteam_shell_session}" ;; ' +
+        'run) target="#{@devteam_run_session}" ;; ' +
+        '*) exit 0 ;; ' +
+        'esac; ' +
+        'if tmux has-session -t "=$target" 2>/dev/null; then ' +
+          'tmux switch-client -t "$target"; ' +
+        'else ' +
+          'tmux display-message "Open $word from devteam first"; ' +
+        'fi'
+    ]);
+  }
+
+  private listManagedSessionsSync(): TmuxManagedSession[] {
+    const output = runCommandQuick([
+      'tmux',
+      'list-sessions',
+      '-F',
+      '#{session_id}\t#{session_name}\t#{session_last_attached}'
+    ], undefined, this.tmuxEnv);
+
+    if (!output) return [];
+
+    return output
+      .split('\n')
+      .filter(Boolean)
+      .map((line) => {
+        const [id = '', name = '', lastAttached = '0'] = line.split('\t');
+        return {
+          id,
+          name,
+          lastAttached: Number(lastAttached) || 0,
+          role: this.getSessionRole(name),
+          base: this.getBaseSessionName(name),
+        };
+      })
+      .filter((session) => session.name.startsWith(SESSION_PREFIX));
+  }
+
+  private buildSessionFamilies(sessions: TmuxManagedSession[]): Map<string, TmuxSessionFamily> {
+    const families = new Map<string, TmuxSessionFamily>();
+
+    for (const session of sessions) {
+      const current = families.get(session.base) || {
+        base: session.base,
+        displayName: session.base.startsWith(SESSION_PREFIX) ? session.base.slice(SESSION_PREFIX.length) : session.base,
+        lastAttached: 0,
+      };
+
+      current.lastAttached = Math.max(current.lastAttached, session.lastAttached);
+      if (session.role === 'agent') current.agent = session;
+      if (session.role === 'shell') current.shell = session;
+      if (session.role === 'run') current.run = session;
+      families.set(session.base, current);
+    }
+
+    return families;
+  }
+
+  private buildTopTabsFormat(currentSession: string, families: Map<string, TmuxSessionFamily>): string {
+    const currentBase = this.getBaseSessionName(currentSession);
+    const tabs = Array.from(families.values())
+      .sort((a, b) => b.lastAttached - a.lastAttached || a.displayName.localeCompare(b.displayName))
+      .map((family) => {
+        const active = family.base === currentBase;
+        const id = family.agent?.id || family.shell?.id || family.run?.id || '';
+        const label = this.trimLabel(family.displayName, 28);
+        const style = active
+          ? '#[fg=colour235,bg=colour45,bold]'
+          : '#[fg=colour252,bg=colour238]';
+        const spacer = active ? '#[fg=colour45,bg=colour235]' : '#[fg=colour238,bg=colour235]';
+        return `#[range=user|${id}]${style} ${label} ${spacer} `;
+      })
+      .join('');
+
+    return `${tabs}#[default]#[align=right]#[fg=colour245,bg=colour235] click worktrees | Ctrl+b d detach `;
+  }
+
+  private buildBottomTabsFormat(currentSession: string, family: TmuxSessionFamily): string {
+    const currentRole = this.getSessionRole(currentSession);
+    const render = (label: 'agent' | 'shell' | 'run', available: boolean): string => {
+      const active = currentRole === label;
+      const style = active
+        ? '#[fg=colour235,bg=colour148,bold]'
+        : available
+          ? '#[fg=colour252,bg=colour239]'
+          : '#[fg=colour244,bg=colour237]';
+      return `${style} ${label} #[default]`;
+    };
+
+    return [
+      render('agent', true),
+      render('shell', !!family.shell),
+      render('run', !!family.run),
+      '#[fg=colour244] click mode tabs #[default]'
+    ].join('');
+  }
+
+  private getSessionRole(sessionName: string): TmuxSessionRole {
+    if (sessionName.endsWith('-shell')) return 'shell';
+    if (sessionName.endsWith('-run')) return 'run';
+    return 'agent';
+  }
+
+  private getBaseSessionName(sessionName: string): string {
+    if (sessionName.endsWith('-shell')) return sessionName.slice(0, -6);
+    if (sessionName.endsWith('-run')) return sessionName.slice(0, -4);
+    return sessionName;
+  }
+
+  private trimLabel(label: string, maxLength: number): string {
+    if (label.length <= maxLength) return label;
+    return `${label.slice(0, Math.max(0, maxLength - 3))}...`;
+  }
 }
+
+type TmuxSessionRole = 'agent' | 'shell' | 'run';
+
+type TmuxManagedSession = {
+  id: string;
+  name: string;
+  lastAttached: number;
+  role: TmuxSessionRole;
+  base: string;
+};
+
+type TmuxSessionFamily = {
+  base: string;
+  displayName: string;
+  lastAttached: number;
+  agent?: TmuxManagedSession;
+  shell?: TmuxManagedSession;
+  run?: TmuxManagedSession;
+};

--- a/src/shared/utils/tmuxNav.ts
+++ b/src/shared/utils/tmuxNav.ts
@@ -1,0 +1,29 @@
+import type {TmuxService} from '../../services/TmuxService.js';
+
+export type NavMode = 'agent' | 'shell' | 'run';
+
+export function sessionMode(sessionName: string): NavMode {
+  if (sessionName.endsWith('-shell')) return 'shell';
+  if (sessionName.endsWith('-run')) return 'run';
+  return 'agent';
+}
+
+export function baseSessionName(sessionName: string): string {
+  if (sessionName.endsWith('-shell')) return sessionName.slice(0, -6);
+  if (sessionName.endsWith('-run')) return sessionName.slice(0, -4);
+  return sessionName;
+}
+
+export function modeSessionName(tmux: TmuxService, project: string, feature: string, mode: NavMode): string {
+  if (mode === 'shell') return tmux.shellSessionName(project, feature);
+  if (mode === 'run') return tmux.runSessionName(project, feature);
+  return tmux.sessionName(project, feature);
+}
+
+export function modeLabel(mode: NavMode): string {
+  if (mode === 'agent') return 'A';
+  if (mode === 'shell') return 'S';
+  return 'R';
+}
+
+export const modeOrder: NavMode[] = ['agent', 'shell', 'run'];

--- a/tests/fakes/FakeTmuxService.ts
+++ b/tests/fakes/FakeTmuxService.ts
@@ -7,6 +7,8 @@ import {memoryStore} from './stores.js';
 export class FakeTmuxService extends TmuxService {
   private sentKeys: Array<{session: string, keys: string[]}> = [];
   private sessions = new Map<string, SessionInfo>();
+  private sessionOptions = new Map<string, Map<string, string>>();
+  private globalOptions = new Map<string, string>();
 
   constructor() {
     super(new FakeAIToolService());
@@ -183,12 +185,19 @@ export class FakeTmuxService extends TmuxService {
     }
   }
 
+  attachSessionWithControls(sessionName: string): void {
+    this.configureSessionUI(sessionName);
+    this.attachSessionInteractive(sessionName);
+  }
+
   setOption(option: string, value: string): void {
-    // Mock implementation - just store for testing if needed
+    this.globalOptions.set(option, value);
   }
 
   setSessionOption(session: string, option: string, value: string): void {
-    // Mock implementation - just store for testing if needed
+    const current = this.sessionOptions.get(session) || new Map<string, string>();
+    current.set(option, value);
+    this.sessionOptions.set(session, current);
   }
 
   async listPanes(session: string): Promise<string> {
@@ -298,6 +307,14 @@ export class FakeTmuxService extends TmuxService {
   // Clear sent keys history
   clearSentKeys(): void {
     this.sentKeys = [];
+  }
+
+  getSessionOption(session: string, option: string): string | undefined {
+    return this.sessionOptions.get(session)?.get(option);
+  }
+
+  getGlobalOption(option: string): string | undefined {
+    return this.globalOptions.get(option);
   }
   
   // Helper method to determine if a session should be preserved

--- a/tests/fakes/FakeTmuxService.ts
+++ b/tests/fakes/FakeTmuxService.ts
@@ -9,6 +9,7 @@ export class FakeTmuxService extends TmuxService {
   private sessions = new Map<string, SessionInfo>();
   private sessionOptions = new Map<string, Map<string, string>>();
   private globalOptions = new Map<string, string>();
+  private paneState = new Map<string, {navPane: string; mainPane: string}>();
 
   constructor() {
     super(new FakeAIToolService());
@@ -186,8 +187,32 @@ export class FakeTmuxService extends TmuxService {
   }
 
   attachSessionWithControls(sessionName: string): void {
-    this.configureSessionUI(sessionName);
+    this.prepareSessionNavigator(sessionName);
     this.attachSessionInteractive(sessionName);
+  }
+
+  prepareSessionNavigator(sessionName: string): void {
+    const panes = this.paneState.get(sessionName) || {
+      navPane: `%${sessionName}-nav`,
+      mainPane: `%${sessionName}-main`,
+    };
+    this.paneState.set(sessionName, panes);
+    this.setSessionOption(sessionName, '@devteam_nav_pane', panes.navPane);
+    this.setSessionOption(sessionName, '@devteam_main_pane', panes.mainPane);
+    this.setSessionOption(sessionName, 'status', 'off');
+    this.setSessionOption(sessionName, 'pane-border-status', 'off');
+    this.setSessionOption(sessionName, 'mouse', 'on');
+  }
+
+  switchClient(sessionName: string): void {
+    this.attachSessionInteractive(sessionName);
+  }
+
+  selectMainPane(sessionName: string): void {
+    const panes = this.paneState.get(sessionName);
+    if (panes) {
+      this.recordSentKeys(sessionName, ['select-pane', panes.mainPane]);
+    }
   }
 
   setOption(option: string, value: string): void {

--- a/tests/unit/TmuxNavigatorApp.test.ts
+++ b/tests/unit/TmuxNavigatorApp.test.ts
@@ -18,6 +18,12 @@ describe('TmuxNavigatorApp layout helpers', () => {
     expect(layout.pageStart).toBe(0);
   });
 
+  test('reduces column count when multiple tiles would overflow the pane', () => {
+    expect(computeLayout(48, 11, 12, 0).tileColumns).toBe(1);
+    expect(computeLayout(49, 11, 12, 0).tileColumns).toBe(2);
+    expect(computeLayout(74, 11, 12, 0).tileColumns).toBe(3);
+  });
+
   test('maps tile clicks across three-line tile rows', () => {
     const layout = computeLayout(120, 11, 12, 0);
     expect(tileHitTarget(2, 1, layout)).toBe(0);

--- a/tests/unit/TmuxNavigatorApp.test.ts
+++ b/tests/unit/TmuxNavigatorApp.test.ts
@@ -1,0 +1,49 @@
+import {describe, expect, test} from '@jest/globals';
+import {bottomActionHit, compactModeState, computeLayout, modeStatusSummary, renderActionLabel, tileHitTarget} from '../../src/TmuxNavigatorApp.js';
+
+describe('TmuxNavigatorApp layout helpers', () => {
+  const item = {
+    sessions: {
+      agent: {exists: true, usable: true},
+      shell: {exists: true, usable: false},
+      run: {exists: false, usable: false},
+    },
+  } as any;
+
+  test('uses up to six visible tiles with three-line rows', () => {
+    const layout = computeLayout(120, 11, 12, 5);
+    expect(layout.tileColumns).toBe(3);
+    expect(layout.tileRows).toBe(2);
+    expect(layout.visibleCount).toBe(6);
+    expect(layout.pageStart).toBe(0);
+  });
+
+  test('maps tile clicks across three-line tile rows', () => {
+    const layout = computeLayout(120, 11, 12, 0);
+    expect(tileHitTarget(2, 1, layout)).toBe(0);
+    expect(tileHitTarget(layout.tileWidth + 2, 2, layout)).toBe(1);
+    expect(tileHitTarget(2, 4, layout)).toBe(3);
+    expect(tileHitTarget(2, 8, layout)).toBeNull();
+  });
+
+  test('maps bottom action clicks using rendered label widths', () => {
+    const layout = computeLayout(120, 11, 12, 0);
+    const actionY = layout.tileRows * 3 + 2;
+    const agentLabel = renderActionLabel('agent', item.sessions.agent, true);
+    const shellLabel = renderActionLabel('shell', item.sessions.shell, false);
+    const runLabel = renderActionLabel('run', item.sessions.run, false);
+    const closeX = agentLabel.length + shellLabel.length + runLabel.length + 4;
+    const backX = closeX + ' Close '.length + 1;
+
+    expect(bottomActionHit(2, actionY, 120, layout, item, 'agent')).toBe('agent');
+    expect(bottomActionHit(closeX, actionY, 120, layout, item, 'agent')).toBe('close');
+    expect(bottomActionHit(backX, actionY, 120, layout, item, 'agent')).toBe('back');
+  });
+
+  test('summarizes inline mode state compactly', () => {
+    expect(compactModeState('agent', item.sessions.agent)).toBe('A');
+    expect(compactModeState('shell', item.sessions.shell)).toBe('!');
+    expect(compactModeState('run', item.sessions.run)).toBe('-');
+    expect(modeStatusSummary(item)).toBe('AA S! R-');
+  });
+});

--- a/tests/unit/TmuxServiceTabs.test.ts
+++ b/tests/unit/TmuxServiceTabs.test.ts
@@ -1,0 +1,40 @@
+import {describe, test, expect} from '@jest/globals';
+import {TmuxService} from '../../src/services/TmuxService.js';
+
+describe('TmuxService tab formatting', () => {
+  test('builds top worktree tabs in most-recent-first order', () => {
+    const tmux = new TmuxService();
+    const families = (tmux as any).buildSessionFamilies([
+      {id: '$1', name: 'dev-alpha-one', lastAttached: 10, role: 'agent', base: 'dev-alpha-one'},
+      {id: '$2', name: 'dev-bravo-two', lastAttached: 25, role: 'agent', base: 'dev-bravo-two'},
+      {id: '$3', name: 'dev-alpha-one-shell', lastAttached: 30, role: 'shell', base: 'dev-alpha-one'},
+    ]);
+
+    const format = (tmux as any).buildTopTabsFormat('dev-alpha-one-shell', families);
+
+    expect(format.indexOf('alpha-one')).toBeLessThan(format.indexOf('bravo-two'));
+    expect(format).toContain('#[range=user|$1]');
+    expect(format).toContain('#[range=user|$2]');
+    expect(format).toContain('click worktrees');
+  });
+
+  test('builds bottom mode tabs with active and unavailable states', () => {
+    const tmux = new TmuxService();
+    const family = {
+      base: 'dev-sample-feature',
+      displayName: 'sample-feature',
+      lastAttached: 12,
+      agent: {id: '$4', name: 'dev-sample-feature', lastAttached: 12, role: 'agent', base: 'dev-sample-feature'},
+      shell: {id: '$5', name: 'dev-sample-feature-shell', lastAttached: 9, role: 'shell', base: 'dev-sample-feature'},
+    };
+
+    const format = (tmux as any).buildBottomTabsFormat('dev-sample-feature-shell', family);
+
+    expect(format).toContain(' agent ');
+    expect(format).toContain(' shell ');
+    expect(format).toContain(' run ');
+    expect(format).toContain('click mode tabs');
+    expect(format).toContain('colour148');
+    expect(format).toContain('colour237');
+  });
+});

--- a/tests/unit/TmuxServiceTabs.test.ts
+++ b/tests/unit/TmuxServiceTabs.test.ts
@@ -13,8 +13,8 @@ describe('TmuxService tab formatting', () => {
     const format = (tmux as any).buildTopTabsFormat('dev-alpha-one-shell', families);
 
     expect(format.indexOf('alpha-one')).toBeLessThan(format.indexOf('bravo-two'));
-    expect(format).toContain('#[range=user|$1]');
-    expect(format).toContain('#[range=user|$2]');
+    expect(format).toContain('#[range=user|dt:switch:dev-alpha-one]');
+    expect(format).toContain('#[range=user|dt:switch:dev-bravo-two]');
     expect(format).toContain('click worktrees');
   });
 

--- a/tests/unit/tmuxNav.test.ts
+++ b/tests/unit/tmuxNav.test.ts
@@ -1,0 +1,23 @@
+import {describe, test, expect} from '@jest/globals';
+import {baseSessionName, modeLabel, modeSessionName, sessionMode} from '../../src/shared/utils/tmuxNav.js';
+import {FakeTmuxService} from '../fakes/FakeTmuxService.js';
+
+describe('tmux nav helpers', () => {
+  test('parses session mode and base session correctly', () => {
+    expect(sessionMode('dev-proj-feat')).toBe('agent');
+    expect(sessionMode('dev-proj-feat-shell')).toBe('shell');
+    expect(sessionMode('dev-proj-feat-run')).toBe('run');
+    expect(baseSessionName('dev-proj-feat-shell')).toBe('dev-proj-feat');
+    expect(baseSessionName('dev-proj-feat-run')).toBe('dev-proj-feat');
+  });
+
+  test('builds mode session names and labels', () => {
+    const tmux = new FakeTmuxService();
+    expect(modeSessionName(tmux as any, 'proj', 'feat', 'agent')).toBe('dev-proj-feat');
+    expect(modeSessionName(tmux as any, 'proj', 'feat', 'shell')).toBe('dev-proj-feat-shell');
+    expect(modeSessionName(tmux as any, 'proj', 'feat', 'run')).toBe('dev-proj-feat-run');
+    expect(modeLabel('agent')).toBe('A');
+    expect(modeLabel('shell')).toBe('S');
+    expect(modeLabel('run')).toBe('R');
+  });
+});


### PR DESCRIPTION
## Summary
- add a tmux top status bar that lists worktree sessions in most-recent-first order
- add a bottom pane-border mode strip for `agent`, `shell`, and `run`
- enable mouse-driven switching between worktrees and available mode sessions
- add unit coverage for the tab format generation and update the fake tmux service for the new UI state

## Verification
- `npm run typecheck`
- `npm run build`
- `npm test -- --runInBand`
- `npm run test:terminal`