### PR TITLE
fix: close shell when run program exits (rename detachOnExit → keepSh…

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -273,9 +273,9 @@ export const CONFIG_SCHEMA: Record<string, SchemaNode> = {
         description: 'Env vars exported before the command runs',
         example: {},
       },
-      detachOnExit: {
+      keepShellRunning: {
         type: 'boolean',
-        description: 'When the program being run exits: true closes the pane; false keeps it open so you can see the output.',
+        description: 'When the program being run exits: true keeps the shell open so you can see the output; false (default) closes the pane.',
         example: false,
       },
     },
@@ -342,7 +342,7 @@ export type ProjectConfig = {
     mainCommand?: string;
     preRunCommands?: string[];
     environmentVariables?: Record<string, string>;
-    detachOnExit?: boolean;
+    keepShellRunning?: boolean;
   };
   worktreeSetup?: {
     copyFiles?: string[];

--- a/src/cores/WorktreeCore.ts
+++ b/src/cores/WorktreeCore.ts
@@ -413,9 +413,6 @@ export class WorktreeCore implements CoreBase<State> {
     const mainCmd = exec.mainCommand;
     const pre = Array.isArray(exec.preRunCommands) ? exec.preRunCommands.filter(Boolean) : [];
     const env = exec.environmentVariables && typeof exec.environmentVariables === 'object' ? exec.environmentVariables : {};
-    // detachOnExit=true means the pane detaches (closes) when the command exits.
-    // detachOnExit=false keeps the pane open so the user can read the output.
-    try { this.tmux.setSessionOption(name, 'remain-on-exit', exec.detachOnExit ? 'off' : 'on'); } catch {}
     if (!mainCmd || typeof mainCmd !== 'string' || mainCmd.trim().length === 0) {
       this.tmux.attachSessionWithControls(name, {
         project: worktree.project,
@@ -429,7 +426,8 @@ export class WorktreeCore implements CoreBase<State> {
       this.tmux.sendText(name, `export ${k}=${JSON.stringify(String(v))}`, { executeCommand: true });
     }
     for (const cmd of pre) this.tmux.sendText(name, cmd, { executeCommand: true });
-    this.tmux.sendText(name, mainCmd, { executeCommand: true });
+    const cmdToRun = exec.keepShellRunning ? mainCmd : `${mainCmd}; exit`;
+    this.tmux.sendText(name, cmdToRun, { executeCommand: true });
     this.tmux.attachSessionWithControls(name, {
       project: worktree.project,
       worktree: worktree.feature,


### PR DESCRIPTION
…ellRunning)

The old remain-on-exit tmux option had no effect because the shell is the primary process in the pane — it stays alive regardless. Fix by appending "; exit" to the command so the shell exits when the program does.

keepShellRunning: true keeps the shell open; false (default) closes it.