### PR TITLE
Fix: isRefreshingVisible guard — try/finally + forceRefreshVisible preemption

### DIFF
--- a/src/cores/WorktreeCore.ts
+++ b/src/cores/WorktreeCore.ts
@@ -162,33 +162,37 @@ export class WorktreeCore implements CoreBase<State> {
   async refreshVisibleStatus(currentPage: number, pageSize: number): Promise<void> {
     if (this.isRefreshingVisible) return;
     this.isRefreshingVisible = true;
-    // Compute slice and refresh git/tmux status for visible rows
-    const start = currentPage * pageSize;
-    const end = Math.min(start + pageSize, this.state.worktrees.length);
-    const slice = this.state.worktrees.slice(start, end);
-    const sessions = await this.tmux.listSessions();
-    const updated: WorktreeInfo[] = [];
-    for (const wt of slice) {
-      const sessionName = this.tmux.sessionName(wt.project, wt.feature);
-      const attached = sessions.includes(sessionName);
-      // Fetch AI status first: if agent just finished working, invalidate the git slow-metrics
-      // cache before fetching git status so this tick shows fresh committed stats.
-      const aiResult = attached
-        ? await this.tmux.getAIStatus(sessionName)
-        : {tool: 'none' as const, status: 'not_running' as const};
-      if (wt.session?.ai_status === 'working' && aiResult.status !== 'working') {
-        this.git.invalidateGitSlowCache(wt.path);
+    try {
+      // Compute slice and refresh git/tmux status for visible rows
+      const start = currentPage * pageSize;
+      const end = Math.min(start + pageSize, this.state.worktrees.length);
+      const slice = this.state.worktrees.slice(start, end);
+      const sessions = await this.tmux.listSessions();
+      const updated: WorktreeInfo[] = [];
+      for (const wt of slice) {
+        const sessionName = this.tmux.sessionName(wt.project, wt.feature);
+        const attached = sessions.includes(sessionName);
+        // Fetch AI status first: if agent just finished working, invalidate the git slow-metrics
+        // cache before fetching git status so this tick shows fresh committed stats.
+        const aiResult = attached
+          ? await this.tmux.getAIStatus(sessionName)
+          : {tool: 'none' as const, status: 'not_running' as const};
+        if (wt.session?.ai_status === 'working' && aiResult.status !== 'working') {
+          this.git.invalidateGitSlowCache(wt.path);
+        }
+        const gitStatus = await this.git.getGitStatus(wt.path);
+        updated.push(new WorktreeInfo({...wt, git: gitStatus, session: new SessionInfo({session_name: sessionName, attached, ai_status: aiResult.status, ai_tool: aiResult.tool})}));
       }
-      const gitStatus = await this.git.getGitStatus(wt.path);
-      updated.push(new WorktreeInfo({...wt, git: gitStatus, session: new SessionInfo({session_name: sessionName, attached, ai_status: aiResult.status, ai_tool: aiResult.tool})}));
+      const arr = [...this.state.worktrees];
+      for (let i = 0; i < updated.length; i++) arr[start + i] = updated[i];
+      this.setState({worktrees: arr, lastRefreshed: Date.now()});
+    } finally {
+      this.isRefreshingVisible = false;
     }
-    const arr = [...this.state.worktrees];
-    for (let i = 0; i < updated.length; i++) arr[start + i] = updated[i];
-    this.setState({worktrees: arr, lastRefreshed: Date.now()});
-    this.isRefreshingVisible = false;
   }
 
   async forceRefreshVisible(currentPage: number, pageSize: number): Promise<void> {
+    this.isRefreshingVisible = false; // preempt any in-flight poll
     await this.refreshVisibleStatus(currentPage, pageSize);
   }
 


### PR DESCRIPTION
## Summary

- `refreshVisibleStatus` now wraps its body in `try/finally` so the guard is always released, even if a git call or setState throws. Without this, a single error permanently locks the refresh loop until process restart.
- `forceRefreshVisible` preempts any in-flight background poll by resetting the flag before delegating, so user-triggered refreshes (e.g. post-feature-create) are never silently dropped.

## Test plan
- [ ] Verify `npm run typecheck` passes
- [ ] Confirm refreshes continue after a simulated git error
- [ ] Confirm force-refresh works immediately even during a slow background tick