### PR TITLE
fix: correct AI status detection for Claude Code sessions

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -81,8 +81,7 @@ export const AI_TOOLS = {
     resumeArgs: '--continue',
     processPatterns: ['claude'],
     statusPatterns: {
-      working: 'esc to interrupt',
-      waiting_numbered: ['❯', String.raw`\d+\.\s+\w+`],
+      working: '… (',
       idle_prompt: ['│ >', '│']
     }
   },
@@ -93,7 +92,6 @@ export const AI_TOOLS = {
     processPatterns: ['node'],
     statusPatterns: {
       working: 'Esc to interrupt',
-      waiting_numbered: ['▌', '[A-Za-z]'],  // Check for prompt with text content after it
       idle_prompt: ['▌', '⏎ send']
     }
   },
@@ -104,8 +102,7 @@ export const AI_TOOLS = {
     processPatterns: ['node'],
     statusPatterns: {
       working: 'esc to cancel',
-      waiting_numbered: ['Waiting for user', String.raw`\d+\.`],
-      idle_prompt: ['│ >', '']  // Just check for prompt, idle is default state
+      idle_prompt: ['│ >', '']
     }
   }
 } as const;
@@ -114,13 +111,6 @@ export function aiLaunchCommand(tool: keyof typeof AI_TOOLS): string {
   const cfg = AI_TOOLS[tool];
   return `${cfg.command} ${cfg.resumeArgs}`;
 }
-
-// Claude status patterns (Python parity) - kept for backward compatibility
-export const CLAUDE_PATTERNS = {
-  working: 'esc to interrupt',
-  waiting_numbered: ['❯', String.raw`\d+\.\s+\w+`],
-  idle_prompt: ['│ >', '│']
-} as const;
 
 // Additional idle markers for other CLIs (e.g., GPT Codex)
 export const ALT_IDLE_MARKERS: RegExp[] = [

--- a/src/services/AIToolService.ts
+++ b/src/services/AIToolService.ts
@@ -3,6 +3,9 @@ import {AI_TOOLS, aiLaunchCommand} from '../constants.js';
 import {AIStatus, AITool} from '../models.js';
 import {setLastTool} from '../shared/utils/aiSessionMemory.js';
 
+// Matches ❯ immediately followed by a numbered option on the same line (e.g. "❯ 1. Accept")
+const CLAUDE_WAITING_RE = /❯\s+\d+\.\s+\w+/m;
+
 export class AIToolService {
   /**
    * Get tool name for display
@@ -97,17 +100,14 @@ export class AIToolService {
     if (tool === 'none') return 'not_running';
     
     const toolConfig = AI_TOOLS[tool];
-    const patterns = toolConfig.statusPatterns;
-    
-    // Check in priority order: working → waiting → idle (default)
-    
+
     // 1. Check for working state first (most specific)
-    if (this.isWorking(text, patterns.working)) {
+    if (this.isWorking(text, toolConfig.statusPatterns.working)) {
       return 'working';
     }
-    
+
     // 2. Check for waiting states (tool-specific logic)
-    if (this.isWaitingForTool(text, tool, patterns)) {
+    if (this.isWaitingForTool(text, tool)) {
       return 'waiting';
     }
     
@@ -125,36 +125,28 @@ export class AIToolService {
   /**
    * Check if AI tool is waiting for user input (tool-specific logic)
    */
-  private isWaitingForTool(text: string, tool: AITool, patterns: any): boolean {
+  private isWaitingForTool(text: string, tool: AITool): boolean {
     const lower = text.toLowerCase();
     switch (tool) {
       case 'gemini':
         return lower.includes('waiting for user');
-      
+
       case 'codex':
         // Codex uses the block cursor for interactive prompts; idle restores the send hint.
         return text.includes('▌') && !text.includes('⏎ send');
-      
+
       case 'claude':
-        // Observed against current Claude Code permission/question prompts; keep narrow to avoid
-        // matching generic file-permission errors in normal output.
-        return this.isWaiting(text, patterns.waiting_numbered) ||
+        // CLAUDE_WAITING_RE requires ❯ and the numbered option on the same line, preventing
+        // false positives from scrollback ❯ (user prompts) + prior numbered Claude responses.
+        return CLAUDE_WAITING_RE.test(text) ||
           lower.includes('allow execution') ||
           lower.includes('needs permission') ||
           lower.includes('yes, allow') ||
           lower.includes('do you want me to');
-      
+
       default:
         return false;
     }
-  }
-
-  /**
-   * Check if text matches waiting pattern (prompt symbol + regex pattern)
-   */
-  private isWaiting(text: string, patterns: readonly [string, string]): boolean {
-    const [promptSymbol, pattern] = patterns;
-    return text.includes(promptSymbol) && new RegExp(pattern, 'm').test(text);
   }
 
   /**

--- a/tests/unit/AIToolService.test.ts
+++ b/tests/unit/AIToolService.test.ts
@@ -92,7 +92,7 @@ random-session:33333`);
   describe('getStatusForTool', () => {
     describe('Claude status detection', () => {
       test('detects working state', () => {
-        const workingText = 'I am processing your request... esc to interrupt';
+        const workingText = '· Calculating… (12s · ↓ 512 tokens)';
         expect(aiToolService.getStatusForTool(workingText, 'claude')).toBe('working');
       });
 
@@ -109,6 +109,16 @@ random-session:33333`);
       test('detects idle state as default', () => {
         const idleText = '│ >\n│ Type your message';
         expect(aiToolService.getStatusForTool(idleText, 'claude')).toBe('idle');
+      });
+
+      test('idle with ❯ prompt in scrollback alongside numbered list is not waiting', () => {
+        const idleWithScrollback = '1. Fix the bug\n2. Add tests\n3. Update docs\n❯ ';
+        expect(aiToolService.getStatusForTool(idleWithScrollback, 'claude')).toBe('idle');
+      });
+
+      test('idle during active work with numbered plan in scrollback is not waiting', () => {
+        const workingWithPlan = '1. Step one\n2. Step two\n❯ run the plan\n● Bash(npm test)';
+        expect(aiToolService.getStatusForTool(workingWithPlan, 'claude')).toBe('idle');
       });
     });
 

--- a/tests/unit/ai-tool-detection.test.ts
+++ b/tests/unit/ai-tool-detection.test.ts
@@ -23,26 +23,11 @@ describe('AI Tool Detection', () => {
   describe('Claude Detection', () => {
     const claudeScreens = {
       working: `
-Human: Write a function to calculate factorial
+● Bash(npm test)
+  ⎿  Running…
 
-I'll help you write a factorial function. Here's a simple implementation:
-
-\`\`\`python
-def factorial(n):
-    if n < 0:
-        raise ValueError("Factorial is not defined for negative numbers")
-    elif n == 0 or n == 1:
-        return 1
-    else:
-        result = 1
-        for i in range(2, n + 1):
-            result *= i
-        return result
-\`\`\`
-
-This function calculates the factorial of a non-negative integer n.
-
-esc to interrupt`,
+· Calculating… (12s · ↓ 512 tokens)
+  ⎿  Tip: Use /btw to ask a side question`,
       waiting: `
 Human: What would you like me to help you with?
 


### PR DESCRIPTION
- Fix false positive "waiting" for idle Claude sessions: combined the
  separate ❯ and numbered-list checks into a single regex that requires
  both on the same line, preventing scrollback content from triggering it
- Fix "working" detection: replace 'esc to interrupt' (no longer shown by
  Claude Code) with '… (' which matches all rotating-verb timing lines
- Remove dead CLAUDE_PATTERNS constant and waiting_numbered fields from
  AI_TOOLS statusPatterns
- Hoist CLAUDE_WAITING_RE to module scope for clarity and efficiency

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
