### PR TITLE
[codex] move session marker into cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -145,3 +145,6 @@ vite.config.ts.timestamp-*
 
 # Devteam local cache
 .devteam
+
+# Legacy local session marker
+.devteam-session

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,9 +1,11 @@
 import {run} from './bootstrap.js';
 import {initializeMemoryLogging, logError, dumpLogsToConsole} from './shared/utils/logger.js';
 import {commandExists} from './shared/utils/commandExecutor.js';
+import {writeCurrentSessionMarker} from './shared/utils/sessionMarker.js';
 
 // Initialize memory logging before running the app
 initializeMemoryLogging();
+writeCurrentSessionMarker();
 
 // Proactive check for tmux availability with macOS guidance
 try {
@@ -46,4 +48,3 @@ run().catch((err) => {
   handleExit();
   process.exit(1);
 });
-

--- a/src/shared/utils/sessionMarker.ts
+++ b/src/shared/utils/sessionMarker.ts
@@ -1,0 +1,84 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import crypto from 'node:crypto';
+import {DIR_BRANCHES_SUFFIX, SESSION_PREFIX} from '../../constants.js';
+import {ensureDirectory} from './fileSystem.js';
+import {logError} from './logger.js';
+
+type SessionMarkerKind = 'worktree' | 'workspace';
+
+type SessionMarkerPayload = {
+  v: 1;
+  session: string;
+  project: string;
+  feature: string;
+  kind: SessionMarkerKind;
+};
+
+function baseDir(): string {
+  return process.env.DEVTEAM_SESSION_MARKER_DIR
+    || path.join(os.homedir(), '.cache', 'devteam', 'session-markers');
+}
+
+function legacyPath(cwd: string): string {
+  return path.join(cwd, '.devteam-session');
+}
+
+function fileFor(cwd: string): string {
+  const key = crypto.createHash('sha1').update(path.resolve(cwd)).digest('hex');
+  return path.join(baseDir(), `${key}.json`);
+}
+
+function derivePayload(cwd: string): SessionMarkerPayload | null {
+  const resolved = path.resolve(cwd);
+  const feature = path.basename(resolved);
+  const parent = path.basename(path.dirname(resolved));
+
+  if (parent === 'workspaces') {
+    return {
+      v: 1,
+      session: `${SESSION_PREFIX}workspace-${feature}`,
+      project: 'workspace',
+      feature,
+      kind: 'workspace',
+    };
+  }
+
+  if (parent.endsWith(DIR_BRANCHES_SUFFIX)) {
+    const project = parent.slice(0, -DIR_BRANCHES_SUFFIX.length);
+    return {
+      v: 1,
+      session: `${SESSION_PREFIX}${project}-${feature}`,
+      project,
+      feature,
+      kind: 'worktree',
+    };
+  }
+
+  return null;
+}
+
+export function getSessionMarkerPath(cwd: string): string {
+  return fileFor(cwd);
+}
+
+export function writeCurrentSessionMarker(cwd: string = process.cwd()): void {
+  const payload = derivePayload(cwd);
+  if (!payload) return;
+
+  try {
+    ensureDirectory(baseDir());
+    fs.writeFileSync(fileFor(cwd), JSON.stringify(payload, null, 2), 'utf8');
+  } catch (err) {
+    logError('sessionMarker.writeCurrentSessionMarker failed', {
+      error: err instanceof Error ? err.message : String(err),
+      cwd,
+    });
+    return;
+  }
+
+  try {
+    fs.rmSync(legacyPath(cwd), {force: true});
+  } catch {}
+}

--- a/tests/setup.e2e.ts
+++ b/tests/setup.e2e.ts
@@ -8,6 +8,8 @@ import fs from 'node:fs';
 // Keep per-worktree AI-session memory out of the user's real cache during tests.
 const aiSessionTmp = fs.mkdtempSync(path.join(os.tmpdir(), 'devteam-ai-sessions-'));
 process.env.DEVTEAM_AI_SESSION_DIR = aiSessionTmp;
+const sessionMarkerTmp = fs.mkdtempSync(path.join(os.tmpdir(), 'devteam-session-markers-'));
+process.env.DEVTEAM_SESSION_MARKER_DIR = sessionMarkerTmp;
 
 // Stub process.exit so App's exit paths don't terminate the test process
 const mockExit = jest.fn();

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -7,6 +7,8 @@ import fs from 'node:fs';
 // Using mkdtempSync gives each test process its own isolated dir.
 const aiSessionTmp = fs.mkdtempSync(path.join(os.tmpdir(), 'devteam-ai-sessions-'));
 process.env.DEVTEAM_AI_SESSION_DIR = aiSessionTmp;
+const sessionMarkerTmp = fs.mkdtempSync(path.join(os.tmpdir(), 'devteam-session-markers-'));
+process.env.DEVTEAM_SESSION_MARKER_DIR = sessionMarkerTmp;
 
 // Enable fake timers for all tests to speed up delays
 jest.useFakeTimers();

--- a/tests/unit/sessionMarker.test.ts
+++ b/tests/unit/sessionMarker.test.ts
@@ -1,0 +1,65 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {getSessionMarkerPath, writeCurrentSessionMarker} from '../../src/shared/utils/sessionMarker.js';
+
+describe('sessionMarker', () => {
+  let originalEnv: string | undefined;
+  let tmpDir: string;
+
+  beforeEach(() => {
+    originalEnv = process.env.DEVTEAM_SESSION_MARKER_DIR;
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'devteam-session-marker-'));
+    process.env.DEVTEAM_SESSION_MARKER_DIR = tmpDir;
+  });
+
+  afterEach(() => {
+    process.env.DEVTEAM_SESSION_MARKER_DIR = originalEnv;
+    fs.rmSync(tmpDir, {recursive: true, force: true});
+  });
+
+  test('writes worktree marker into cache and removes legacy file', () => {
+    const cwd = '/tmp/projects/devteam-branches/session-marker';
+    const legacyPath = path.join(cwd, '.devteam-session');
+    fs.mkdirSync(cwd, {recursive: true});
+    fs.writeFileSync(legacyPath, 'legacy', 'utf8');
+
+    writeCurrentSessionMarker(cwd);
+
+    const markerPath = getSessionMarkerPath(cwd);
+    const marker = JSON.parse(fs.readFileSync(markerPath, 'utf8'));
+    expect(marker).toEqual({
+      v: 1,
+      session: 'dev-devteam-session-marker',
+      project: 'devteam',
+      feature: 'session-marker',
+      kind: 'worktree',
+    });
+    expect(fs.existsSync(legacyPath)).toBe(false);
+  });
+
+  test('writes workspace marker into cache', () => {
+    const cwd = '/tmp/projects/workspaces/feature-a';
+    fs.mkdirSync(cwd, {recursive: true});
+
+    writeCurrentSessionMarker(cwd);
+
+    const marker = JSON.parse(fs.readFileSync(getSessionMarkerPath(cwd), 'utf8'));
+    expect(marker).toEqual({
+      v: 1,
+      session: 'dev-workspace-feature-a',
+      project: 'workspace',
+      feature: 'feature-a',
+      kind: 'workspace',
+    });
+  });
+
+  test('does nothing for paths that are not worktrees or workspaces', () => {
+    const cwd = '/tmp/projects/devteam';
+    fs.mkdirSync(cwd, {recursive: true});
+
+    writeCurrentSessionMarker(cwd);
+
+    expect(fs.existsSync(getSessionMarkerPath(cwd))).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Move the runtime session marker out of the worktree root and into a cache-backed location under `~/.cache/devteam/session-markers`.

## What Changed

- add a dedicated `sessionMarker` utility that derives worktree/workspace marker payloads and writes them into the cache directory
- call that utility during CLI startup so the current session marker is refreshed when `devteam` launches
- best-effort remove any legacy `.devteam-session` file from the current worktree/workspace root after writing the cache-backed marker
- isolate marker writes in tests with `DEVTEAM_SESSION_MARKER_DIR`
- add unit coverage for worktree markers, workspace markers, and non-marker paths
- ignore legacy `.devteam-session` files at the repo level to avoid accidental noise in working trees

## Why

The root cause was that session metadata could appear as a repo-local `.devteam-session` file, which is the wrong lifecycle for ephemeral runtime state and creates untracked-file noise in worktrees. This change moves that state into the existing cache-style storage model the app already uses elsewhere.

## Validation

- `npm run build`
- `npm test`
- `npm run typecheck`
