### PR TITLE
Fix Claude continue fallback using shell OR operator

### DIFF
--- a/src/cores/WorktreeCore.ts
+++ b/src/cores/WorktreeCore.ts
@@ -258,7 +258,7 @@ export class WorktreeCore implements CoreBase<State> {
       else if (sessionTool && sessionTool !== 'none') selectedTool = sessionTool;
       else if (remembered) selectedTool = remembered;
       if (selectedTool !== 'none') {
-        if (selectedTool === 'claude') await this.launchClaudeSessionWithFallback(sessionName, worktree.path);
+        if (selectedTool === 'claude') this.launchClaudeSessionWithFallback(sessionName, worktree.path);
         else this.tmux.createSessionWithCommand(sessionName, worktree.path, aiLaunchCommand(selectedTool), true);
         setLastTool(selectedTool, worktree.path);
       } else {
@@ -386,23 +386,9 @@ export class WorktreeCore implements CoreBase<State> {
     for (const name of [s, sh, rn]) { if (active.includes(name)) this.tmux.killSession(name); }
   }
 
-  private async launchClaudeSessionWithFallback(sessionName: string, cwd: string): Promise<void> {
-    this.tmux.createSession(sessionName, cwd, true);
-    this.tmux.sendText(sessionName, aiLaunchCommand('claude'), {executeCommand: true});
-    const started = await this.waitForAIToolStart(sessionName, 'claude');
-    if (!started) {
-      logDebug('Claude resume did not start; retrying with a fresh session', {sessionName, cwd});
-      this.tmux.sendText(sessionName, 'claude', {executeCommand: true});
-    }
-  }
-
-  private async waitForAIToolStart(sessionName: string, tool: AITool, attempts: number = 3, waitMs: number = 150): Promise<boolean> {
-    for (let attempt = 0; attempt < attempts; attempt++) {
-      const status = await this.tmux.getAIStatus(sessionName);
-      if (status.tool === tool) return true;
-      if (attempt < attempts - 1) await new Promise(resolve => setTimeout(resolve, waitMs));
-    }
-    return false;
+  private launchClaudeSessionWithFallback(sessionName: string, cwd: string): void {
+    const continueCmd = aiLaunchCommand('claude');
+    this.tmux.createSessionWithCommand(sessionName, cwd, `${continueCmd} || claude`, true);
   }
 
   private setState(partial: Partial<State>): void {

--- a/tests/unit/WorktreeCoreAutoResume.test.ts
+++ b/tests/unit/WorktreeCoreAutoResume.test.ts
@@ -46,27 +46,15 @@ describe('WorktreeCore auto-resume', () => {
     fs.rmSync(tmpDir, {recursive: true, force: true});
   });
 
-  test('attachSession launches claude --continue and records lastTool', async () => {
+  test('attachSession launches claude with shell fallback and records lastTool', async () => {
     const {core, tmux} = buildCore();
     const wt = worktreeFor('proj', 'feat');
 
     await core.attachSession(wt, 'claude');
 
     const sessionName = tmux.sessionName('proj', 'feat');
-    expect(getExecutedCommands(tmux, sessionName)).toEqual(['claude --continue']);
+    expect(getExecutedCommands(tmux, sessionName)).toEqual(['claude --continue || claude']);
     expect(getLastTool(wt.path)).toBe('claude');
-  });
-
-  test('attachSession falls back to plain claude when resume does not start a session', async () => {
-    const {core, tmux} = buildCore();
-    const wt = worktreeFor('proj', 'feat');
-    const sessionName = tmux.sessionName('proj', 'feat');
-    tmux.failNextClaudeContinue(sessionName);
-
-    await core.attachSession(wt, 'claude');
-
-    expect(getExecutedCommands(tmux, sessionName)).toEqual(['claude --continue', 'claude']);
-    expect(tmux.getSessionInfo(sessionName)?.ai_tool).toBe('claude');
   });
 
   test('attachSession uses remembered tool when no explicit choice', async () => {


### PR DESCRIPTION
## Summary

- Replaces the polling-based `waitForAIToolStart` approach with a simple shell fallback command: `claude --continue || claude`
- The previous fix had a race condition: if the polling check ran while `claude --continue` was briefly starting up (before it printed "No conversation found to continue" and exited), it would see `tool === 'claude'` and skip the fallback entirely
- Now the shell handles the fallback natively — if `claude --continue` exits non-zero, `claude` starts immediately, no timing involved

## Test plan

- [x] All 58 test suites pass (466 tests)
- [x] TypeScript typecheck clean
- [x] Removed now-unused `waitForAIToolStart` polling method and `failNextClaudeContinue` test scenario (both tied to the old approach)

🤖 Generated with [Claude Code](https://claude.com/claude-code)