### PR TITLE
feat: auto-suffix worktree name on branch conflict

### DIFF
--- a/src/cores/WorktreeCore.ts
+++ b/src/cores/WorktreeCore.ts
@@ -236,12 +236,17 @@ export class WorktreeCore implements CoreBase<State> {
 
   // Worktree operations
   async createFeature(projectName: string, featureName: string): Promise<WorktreeInfo | null> {
-    const created = this.git.createWorktree(projectName, featureName);
+    let uniqueName = featureName;
+    let counter = 2;
+    while (counter <= 99 && this.git.branchExists(projectName, uniqueName)) {
+      uniqueName = `${featureName}-${counter++}`;
+    }
+    const created = this.git.createWorktree(projectName, uniqueName);
     if (!created) return null;
-    const worktreePath = path.join(this.git.basePath, `${projectName}${DIR_BRANCHES_SUFFIX}`, featureName);
+    const worktreePath = path.join(this.git.basePath, `${projectName}${DIR_BRANCHES_SUFFIX}`, uniqueName);
     this.setupWorktreeEnvironment(projectName, worktreePath);
     await this.refresh();
-    return new WorktreeInfo({project: projectName, feature: featureName, path: worktreePath, branch: featureName});
+    return new WorktreeInfo({project: projectName, feature: uniqueName, path: worktreePath, branch: uniqueName});
   }
 
   async createFromBranch(project: string, remoteBranch: string, localName: string): Promise<boolean> {

--- a/src/screens/CreateFeatureScreen.tsx
+++ b/src/screens/CreateFeatureScreen.tsx
@@ -50,11 +50,21 @@ export default function CreateFeatureScreen({
           onSuccess();
           // Small delay to ensure UI state updates and worktree appears
           await new Promise(resolve => setTimeout(resolve, 100));
-          const needsSelection = await needsToolSelection(created);
-          if (needsSelection) {
-            showAIToolSelection(created);
+          const proceedWithSession = async () => {
+            const needsSelection = await needsToolSelection(created);
+            if (needsSelection) {
+              showAIToolSelection(created);
+            } else {
+              await attachSession(created);
+            }
+          };
+          if (created.feature !== safeFeature) {
+            showInfo(`'${feature}' was already taken — created as '${created.feature}' instead.`, {
+              title: 'Name Already Exists',
+              onClose: proceedWithSession,
+            });
           } else {
-            await attachSession(created);
+            await proceedWithSession();
           }
         } else {
           onCancel();

--- a/src/services/GitService.ts
+++ b/src/services/GitService.ts
@@ -227,6 +227,12 @@ export class GitService {
   }
 
 
+  branchExists(project: string, branchName: string): boolean {
+    const mainRepo = path.join(this.basePath, project);
+    const result = runCommandQuick(['git', '-C', mainRepo, 'rev-parse', '--verify', branchName]);
+    return !!result && !/fatal/i.test(result);
+  }
+
   createWorktree(project: string, featureName: string, branchName?: string): boolean {
     const mainRepo = path.join(this.basePath, project);
     const branchesDir = path.join(this.basePath, `${project}${DIR_BRANCHES_SUFFIX}`);
@@ -259,9 +265,7 @@ export class GitService {
     if (fs.existsSync(worktreePath)) return false;
     
     const localBranch = remoteBranch.startsWith('origin/') ? remoteBranch.slice(7) : remoteBranch;
-    const exists = runCommandQuick(['git', '-C', mainRepo, 'rev-parse', '--verify', localBranch]);
-    
-    if (exists && !/fatal/i.test(exists)) {
+    if (this.branchExists(project, localBranch)) {
       runCommand(['git', '-C', mainRepo, 'worktree', 'add', worktreePath, localBranch]);
     } else {
       runCommand(['git', '-C', mainRepo, 'worktree', 'add', '--track', '-b', localBranch, worktreePath, remoteBranch]);

--- a/tests/unit/git-worktree-creation.test.ts
+++ b/tests/unit/git-worktree-creation.test.ts
@@ -145,7 +145,34 @@ describe('GitService worktree creation', () => {
     expect(mockFileSystem.ensureDirectory).toHaveBeenCalled();
     expect(mockCommandExecutor.runCommand).not.toHaveBeenCalled();
     expect(mockGitHelpers.findBaseBranch).not.toHaveBeenCalled();
-    
+
+    expect(result).toBe(false);
+  });
+
+  test('branchExists returns true when git rev-parse succeeds', () => {
+    mockCommandExecutor.runCommandQuick.mockReturnValue('abc123');
+
+    const result = gitService.branchExists('test-project', 'my-branch');
+
+    expect(mockCommandExecutor.runCommandQuick).toHaveBeenCalledWith(
+      ['git', '-C', '/test/base/path/test-project', 'rev-parse', '--verify', 'my-branch']
+    );
+    expect(result).toBe(true);
+  });
+
+  test('branchExists returns false when git rev-parse outputs fatal error', () => {
+    mockCommandExecutor.runCommandQuick.mockReturnValue('fatal: not a valid object name');
+
+    const result = gitService.branchExists('test-project', 'nonexistent-branch');
+
+    expect(result).toBe(false);
+  });
+
+  test('branchExists returns false when git rev-parse returns empty string', () => {
+    mockCommandExecutor.runCommandQuick.mockReturnValue('');
+
+    const result = gitService.branchExists('test-project', 'nonexistent-branch');
+
     expect(result).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

- When creating a worktree whose branch name already exists (e.g. from a previously archived worktree), the name is now auto-incremented (`my-feature-2`, `my-feature-3`, …, up to `-99`) instead of silently returning to the main screen
- A modal informs the user when the name was changed (`'my-feature' was already taken — created as 'my-feature-2' instead`)
- Extracted the inline `rev-parse --verify` branch check in `createWorktreeFromRemote` to reuse the new `branchExists()` helper

## Test plan

- [ ] Added unit tests for `GitService.branchExists()` covering success, fatal error, and empty output cases
- [ ] Existing 474 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)