### PR TITLE
feat: re-apply files button in config dialog + 5-min Claude timeout

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -51,6 +51,7 @@ function AppContent() {
     generateConfigWithAI,
     editConfigWithAI,
     applyConfig,
+    reapplyFiles,
     getAvailableAITools,
     needsToolSelection
   } = useWorktreeContext();
@@ -373,6 +374,7 @@ function AppContent() {
           onGenerate={() => runSettingsAI(settingsProject, () => generateConfigWithAI(settingsProject))}
           onEdit={(userPrompt: string) => runSettingsAI(settingsProject, () => editConfigWithAI(settingsProject, userPrompt))}
           onApply={(proposed: string) => applyProposedConfig(settingsProject, proposed)}
+          onReapplyFiles={() => reapplyFiles(settingsProject)}
           onDiscardResult={() => clearSettingsAIResult()}
           onCancel={showList}
         />

--- a/src/components/dialogs/SettingsDialog.tsx
+++ b/src/components/dialogs/SettingsDialog.tsx
@@ -15,6 +15,7 @@ type Props = {
   onGenerate: () => void;
   onEdit: (userPrompt: string) => void;
   onApply: (content: string) => void;
+  onReapplyFiles: () => {count: number};
   onDiscardResult: () => void;
   onCancel: () => void;
 };
@@ -46,11 +47,14 @@ export default function SettingsDialog({
   onGenerate,
   onEdit,
   onApply,
+  onReapplyFiles,
   onDiscardResult,
   onCancel,
 }: Props) {
   // TextInput from @inkjs/ui is uncontrolled; bump key to remount-and-clear after submit.
   const [inputKey, setInputKey] = useState(0);
+  const [showReapplyPrompt, setShowReapplyPrompt] = useState(false);
+  const [reapplyStatus, setReapplyStatus] = useState<string | null>(null);
   const {requestFocus, releaseFocus} = useInputFocus();
   const {columns} = useTerminalDimensions();
   const layout = useMemo(() => computeLayout(columns), [columns]);
@@ -72,11 +76,27 @@ export default function SettingsDialog({
   }, [requestFocus, releaseFocus]);
 
   useInput((input, key) => {
+    if (showReapplyPrompt) {
+      if (input === 'y' || input === 'Y') {
+        const {count} = onReapplyFiles();
+        setReapplyStatus(`Re-applied files to ${count} worktree${count === 1 ? '' : 's'}`);
+      }
+      setShowReapplyPrompt(false);
+      return;
+    }
     if (key.escape) { onCancel(); return; }
     if (!inPreview || !result) return;
     if (result.success && result.content) {
-      if (input === 'a' || input === 'A') onApply(result.content);
-      else if (input === 'd' || input === 'D') onDiscardResult();
+      if (input === 'a' || input === 'A') {
+        const worktreeSetupChanged = !sameValue(
+          resolveValue(currentParsed, 'worktreeSetup'),
+          resolveValue(proposedParsed, 'worktreeSetup')
+        );
+        onApply(result.content);
+        if (worktreeSetupChanged) setShowReapplyPrompt(true);
+      } else if (input === 'd' || input === 'D') {
+        onDiscardResult();
+      }
     } else if (input === 'd' || input === 'D' || key.return) {
       onDiscardResult();
     }
@@ -116,7 +136,19 @@ export default function SettingsDialog({
         </Box>
       ) : null}
 
-      {!inPreview ? (
+      {reapplyStatus ? (
+        <Box marginTop={1}>
+          <Text color="green">{reapplyStatus}</Text>
+        </Box>
+      ) : null}
+
+      {showReapplyPrompt ? (
+        <Box marginTop={1} flexDirection="column" borderStyle="single" borderColor="yellow" paddingX={1}>
+          <Text color="yellow">File setup changed. Re-apply files to existing worktrees?</Text>
+        </Box>
+      ) : null}
+
+      {!inPreview && !showReapplyPrompt ? (
         <Box marginTop={1} flexDirection="column">
           <Text>Ask Claude to update the config (empty prompt = regenerate from scratch):</Text>
           <Box borderStyle="single" borderColor="gray" paddingX={1}>
@@ -132,11 +164,13 @@ export default function SettingsDialog({
 
       <Box marginTop={1}>
         <Text color="magenta">
-          {inPreview
-            ? (result?.success ? '[a] apply  [d] discard  [esc] back' : '[d] dismiss  [esc] back')
-            : loading
-              ? '[esc] back (AI keeps running)'
-              : '[enter] send prompt (empty = regenerate)  [esc] back'}
+          {showReapplyPrompt
+            ? '[y] re-apply files  [any other key] skip'
+            : inPreview
+              ? (result?.success ? '[a] apply  [d] discard  [esc] back' : '[d] dismiss  [esc] back')
+              : loading
+                ? '[esc] back (AI keeps running)'
+                : '[enter] send prompt (empty = regenerate)  [esc] back'}
         </Text>
       </Box>
     </Box>

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -134,6 +134,7 @@ export const ALT_IDLE_MARKERS: RegExp[] = [
 // Process timeouts (ms)
 export const SUBPROCESS_TIMEOUT = 30_000;
 export const SUBPROCESS_SHORT_TIMEOUT = 5_000;
+export const CLAUDE_TIMEOUT = 300_000; // 5 minutes
 // How long tmux shows messages (like "detached") in ms
 // 0 disables message display entirely in supported tmux versions
 export const TMUX_DISPLAY_TIME = 0;

--- a/src/contexts/WorktreeContext.tsx
+++ b/src/contexts/WorktreeContext.tsx
@@ -54,6 +54,7 @@ interface WorktreeContextType {
   generateConfigWithAI: (project: string) => Promise<{success: boolean; content?: string; path: string; error?: string}>;
   editConfigWithAI: (project: string, userPrompt: string) => Promise<{success: boolean; content?: string; path: string; error?: string}>;
   applyConfig: (project: string, content: string) => {success: boolean; error?: string};
+  reapplyFiles: (project: string) => {count: number};
 }
 
 const WorktreeContext = createContext<WorktreeContextType | null>(null);
@@ -111,6 +112,7 @@ export function WorktreeProvider({children, core: coreOverride}: WorktreeProvide
   const generateConfigWithAI = useCallback(async (project: string) => core.generateConfigWithAI(project), [core]);
   const editConfigWithAI = useCallback(async (project: string, userPrompt: string) => core.editConfigWithAI(project, userPrompt), [core]);
   const applyConfig = useCallback((project: string, content: string) => core.applyConfig(project, content), [core]);
+  const reapplyFiles = useCallback((project: string) => core.reapplyFiles(project), [core]);
 
   const contextValue: WorktreeContextType = {
     // State
@@ -160,7 +162,8 @@ export function WorktreeProvider({children, core: coreOverride}: WorktreeProvide
     readConfigContent,
     generateConfigWithAI,
     editConfigWithAI,
-    applyConfig
+    applyConfig,
+    reapplyFiles
   };
 
   return (

--- a/src/cores/WorktreeCore.ts
+++ b/src/cores/WorktreeCore.ts
@@ -408,6 +408,14 @@ export class WorktreeCore implements CoreBase<State> {
     return this.runConfigPrompt(project, prompt);
   }
 
+  reapplyFiles(project: string): {count: number} {
+    const worktrees = this.state.worktrees.filter(wt => wt.project === project && !wt.is_archived);
+    for (const wt of worktrees) {
+      this.setupWorktreeEnvironment(project, wt.path);
+    }
+    return {count: worktrees.length};
+  }
+
   applyConfig(project: string, content: string): {success: boolean; error?: string} {
     try { JSON.parse(content); } catch (e) {
       return {success: false, error: `Invalid JSON: ${e instanceof Error ? e.message : String(e)}`};

--- a/src/shared/utils/commandExecutor.ts
+++ b/src/shared/utils/commandExecutor.ts
@@ -1,5 +1,5 @@
 import {execFileSync, spawnSync, execFile, spawn} from 'child_process';
-import {SUBPROCESS_SHORT_TIMEOUT, SUBPROCESS_TIMEOUT, AI_TOOLS} from '../../constants.js';
+import {SUBPROCESS_SHORT_TIMEOUT, SUBPROCESS_TIMEOUT, CLAUDE_TIMEOUT, AI_TOOLS} from '../../constants.js';
 
 // Consolidated command executors (sync + async) with options
 export function runCommand(
@@ -85,7 +85,7 @@ export function runClaudeAsync(
   opts: { cwd?: string; timeoutMs?: number } = {}
 ): Promise<{success: boolean; output: string; error?: string}> {
   return new Promise((resolve) => {
-    const timeoutMs = opts.timeoutMs ?? SUBPROCESS_TIMEOUT;
+    const timeoutMs = opts.timeoutMs ?? CLAUDE_TIMEOUT;
     let stdout = '';
     let stderr = '';
     let settled = false;


### PR DESCRIPTION
- After applying a config change via the AI settings dialog, if
  worktreeSetup (copyFiles/symlinkPaths) changed, prompt the user
  to re-apply files to all existing worktrees ([y] to confirm)
- Adds WorktreeCore.reapplyFiles() and wires it through context/App
- Raises Claude subprocess timeout from 30s to 5 minutes (CLAUDE_TIMEOUT)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
