### PR TITLE
[codex] Fix Claude continue fallback

### DIFF
--- a/src/cores/WorktreeCore.ts
+++ b/src/cores/WorktreeCore.ts
@@ -260,7 +260,8 @@ export class WorktreeCore implements CoreBase<State> {
         selected = this.availableAITools[0];
       }
       if (selected !== 'none') {
-        this.tmux.createSessionWithCommand(sessionName, worktree.path, aiLaunchCommand(selected), true);
+        if (selected === 'claude') await this.launchClaudeSessionWithFallback(sessionName, worktree.path);
+        else this.tmux.createSessionWithCommand(sessionName, worktree.path, aiLaunchCommand(selected), true);
         setLastTool(selected, worktree.path);
       } else {
         this.tmux.createSession(sessionName, worktree.path, true);
@@ -368,6 +369,25 @@ export class WorktreeCore implements CoreBase<State> {
     const rn = this.tmux.runSessionName(projectName, featureName);
     const active = await this.tmux.listSessions();
     for (const name of [s, sh, rn]) { if (active.includes(name)) this.tmux.killSession(name); }
+  }
+
+  private async launchClaudeSessionWithFallback(sessionName: string, cwd: string): Promise<void> {
+    this.tmux.createSession(sessionName, cwd, true);
+    this.tmux.sendText(sessionName, aiLaunchCommand('claude'), {executeCommand: true});
+    const started = await this.waitForAIToolStart(sessionName, 'claude');
+    if (!started) {
+      logDebug('Claude resume did not start; retrying with a fresh session', {sessionName, cwd});
+      this.tmux.sendText(sessionName, 'claude', {executeCommand: true});
+    }
+  }
+
+  private async waitForAIToolStart(sessionName: string, tool: AITool, attempts: number = 3, waitMs: number = 150): Promise<boolean> {
+    for (let attempt = 0; attempt < attempts; attempt++) {
+      const status = await this.tmux.getAIStatus(sessionName);
+      if (status.tool === tool) return true;
+      if (attempt < attempts - 1) await new Promise(resolve => setTimeout(resolve, waitMs));
+    }
+    return false;
   }
 
   private setState(partial: Partial<State>): void {

--- a/tests/fakes/FakeTmuxService.ts
+++ b/tests/fakes/FakeTmuxService.ts
@@ -7,6 +7,7 @@ import {memoryStore} from './stores.js';
 export class FakeTmuxService extends TmuxService {
   private sentKeys: Array<{session: string, keys: string[]}> = [];
   private sessions = new Map<string, SessionInfo>();
+  private failClaudeContinueSessions = new Set<string>();
 
   constructor() {
     super(new FakeAIToolService());
@@ -145,6 +146,7 @@ export class FakeTmuxService extends TmuxService {
     const { addNewline = false, executeCommand = false } = options;
     
     if (executeCommand) {
+      this.applyCommandEffect(session, text);
       this.recordSentKeys(session, [text, 'C-m']);
     } else if (addNewline) {
       this.recordSentKeys(session, [text + '\n']);
@@ -257,6 +259,10 @@ export class FakeTmuxService extends TmuxService {
 
 
   // Helper methods for testing AI tools
+  failNextClaudeContinue(session: string): void {
+    this.failClaudeContinueSessions.add(session);
+  }
+
   setAITool(session: string, tool: AITool): void {
     const sessionInfo = this.sessions.get(session) || memoryStore.sessions.get(session);
     if (sessionInfo) {
@@ -298,6 +304,37 @@ export class FakeTmuxService extends TmuxService {
   // Clear sent keys history
   clearSentKeys(): void {
     this.sentKeys = [];
+  }
+
+  private applyCommandEffect(session: string, text: string): void {
+    const sessionInfo = this.sessions.get(session) || memoryStore.sessions.get(session);
+    if (!sessionInfo) return;
+    const command = text.trim();
+
+    if (command === 'claude --continue') {
+      if (this.failClaudeContinueSessions.delete(session)) {
+        sessionInfo.ai_tool = 'none';
+        sessionInfo.ai_status = 'active';
+        sessionInfo.claude_status = 'active';
+      } else {
+        sessionInfo.ai_tool = 'claude';
+        sessionInfo.ai_status = 'idle';
+        sessionInfo.claude_status = 'idle';
+      }
+    } else if (command === 'claude') {
+      sessionInfo.ai_tool = 'claude';
+      sessionInfo.ai_status = 'idle';
+      sessionInfo.claude_status = 'idle';
+    } else if (command.includes('codex')) {
+      sessionInfo.ai_tool = 'codex';
+      sessionInfo.ai_status = 'idle';
+    } else if (command.includes('gemini')) {
+      sessionInfo.ai_tool = 'gemini';
+      sessionInfo.ai_status = 'idle';
+    }
+
+    this.sessions.set(session, sessionInfo);
+    try { memoryStore.sessions.set(session, sessionInfo); } catch {}
   }
   
   // Helper method to determine if a session should be preserved

--- a/tests/unit/WorktreeCoreAutoResume.test.ts
+++ b/tests/unit/WorktreeCoreAutoResume.test.ts
@@ -24,6 +24,12 @@ function worktreeFor(project: string, feature: string): WorktreeInfo {
   return wt;
 }
 
+function getExecutedCommands(tmux: FakeTmuxService, sessionName: string): string[] {
+  return tmux.getSentKeys(sessionName)
+    .filter(keys => (keys[0] === 'command' && typeof keys[1] === 'string') || keys[keys.length - 1] === 'C-m')
+    .map(keys => keys[0] === 'command' ? keys[1] : keys[0]);
+}
+
 describe('WorktreeCore auto-resume', () => {
   let tmpDir: string;
   let originalEnv: string | undefined;
@@ -47,9 +53,20 @@ describe('WorktreeCore auto-resume', () => {
     await core.attachSession(wt, 'claude');
 
     const sessionName = tmux.sessionName('proj', 'feat');
-    const commandEntries = tmux.getSentKeys(sessionName).filter(k => k[0] === 'command');
-    expect(commandEntries.map(k => k[1])).toEqual(['claude --continue']);
+    expect(getExecutedCommands(tmux, sessionName)).toEqual(['claude --continue']);
     expect(getLastTool(wt.path)).toBe('claude');
+  });
+
+  test('attachSession falls back to plain claude when resume does not start a session', async () => {
+    const {core, tmux} = buildCore();
+    const wt = worktreeFor('proj', 'feat');
+    const sessionName = tmux.sessionName('proj', 'feat');
+    tmux.failNextClaudeContinue(sessionName);
+
+    await core.attachSession(wt, 'claude');
+
+    expect(getExecutedCommands(tmux, sessionName)).toEqual(['claude --continue', 'claude']);
+    expect(tmux.getSessionInfo(sessionName)?.ai_tool).toBe('claude');
   });
 
   test('attachSession uses remembered tool when no explicit choice', async () => {
@@ -60,8 +77,7 @@ describe('WorktreeCore auto-resume', () => {
     await core.attachSession(wt);
 
     const sessionName = tmux.sessionName('proj', 'feat');
-    const commandEntries = tmux.getSentKeys(sessionName).filter(k => k[0] === 'command');
-    expect(commandEntries.map(k => k[1])).toEqual(['codex resume --last']);
+    expect(getExecutedCommands(tmux, sessionName)).toEqual(['codex resume --last']);
   });
 
   test('attachSession with existing tmux session does not re-spawn the tool', async () => {


### PR DESCRIPTION
## Summary
Fix Claude session startup when `claude --continue` has nothing to resume.

## What Changed
- start Claude sessions inside a persistent shell-backed tmux session
- retry with plain `claude` if `claude --continue` does not actually start Claude
- add a regression test covering the no-previous-session fallback path
- update the fake tmux service to simulate Claude resume failure in tests

## Why
When a worktree had no prior Claude session, launching tmux directly with `claude --continue` could exit immediately. That left the attach flow without a usable session instead of falling back to a fresh Claude instance.

## Impact
Attaching to a worktree like `fix-continue` now recovers automatically: devteam first attempts resume, and if Claude is not running shortly after launch, it retries with a fresh `claude` session.

## Validation
- `npm test -- --runInBand tests/unit/WorktreeCoreAutoResume.test.ts`
- `npm test`
- `npm run typecheck`
- `npm run build`
