### PR TITLE
[codex] Improve tmux session status bar

### DIFF
--- a/src/cores/WorktreeCore.ts
+++ b/src/cores/WorktreeCore.ts
@@ -244,25 +244,23 @@ export class WorktreeCore implements CoreBase<State> {
   async attachSession(worktree: WorktreeInfo, aiTool?: AITool): Promise<void> {
     const sessionName = this.tmux.sessionName(worktree.project, worktree.feature);
     const sessions = await this.tmux.listSessions();
+    const sessionTool = worktree.session?.ai_tool as AITool | undefined;
+    let selectedTool: AITool = sessionTool && sessionTool !== 'none' ? sessionTool : 'none';
     if (!sessions.includes(sessionName)) {
       // Preference order for which tool to launch:
       //   1. Explicit argument (e.g. from the tool-picker dialog)
       //   2. Tool currently running in the session (won't apply when there's no session)
       //   3. Last tool devteam launched here, remembered across restarts
       //   4. First available installed tool
-      const sessionTool = worktree.session?.ai_tool as AITool | undefined;
       const remembered = getLastTool(worktree.path);
-      let selected: AITool = 'none';
-      if (aiTool && aiTool !== 'none') selected = aiTool;
-      else if (sessionTool && sessionTool !== 'none') selected = sessionTool;
-      else if (remembered) selected = remembered;
-      if (selected === 'none' && this.availableAITools.length >= 1) {
-        selected = this.availableAITools[0];
-      }
-      if (selected !== 'none') {
-        if (selected === 'claude') await this.launchClaudeSessionWithFallback(sessionName, worktree.path);
-        else this.tmux.createSessionWithCommand(sessionName, worktree.path, aiLaunchCommand(selected), true);
-        setLastTool(selected, worktree.path);
+      selectedTool = 'none';
+      if (aiTool && aiTool !== 'none') selectedTool = aiTool;
+      else if (sessionTool && sessionTool !== 'none') selectedTool = sessionTool;
+      else if (remembered) selectedTool = remembered;
+      if (selectedTool !== 'none') {
+        if (selectedTool === 'claude') await this.launchClaudeSessionWithFallback(sessionName, worktree.path);
+        else this.tmux.createSessionWithCommand(sessionName, worktree.path, aiLaunchCommand(selectedTool), true);
+        setLastTool(selectedTool, worktree.path);
       } else {
         this.tmux.createSession(sessionName, worktree.path, true);
       }
@@ -271,6 +269,7 @@ export class WorktreeCore implements CoreBase<State> {
       project: worktree.project,
       worktree: worktree.feature,
       sessionKind: 'agent',
+      aiTool: selectedTool,
     });
   }
   async attachShellSession(worktree: WorktreeInfo): Promise<void> {

--- a/src/cores/WorktreeCore.ts
+++ b/src/cores/WorktreeCore.ts
@@ -267,13 +267,21 @@ export class WorktreeCore implements CoreBase<State> {
         this.tmux.createSession(sessionName, worktree.path, true);
       }
     }
-    this.tmux.attachSessionWithControls(sessionName);
+    this.tmux.attachSessionWithControls(sessionName, {
+      project: worktree.project,
+      worktree: worktree.feature,
+      sessionKind: 'agent',
+    });
   }
   async attachShellSession(worktree: WorktreeInfo): Promise<void> {
     const name = this.tmux.shellSessionName(worktree.project, worktree.feature);
     const sessions = await this.tmux.listSessions();
     if (!sessions.includes(name)) this.tmux.createSession(name, worktree.path, false);
-    this.tmux.attachSessionWithControls(name);
+    this.tmux.attachSessionWithControls(name, {
+      project: worktree.project,
+      worktree: worktree.feature,
+      sessionKind: 'shell',
+    });
   }
   async attachRunSession(worktree: WorktreeInfo): Promise<'success' | 'no_config'> {
     const name = this.tmux.runSessionName(worktree.project, worktree.feature);
@@ -289,7 +297,11 @@ export class WorktreeCore implements CoreBase<State> {
     const detachOnExit: boolean = !!exec.detachOnExit;
     try { this.tmux.setSessionOption(name, 'remain-on-exit', detachOnExit ? 'on' : 'off'); } catch {}
     if (!mainCmd || typeof mainCmd !== 'string' || mainCmd.trim().length === 0) {
-      this.tmux.attachSessionWithControls(name);
+      this.tmux.attachSessionWithControls(name, {
+        project: worktree.project,
+        worktree: worktree.feature,
+        sessionKind: 'execute',
+      });
       return 'no_config';
     }
     for (const [k, v] of Object.entries(env)) {
@@ -298,7 +310,11 @@ export class WorktreeCore implements CoreBase<State> {
     }
     for (const cmd of pre) this.tmux.sendText(name, cmd, { executeCommand: true });
     this.tmux.sendText(name, mainCmd, { executeCommand: true });
-    this.tmux.attachSessionWithControls(name);
+    this.tmux.attachSessionWithControls(name, {
+      project: worktree.project,
+      worktree: worktree.feature,
+      sessionKind: 'execute',
+    });
     return 'success';
   }
 

--- a/src/services/TmuxService.ts
+++ b/src/services/TmuxService.ts
@@ -11,6 +11,7 @@ type SessionDisplayMetadata = {
   project: string;
   worktree: string;
   sessionKind: SessionKind;
+  aiTool?: AITool;
 };
 
 export class TmuxService {
@@ -180,6 +181,7 @@ export class TmuxService {
       this.storeSessionDisplayMetadata(session, sessionMeta);
 
       // Ensure mouse is enabled and status is visible
+      this.setOption('mouse', 'on');
       this.setSessionOption(session, 'mouse', 'on');
       // Ensure status bar is visible
       this.setSessionOption(session, 'status', 'on');
@@ -198,8 +200,17 @@ export class TmuxService {
         runCommand(['tmux', 'bind-key', '-n', key, ...args], { env: this.tmuxEnv });
       };
 
-      // Bind MouseUp (release) on all status regions to detach immediately (no menu)
-      for (const k of ['MouseUp1Status', 'MouseUp1StatusLeft', 'MouseUp1StatusRight', 'MouseUp1StatusDefault']) {
+      // Bind both mouse down and mouse up on status regions for compatibility across tmux versions.
+      for (const k of [
+        'MouseDown1Status',
+        'MouseDown1StatusLeft',
+        'MouseDown1StatusRight',
+        'MouseDown1StatusDefault',
+        'MouseUp1Status',
+        'MouseUp1StatusLeft',
+        'MouseUp1StatusRight',
+        'MouseUp1StatusDefault',
+      ]) {
         bind(k, ['detach-client']);
       }
       // No debug messages bound
@@ -274,7 +285,7 @@ export class TmuxService {
   private storeSessionDisplayMetadata(session: string, metadata: SessionDisplayMetadata): void {
     this.setSessionOption(session, '@devteam_project', metadata.project || 'unknown');
     this.setSessionOption(session, '@devteam_worktree', metadata.worktree || 'unknown');
-    this.setSessionOption(session, '@devteam_session_kind', this.sessionKindLabel(metadata.sessionKind));
+    this.setSessionOption(session, '@devteam_session_chip', this.sessionChip(metadata.sessionKind, metadata.aiTool));
   }
 
   private inferSessionDisplayMetadata(session: string): SessionDisplayMetadata {
@@ -295,25 +306,52 @@ export class TmuxService {
   }
 
   private sessionKindLabel(kind: SessionKind): string {
-    if (kind === 'shell') return 'Shell';
-    if (kind === 'execute') return 'Execute';
-    return 'Agent';
+    if (kind === 'shell') return 'SHELL';
+    if (kind === 'execute') return 'EXECUTE';
+    return 'AGENT';
+  }
+
+  private sessionKindValue(kind: SessionKind, aiTool: AITool = 'none'): string {
+    if (kind === 'shell' || kind === 'execute') return '';
+    if (aiTool === 'claude') return 'claude';
+    if (aiTool === 'codex') return 'codex';
+    if (aiTool === 'gemini') return 'gemini';
+    return '';
+  }
+
+  private sessionKindLabelBg(kind: SessionKind): string {
+    return 'colour31';
+  }
+
+  private sessionKindValueBg(kind: SessionKind): string {
+    return 'colour117';
+  }
+
+  private sessionChip(kind: SessionKind, aiTool: AITool = 'none'): string {
+    const label = this.sessionKindLabel(kind);
+    const value = this.sessionKindValue(kind, aiTool);
+    const labelBg = this.sessionKindLabelBg(kind);
+    const valueBg = this.sessionKindValueBg(kind);
+
+    if (!value) {
+      return `#[fg=colour231,bg=${labelBg},bold] ${label} `;
+    }
+
+    return `#[fg=colour231,bg=${labelBg},bold] ${label} #[fg=colour232,bg=${valueBg},bold] ${value} `;
   }
 
   private buildStatusFormat(): string {
     return (
       ' ' +
-      '#[fg=colour231,bg=colour31,bold] DEVTEAM ' +
-      '#[fg=colour31,bg=colour117] PROJECT ' +
       '#[fg=colour255,bg=colour24,bold] #{@devteam_project} ' +
-      '#[fg=colour130,bg=colour223] WORKTREE ' +
+      '#[default]  ' +
       '#[fg=colour255,bg=colour95,bold] #{@devteam_worktree} ' +
-      '#[fg=colour235,bg=colour186] SESSION ' +
-      '#[fg=colour255,bg=colour60,bold] #{@devteam_session_kind} ' +
+      '#[default]  ' +
+      '#{@devteam_session_chip}' +
       '#[default]' +
       '#[align=right]' +
-      '#[fg=colour255,bg=colour238] PROC #{pane_current_command} ' +
-      '#[fg=colour232,bg=colour117,bold] Return to devteam: Prefix+d '
+      '#[fg=colour232,bg=colour117,bold] Click here to return (or Ctrl+b, then d) ' +
+      '#[fg=colour231,bg=colour31,bold] DEVTEAM '
     );
   }
 }

--- a/src/services/TmuxService.ts
+++ b/src/services/TmuxService.ts
@@ -5,6 +5,13 @@ import {Timer} from '../shared/utils/timing.js';
 import {AIStatus, AITool} from '../models.js';
 import {AIToolService} from './AIToolService.js';
 
+type SessionKind = 'agent' | 'execute' | 'shell';
+
+type SessionDisplayMetadata = {
+  project: string;
+  worktree: string;
+  sessionKind: SessionKind;
+};
 
 export class TmuxService {
   private aiToolService: AIToolService;
@@ -167,18 +174,23 @@ export class TmuxService {
    * that exposes Detach and Kill actions.
    * Uses tmux status-format ranges (tmux 3.2+) and MouseDown1Status binding.
    */
-  configureSessionUI(session: string): void {
+  configureSessionUI(session: string, metadata?: SessionDisplayMetadata): void {
     try {
+      const sessionMeta = metadata || this.inferSessionDisplayMetadata(session);
+      this.storeSessionDisplayMetadata(session, sessionMeta);
+
       // Ensure mouse is enabled and status is visible
       this.setSessionOption(session, 'mouse', 'on');
       // Ensure status bar is visible
       this.setSessionOption(session, 'status', 'on');
       this.setSessionOption(session, 'status-position', 'bottom');
-      this.setSessionOption(session, 'status-style', 'fg=white,bold,bg=black');
+      this.setSessionOption(session, 'status-style', 'fg=colour255,bg=colour235');
       this.setSessionOption(session, 'status-interval', '5');
+      this.setSessionOption(session, 'status-left-length', '120');
+      this.setSessionOption(session, 'status-right-length', '120');
       runCommand([
         'tmux', 'set-option', '-t', session, 'status-format[0]',
-        ' #[align=right]Click here to return to devteam (or press Ctrl+b, then d) '
+        this.buildStatusFormat()
       ], { env: this.tmuxEnv });
 
       const bind = (key: string, args: string[]) => {
@@ -200,8 +212,8 @@ export class TmuxService {
   /**
    * Attach to a session with clickable status bar controls enabled.
    */
-  attachSessionWithControls(sessionName: string): void {
-    this.configureSessionUI(sessionName);
+  attachSessionWithControls(sessionName: string, metadata?: SessionDisplayMetadata): void {
+    this.configureSessionUI(sessionName, metadata);
     this.attachSessionInteractive(sessionName);
   }
 
@@ -257,5 +269,51 @@ export class TmuxService {
     
     // Check if there's a matching worktree
     return validWorktrees.some((wt) => wt.includes(suffix));
+  }
+
+  private storeSessionDisplayMetadata(session: string, metadata: SessionDisplayMetadata): void {
+    this.setSessionOption(session, '@devteam_project', metadata.project || 'unknown');
+    this.setSessionOption(session, '@devteam_worktree', metadata.worktree || 'unknown');
+    this.setSessionOption(session, '@devteam_session_kind', this.sessionKindLabel(metadata.sessionKind));
+  }
+
+  private inferSessionDisplayMetadata(session: string): SessionDisplayMetadata {
+    let baseName = session.startsWith(SESSION_PREFIX) ? session.slice(SESSION_PREFIX.length) : session;
+    let sessionKind: SessionKind = 'agent';
+
+    if (baseName.endsWith('-shell')) {
+      sessionKind = 'shell';
+      baseName = baseName.slice(0, -'-shell'.length);
+    } else if (baseName.endsWith('-run')) {
+      sessionKind = 'execute';
+      baseName = baseName.slice(0, -'-run'.length);
+    }
+
+    const [project = baseName || 'unknown', ...rest] = baseName.split('-');
+    const worktree = rest.join('-') || project;
+    return {project, worktree, sessionKind};
+  }
+
+  private sessionKindLabel(kind: SessionKind): string {
+    if (kind === 'shell') return 'Shell';
+    if (kind === 'execute') return 'Execute';
+    return 'Agent';
+  }
+
+  private buildStatusFormat(): string {
+    return (
+      ' ' +
+      '#[fg=colour231,bg=colour31,bold] DEVTEAM ' +
+      '#[fg=colour31,bg=colour117] PROJECT ' +
+      '#[fg=colour255,bg=colour24,bold] #{@devteam_project} ' +
+      '#[fg=colour130,bg=colour223] WORKTREE ' +
+      '#[fg=colour255,bg=colour95,bold] #{@devteam_worktree} ' +
+      '#[fg=colour235,bg=colour186] SESSION ' +
+      '#[fg=colour255,bg=colour60,bold] #{@devteam_session_kind} ' +
+      '#[default]' +
+      '#[align=right]' +
+      '#[fg=colour255,bg=colour238] PROC #{pane_current_command} ' +
+      '#[fg=colour232,bg=colour117,bold] Return to devteam: Prefix+d '
+    );
   }
 }

--- a/tests/fakes/FakeTmuxService.ts
+++ b/tests/fakes/FakeTmuxService.ts
@@ -202,18 +202,29 @@ export class FakeTmuxService extends TmuxService {
     return '0.0 bash\n1.0 claude'; // Mock pane list
   }
 
-  configureSessionUI(session: string, metadata?: {project: string; worktree: string; sessionKind: 'agent' | 'execute' | 'shell'}): void {
+  configureSessionUI(session: string, metadata?: {project: string; worktree: string; sessionKind: 'agent' | 'execute' | 'shell'; aiTool?: AITool}): void {
     if (!metadata) return;
     this.setSessionOption(session, '@devteam_project', metadata.project);
     this.setSessionOption(session, '@devteam_worktree', metadata.worktree);
-    this.setSessionOption(
-      session,
-      '@devteam_session_kind',
-      metadata.sessionKind === 'agent' ? 'Agent' : metadata.sessionKind === 'execute' ? 'Execute' : 'Shell'
-    );
+    const label = metadata.sessionKind === 'agent' ? 'AGENT' : metadata.sessionKind === 'execute' ? 'EXECUTE' : 'SHELL';
+    const value = metadata.sessionKind === 'agent'
+      ? metadata.aiTool === 'claude'
+        ? 'claude'
+        : metadata.aiTool === 'codex'
+          ? 'codex'
+          : metadata.aiTool === 'gemini'
+            ? 'gemini'
+            : ''
+      : '';
+    const labelBg = 'colour31';
+    const valueBg = 'colour117';
+    const chip = value
+      ? `#[fg=colour231,bg=${labelBg},bold] ${label} #[fg=colour232,bg=${valueBg},bold] ${value} `
+      : `#[fg=colour231,bg=${labelBg},bold] ${label} `;
+    this.setSessionOption(session, '@devteam_session_chip', chip);
   }
 
-  attachSessionWithControls(sessionName: string, metadata?: {project: string; worktree: string; sessionKind: 'agent' | 'execute' | 'shell'}): void {
+  attachSessionWithControls(sessionName: string, metadata?: {project: string; worktree: string; sessionKind: 'agent' | 'execute' | 'shell'; aiTool?: AITool}): void {
     this.configureSessionUI(sessionName, metadata);
     this.attachSessionInteractive(sessionName);
   }

--- a/tests/fakes/FakeTmuxService.ts
+++ b/tests/fakes/FakeTmuxService.ts
@@ -8,6 +8,7 @@ export class FakeTmuxService extends TmuxService {
   private sentKeys: Array<{session: string, keys: string[]}> = [];
   private sessions = new Map<string, SessionInfo>();
   private failClaudeContinueSessions = new Set<string>();
+  private sessionOptions = new Map<string, Map<string, string>>();
 
   constructor() {
     super(new FakeAIToolService());
@@ -190,13 +191,31 @@ export class FakeTmuxService extends TmuxService {
   }
 
   setSessionOption(session: string, option: string, value: string): void {
-    // Mock implementation - just store for testing if needed
+    const existing = this.sessionOptions.get(session) || new Map<string, string>();
+    existing.set(option, value);
+    this.sessionOptions.set(session, existing);
   }
 
   async listPanes(session: string): Promise<string> {
     const sessionInfo = this.sessions.get(session) || memoryStore.sessions.get(session);
     if (!sessionInfo) return '';
     return '0.0 bash\n1.0 claude'; // Mock pane list
+  }
+
+  configureSessionUI(session: string, metadata?: {project: string; worktree: string; sessionKind: 'agent' | 'execute' | 'shell'}): void {
+    if (!metadata) return;
+    this.setSessionOption(session, '@devteam_project', metadata.project);
+    this.setSessionOption(session, '@devteam_worktree', metadata.worktree);
+    this.setSessionOption(
+      session,
+      '@devteam_session_kind',
+      metadata.sessionKind === 'agent' ? 'Agent' : metadata.sessionKind === 'execute' ? 'Execute' : 'Shell'
+    );
+  }
+
+  attachSessionWithControls(sessionName: string, metadata?: {project: string; worktree: string; sessionKind: 'agent' | 'execute' | 'shell'}): void {
+    this.configureSessionUI(sessionName, metadata);
+    this.attachSessionInteractive(sessionName);
   }
 
   // Test helpers

--- a/tests/unit/tmux-status-bar.test.ts
+++ b/tests/unit/tmux-status-bar.test.ts
@@ -20,25 +20,27 @@ describe('TmuxService status bar', () => {
       project: 'tmux-status-bar',
       worktree: 'beautiful-status-bar',
       sessionKind: 'agent',
+      aiTool: 'claude',
     });
 
     const calls = (runCommand as jest.Mock).mock.calls.map(([args]) => args);
 
+    expect(calls).toContainEqual(['tmux', 'set-option', '-g', 'mouse', 'on']);
     expect(calls).toContainEqual(['tmux', 'set-option', '-t', 'dev-anything', '@devteam_project', 'tmux-status-bar']);
     expect(calls).toContainEqual(['tmux', 'set-option', '-t', 'dev-anything', '@devteam_worktree', 'beautiful-status-bar']);
-    expect(calls).toContainEqual(['tmux', 'set-option', '-t', 'dev-anything', '@devteam_session_kind', 'Agent']);
+    expect(calls).toContainEqual(['tmux', 'set-option', '-t', 'dev-anything', '@devteam_session_chip', '#[fg=colour231,bg=colour31,bold] AGENT #[fg=colour232,bg=colour117,bold] claude ']);
 
     const statusFormatCall = calls.find((args) => args[0] === 'tmux' && args[1] === 'set-option' && args[4] === 'status-format[0]');
     expect(statusFormatCall).toBeDefined();
-    expect(statusFormatCall?.[5]).toContain('DEVTEAM');
-    expect(statusFormatCall?.[5]).toContain('PROJECT');
-    expect(statusFormatCall?.[5]).toContain('WORKTREE');
-    expect(statusFormatCall?.[5]).toContain('SESSION');
     expect(statusFormatCall?.[5]).toContain('#{@devteam_project}');
     expect(statusFormatCall?.[5]).toContain('#{@devteam_worktree}');
-    expect(statusFormatCall?.[5]).toContain('#{@devteam_session_kind}');
-    expect(statusFormatCall?.[5]).toContain('#{pane_current_command}');
-    expect(statusFormatCall?.[5]).toContain('Return to devteam: Prefix+d');
+    expect(statusFormatCall?.[5]).toContain('#{@devteam_session_chip}');
+    expect(statusFormatCall?.[5]).toContain('Click here to return (or Ctrl+b, then d)');
+    expect(statusFormatCall?.[5]).toContain('DEVTEAM');
+    expect(calls).toContainEqual(['tmux', 'bind-key', '-n', 'MouseDown1Status', 'detach-client']);
+    expect(calls).toContainEqual(['tmux', 'bind-key', '-n', 'MouseDown1StatusRight', 'detach-client']);
+    expect(calls).toContainEqual(['tmux', 'bind-key', '-n', 'MouseUp1Status', 'detach-client']);
+    expect(calls).toContainEqual(['tmux', 'bind-key', '-n', 'MouseUp1StatusRight', 'detach-client']);
   });
 
   test('falls back to parsing session names for shell sessions', () => {
@@ -47,7 +49,7 @@ describe('TmuxService status bar', () => {
     const calls = (runCommand as jest.Mock).mock.calls.map(([args]) => args);
     expect(calls).toContainEqual(['tmux', 'set-option', '-t', 'dev-myproject-feature-redesign-shell', '@devteam_project', 'myproject']);
     expect(calls).toContainEqual(['tmux', 'set-option', '-t', 'dev-myproject-feature-redesign-shell', '@devteam_worktree', 'feature-redesign']);
-    expect(calls).toContainEqual(['tmux', 'set-option', '-t', 'dev-myproject-feature-redesign-shell', '@devteam_session_kind', 'Shell']);
+    expect(calls).toContainEqual(['tmux', 'set-option', '-t', 'dev-myproject-feature-redesign-shell', '@devteam_session_chip', '#[fg=colour231,bg=colour31,bold] SHELL ']);
   });
 
   test('attaches after configuring the richer session controls', () => {
@@ -55,10 +57,35 @@ describe('TmuxService status bar', () => {
       project: 'demo',
       worktree: 'bar-refresh',
       sessionKind: 'execute',
+      aiTool: 'codex',
     });
 
     expect(runInteractive).toHaveBeenCalledWith('tmux', ['attach-session', '-t', 'dev-demo-run']);
     const calls = (runCommand as jest.Mock).mock.calls.map(([args]) => args);
-    expect(calls).toContainEqual(['tmux', 'set-option', '-t', 'dev-demo-run', '@devteam_session_kind', 'Execute']);
+    expect(calls).toContainEqual(['tmux', 'set-option', '-t', 'dev-demo-run', '@devteam_session_chip', '#[fg=colour231,bg=colour31,bold] EXECUTE ']);
+  });
+
+  test('renders codex as a separate chip value beside the AGENT label', () => {
+    tmuxService.configureSessionUI('dev-codex-demo', {
+      project: 'demo',
+      worktree: 'codex-feature',
+      sessionKind: 'agent',
+      aiTool: 'codex',
+    });
+
+    const calls = (runCommand as jest.Mock).mock.calls.map(([args]) => args);
+    expect(calls).toContainEqual(['tmux', 'set-option', '-t', 'dev-codex-demo', '@devteam_session_chip', '#[fg=colour231,bg=colour31,bold] AGENT #[fg=colour232,bg=colour117,bold] codex ']);
+  });
+
+  test('renders gemini as lowercase in the session value chip', () => {
+    tmuxService.configureSessionUI('dev-gemini-demo', {
+      project: 'demo',
+      worktree: 'gemini-feature',
+      sessionKind: 'agent',
+      aiTool: 'gemini',
+    });
+
+    const calls = (runCommand as jest.Mock).mock.calls.map(([args]) => args);
+    expect(calls).toContainEqual(['tmux', 'set-option', '-t', 'dev-gemini-demo', '@devteam_session_chip', '#[fg=colour231,bg=colour31,bold] AGENT #[fg=colour232,bg=colour117,bold] gemini ']);
   });
 });

--- a/tests/unit/tmux-status-bar.test.ts
+++ b/tests/unit/tmux-status-bar.test.ts
@@ -1,0 +1,64 @@
+jest.mock('../../src/shared/utils/commandExecutor.js', () => ({
+  ...jest.requireActual('../../src/shared/utils/commandExecutor.js'),
+  runCommand: jest.fn(),
+  runInteractive: jest.fn(),
+}));
+
+import {TmuxService} from '../../src/services/TmuxService.js';
+import {runCommand, runInteractive} from '../../src/shared/utils/commandExecutor.js';
+
+describe('TmuxService status bar', () => {
+  let tmuxService: TmuxService;
+
+  beforeEach(() => {
+    tmuxService = new TmuxService();
+    jest.clearAllMocks();
+  });
+
+  test('configures an informative status bar with explicit session metadata', () => {
+    tmuxService.configureSessionUI('dev-anything', {
+      project: 'tmux-status-bar',
+      worktree: 'beautiful-status-bar',
+      sessionKind: 'agent',
+    });
+
+    const calls = (runCommand as jest.Mock).mock.calls.map(([args]) => args);
+
+    expect(calls).toContainEqual(['tmux', 'set-option', '-t', 'dev-anything', '@devteam_project', 'tmux-status-bar']);
+    expect(calls).toContainEqual(['tmux', 'set-option', '-t', 'dev-anything', '@devteam_worktree', 'beautiful-status-bar']);
+    expect(calls).toContainEqual(['tmux', 'set-option', '-t', 'dev-anything', '@devteam_session_kind', 'Agent']);
+
+    const statusFormatCall = calls.find((args) => args[0] === 'tmux' && args[1] === 'set-option' && args[4] === 'status-format[0]');
+    expect(statusFormatCall).toBeDefined();
+    expect(statusFormatCall?.[5]).toContain('DEVTEAM');
+    expect(statusFormatCall?.[5]).toContain('PROJECT');
+    expect(statusFormatCall?.[5]).toContain('WORKTREE');
+    expect(statusFormatCall?.[5]).toContain('SESSION');
+    expect(statusFormatCall?.[5]).toContain('#{@devteam_project}');
+    expect(statusFormatCall?.[5]).toContain('#{@devteam_worktree}');
+    expect(statusFormatCall?.[5]).toContain('#{@devteam_session_kind}');
+    expect(statusFormatCall?.[5]).toContain('#{pane_current_command}');
+    expect(statusFormatCall?.[5]).toContain('Return to devteam: Prefix+d');
+  });
+
+  test('falls back to parsing session names for shell sessions', () => {
+    tmuxService.configureSessionUI('dev-myproject-feature-redesign-shell');
+
+    const calls = (runCommand as jest.Mock).mock.calls.map(([args]) => args);
+    expect(calls).toContainEqual(['tmux', 'set-option', '-t', 'dev-myproject-feature-redesign-shell', '@devteam_project', 'myproject']);
+    expect(calls).toContainEqual(['tmux', 'set-option', '-t', 'dev-myproject-feature-redesign-shell', '@devteam_worktree', 'feature-redesign']);
+    expect(calls).toContainEqual(['tmux', 'set-option', '-t', 'dev-myproject-feature-redesign-shell', '@devteam_session_kind', 'Shell']);
+  });
+
+  test('attaches after configuring the richer session controls', () => {
+    tmuxService.attachSessionWithControls('dev-demo-run', {
+      project: 'demo',
+      worktree: 'bar-refresh',
+      sessionKind: 'execute',
+    });
+
+    expect(runInteractive).toHaveBeenCalledWith('tmux', ['attach-session', '-t', 'dev-demo-run']);
+    const calls = (runCommand as jest.Mock).mock.calls.map(([args]) => args);
+    expect(calls).toContainEqual(['tmux', 'set-option', '-t', 'dev-demo-run', '@devteam_session_kind', 'Execute']);
+  });
+});


### PR DESCRIPTION
## What changed
- replaced the minimal tmux status bar with a styled session bar that shows the active project, worktree, and session type
- passed explicit session metadata from worktree attach flows so Agent, Execute, and Shell sessions render the correct labels without relying on brittle name parsing
- added tmux status-bar unit coverage and updated the fake tmux service so tests can exercise the richer session UI without invoking real tmux bindings

## Why
The previous bar only showed a generic return hint, so once a tmux session was open there was no quick way to tell which project or worktree it belonged to, or whether it was an agent, execute, or shell session.

## Impact
Users now get immediate context in tmux itself, which makes switching between multiple feature worktrees and session modes substantially clearer.

## Validation
- npm run typecheck
- npm run build
- npm test -- --runInBand