### PR TITLE
docs: add full docs handbook and fix stale AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,8 +1,10 @@
 # Coding Agent Team - Developer Guide
 
+> For a complete and accurate architecture reference, read [`docs/README.md`](docs/README.md) first. The sections below are a quick-start guide; `docs/` is the authoritative source.
+
 ## Project Overview
 
-A CLI-based tmux session manager built with TypeScript, React, and Ink. This tool manages development sessions for feature branches across multiple projects, integrating with git worktrees and Claude AI.
+A CLI tool that coordinates git worktrees, tmux sessions, AI agents (Claude/Gemini), and GitHub PR state across one or more projects. It is more than a worktree manager — it is a workspace coordinator for multi-repo AI-assisted development.
 
 ## Architecture
 
@@ -32,63 +34,48 @@ Each worktree gets associated tmux sessions:
 - Shell session: `dev-{project}-{feature}-shell` (for terminal work)
 - Run session: `dev-{project}-{feature}-run` (for executing commands)
 
-#### 3. **Claude Integration**
-The app monitors Claude AI status in tmux panes:
+#### 3. **AI Tool Integration**
+The app supports multiple AI CLIs (Claude, Gemini) and monitors AI status in tmux panes:
 - Working: Shows "esc to interrupt"
 - Waiting: Shows numbered prompt (e.g., "1. ")
 - Idle: Shows standard prompt
 - Thinking: Shows thinking indicator
+
+Tool preference is stored per-project in `.devteam/config.json`.
 ## Project Structure
+
+See [`docs/reference/code-map.md`](docs/reference/code-map.md) for the full file map. Key layout:
 
 ```
 src/
-├── index.ts                 # Entry point
-├── bootstrap.tsx           # App bootstrap (Ink render)
-├── App.tsx                 # Main React component
-├── bin/                    # CLI binary
-│   └── devteam.ts          # CLI executable
-├── components/             # React/Ink UI components
-│   ├── common/            # Shared components
-│   ├── dialogs/           # Modal dialogs
-│   └── views/             # Main views
-├── contexts/              # React contexts (State + Operations)
-│   ├── WorktreeContext.tsx    # Worktree state and operations
-│   ├── GitHubContext.tsx      # PR status and GitHub operations
-│   └── UIContext.tsx          # UI navigation and dialog state
-├── hooks/                 # React hooks
-│   ├── useKeyboardShortcuts.ts  # Keyboard handling
-│   ├── usePRStatus.ts          # PR status fetching
-│   └── useWorktrees.ts         # Worktree management
-├── screens/               # Full-screen components
-│   ├── WorktreeListScreen.tsx   # Main list view
-│   ├── CreateFeatureScreen.tsx  # Feature creation
-│   ├── ArchiveConfirmScreen.tsx # Archive confirmation
-│   └── ArchivedScreen.tsx       # Archived items view
-├── services/              # Stateless data operations
-│   ├── GitService.ts           # Local git operations
-│   ├── GitHubService.ts        # GitHub API operations
-│   ├── TmuxService.ts          # Tmux session management
-│   └── WorktreeService.ts      # Git + Tmux orchestration
-├── shared/utils/          # Utility functions
-│   ├── commandExecutor.ts      # Process execution
-│   ├── fileSystem.ts           # File operations
-│   ├── formatting.ts           # String formatting
-│   └── gitHelpers.ts           # Git utilities
-├── models.ts              # Data models/classes
-├── constants.ts           # App constants
-└── ops.ts                 # Complex operations
+├── App.tsx                 # Root component; provider nesting
+├── bootstrap.tsx           # Ink render entry
+├── bin/devteam.ts          # CLI executable
+├── cores/                  # Core engine classes (business logic, no React)
+│   ├── WorktreeCore.ts     # Worktree list, sessions, git status
+│   └── GitHubCore.ts       # PR status, cache, GitHub operations
+├── engine/core-types.ts    # CoreBase<T> interface
+├── contexts/               # React wrappers around Core engines
+│   ├── WorktreeContext.tsx
+│   ├── GitHubContext.tsx
+│   ├── UIContext.tsx        # Navigation state machine (no Core behind it)
+│   └── InputFocusContext.tsx
+├── screens/                # Three full-screen components
+│   ├── WorktreeListScreen.tsx
+│   ├── CreateFeatureScreen.tsx
+│   └── ArchiveConfirmScreen.tsx
+├── services/               # Stateless external I/O (git, tmux, gh, disk)
+├── components/             # UI components (dialogs, views, common)
+├── hooks/                  # useKeyboardShortcuts and others
+├── models.ts               # WorktreeInfo, PRStatus, GitStatus, SessionInfo
+└── constants.ts            # AI_TOOLS, refresh intervals
 
 tests/
-├── fakes/                 # Fake service implementations
-│   ├── FakeGitService.ts       # In-memory git
-│   ├── FakeTmuxService.ts      # In-memory tmux
-│   ├── FakeWorktreeService.ts  # In-memory worktree
-│   └── stores.ts               # Memory data stores
-├── utils/                 # Test utilities
-│   ├── renderApp.tsx           # Test app rendering
-│   └── testHelpers.ts          # Setup helpers
-├── unit/                  # Unit tests
-└── e2e/                   # End-to-end tests
+├── fakes/                  # In-memory service implementations
+│   └── stores.ts           # Shared memory data stores
+├── utils/renderApp.tsx     # Test app renderer
+├── unit/                   # Unit tests
+└── e2e/                    # E2E tests (mock-rendered + terminal/)
 ```
 
 ## Coding Conventions
@@ -139,20 +126,14 @@ tests/
    }
    ```
 
-6. **Context Providers**: Use React Context for state + operations
+6. **Context Providers**: Subscribe to a Core engine; re-render on state change
    ```tsx
    export function WorktreeProvider({children}) {
-     const [worktrees, setWorktrees] = useState([]);
-     const gitService = new GitService();
-     const tmuxService = new TmuxService();
-     
-     const createFeature = async (project, name) => {
-       await gitService.createWorktree(project, name);
-       await tmuxService.createSession(project, name);
-       refresh();
-     };
-     
-     const value = { worktrees, createFeature, refresh };
+     const [state, setState] = useState(() => core.getState());
+
+     useEffect(() => core.subscribe(setState), []);
+
+     const value = { ...state, createFeature: core.createFeature.bind(core) };
      return (
        <WorktreeContext.Provider value={value}>
          {children}
@@ -165,27 +146,35 @@ tests/
 
 - **Files**: camelCase for `.ts`, PascalCase for `.tsx`
 - **Components**: PascalCase (e.g., `WorktreeListScreen`)
-- **Hooks**: `use` prefix (e.g., `useWorktrees`)
+- **Hooks**: `use` prefix (e.g., `useKeyboardShortcuts`)
 - **Services**: PascalCase with `Service` suffix
 - **Constants**: UPPER_SNAKE_CASE
 - **Interfaces**: PascalCase, often with `Info` or `State` suffix
 
 ### Architecture Layers
 
-1. **Service Layer** (Stateless Data Operations):
+1. **Service Layer** (Stateless External I/O):
    - **GitService**: Local git operations (worktrees, branches, status, diff)
    - **GitHubService**: GitHub API operations (PRs, checks, issues)
    - **TmuxService**: Tmux session management
-   - **WorktreeService**: Orchestrates git + tmux operations
-   - Services are stateless and only fetch/transform data
+   - **WorkspaceService**: Workspace layout and disk operations
+   - **PRStatusCacheService**: Disk cache for PR data
+   - **AIToolService**: AI tool detection and preference
+   - Services are stateless and only fetch/transform data; no mutable state
 
-2. **Context Layer** (State Management + Operations):
-   - **WorktreeContext**: Manages worktree state and operations
-   - **GitHubContext**: Manages PR status cache and GitHub operations
-   - **UIContext**: Manages UI navigation and dialog state
-   - Contexts combine state management with operation methods
+2. **Core Engine Layer** (Business Logic + State):
+   - **WorktreeCore**: Owns worktree list, git status, session state; runs refresh loops
+   - **GitHubCore**: Owns PR status; manages cache, throttled batch fetching
+   - Cores implement `CoreBase<T>` with `subscribe(fn)` for React observation
+   - No React dependency; fully testable as plain TypeScript
 
-3. **Component Layer**: Thin components that use contexts
+3. **Context Layer** (React Wrappers):
+   - **WorktreeContext**: Subscribes to WorktreeCore; exposes state + operations as hooks
+   - **GitHubContext**: Subscribes to GitHubCore; exposes PR operations
+   - **UIContext**: Pure React state machine for navigation (no Core behind it)
+   - **InputFocusContext**: Tracks which component owns keyboard focus
+
+4. **Component Layer**: Thin components that use contexts; no business logic
 
 ## Testing Approach
 
@@ -284,30 +273,17 @@ export class MyService {
 }
 ```
 
-### 3. New Context (State + Operations)
+### 3. New Context (React wrapper around a Core engine)
 
 Create in `src/contexts/`:
 ```typescript
 export function MyContextProvider({children}) {
-  const [data, setData] = useState([]);
-  const [loading, setLoading] = useState(false);
-  
-  const myService = new MyService();
-  
-  const loadData = async () => {
-    setLoading(true);
-    const result = await myService.fetchData();
-    setData(result);
-    setLoading(false);
-  };
-  
-  const createItem = async (item) => {
-    await myService.createItem(item);
-    loadData(); // Refresh state
-  };
-  
-  const value = { data, loading, loadData, createItem };
-  return h(MyContext.Provider, {value}, children);
+  const [state, setState] = useState(() => myCore.getState());
+
+  useEffect(() => myCore.subscribe(setState), []);
+
+  const value = { ...state, doThing: myCore.doThing.bind(myCore) };
+  return <MyContext.Provider value={value}>{children}</MyContext.Provider>;
 }
 ```
 
@@ -496,9 +472,9 @@ npm link            # Install globally as 'devteam'
 
 ### Architecture
 1. **Services are stateless** - only fetch and transform data
-2. **Contexts manage state** - combine state with operation methods
-3. **Clear separation** - GitService (local) vs GitHubService (API)
-4. **No dependency injection** - services instantiated directly in contexts
+2. **Core engines own state** - business logic and refresh loops live in `src/cores/`
+3. **Contexts are thin wrappers** - subscribe to a Core, expose state + operations via hooks
+4. **Clear separation** - GitService (local git) vs GitHubService (GitHub API)
 
 ### Implementation  
 5. **Always use absolute paths** in file operations

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,42 @@
+# DevTeam Docs
+
+DevTeam is a CLI tool that coordinates git worktrees, tmux sessions, AI agents, and GitHub PR state across one or more projects.
+
+## Start here
+
+For a mental model of how the pieces fit together: [architecture/overview.md](architecture/overview.md)
+
+For what the key terms mean: [concepts/projects-worktrees-workspaces.md](concepts/projects-worktrees-workspaces.md)
+
+For a map of the codebase: [reference/code-map.md](reference/code-map.md)
+
+## By topic
+
+### Architecture
+- [overview.md](architecture/overview.md) — major components and boundaries
+- [state-and-data-flow.md](architecture/state-and-data-flow.md) — Core engines, contexts, refresh loops
+- [filesystem-and-layout.md](architecture/filesystem-and-layout.md) — directory conventions and persisted files
+- [tmux-and-ai-sessions.md](architecture/tmux-and-ai-sessions.md) — session naming, status polling, AI tool integration
+- [github-and-pr-caching.md](architecture/github-and-pr-caching.md) — PR cache, invalidation, refresh strategy
+- [testing-strategy.md](architecture/testing-strategy.md) — unit, E2E, and terminal test layers
+
+### Concepts
+- [projects-worktrees-workspaces.md](concepts/projects-worktrees-workspaces.md) — stable nouns and their invariants
+- [project-config.md](concepts/project-config.md) — `.devteam/config.json` structure and AI editing
+- [status-model.md](concepts/status-model.md) — git, session, and PR status fields
+
+### Features
+- [feature-creation.md](features/feature-creation.md)
+- [session-lifecycle.md](features/session-lifecycle.md)
+- [diff-review-comments.md](features/diff-review-comments.md)
+- [branch-picking.md](features/branch-picking.md)
+- [settings-ai-editing.md](features/settings-ai-editing.md)
+- [archive-and-restore.md](features/archive-and-restore.md)
+
+### Reference
+- [code-map.md](reference/code-map.md) — if you need X, open these files
+- [glossary.md](reference/glossary.md)
+- [decisions.md](reference/decisions.md) — non-obvious design choices
+
+### Operations
+- [release-and-version-check.md](operations/release-and-version-check.md)

--- a/docs/architecture/filesystem-and-layout.md
+++ b/docs/architecture/filesystem-and-layout.md
@@ -1,0 +1,65 @@
+# Filesystem and Layout
+
+## Projects directory
+
+The app is given a root directory (via `--dir`, `PROJECTS_DIR`, or cwd). It expects this layout:
+
+```
+{root}/
+  {project}/                          # main worktree (default branch)
+  {project}-branches/
+    {feature}/                        # feature worktree
+    {feature2}/
+  {project}-archived/
+    archived-{timestamp}_{feature}/   # archived worktree
+```
+
+Multiple projects can coexist under the same root. The app discovers them by scanning for directories that match this naming pattern.
+
+## Per-worktree files
+
+DevTeam copies these files into each new feature worktree at creation time:
+
+| File | Purpose |
+|------|---------|
+| `.env.local` | Environment variables |
+| `.claude/settings.local.json` | AI tool settings (Claude) |
+| `CLAUDE.md` | AI context document for Claude |
+
+Source is always the main worktree of the same project.
+
+## Project config
+
+Each project stores its config at `{project-root}/.devteam/config.json`. This is created by the settings/AI editing workflow. See [concepts/project-config.md](../concepts/project-config.md).
+
+## PR disk cache
+
+`PRStatusCacheService` writes PR status to disk. Cache entries are keyed by `{worktree-path}:{commit-hash}`. A cache hit is valid only when the current HEAD commit matches the cached commit, so merges and new commits automatically invalidate it.
+
+Location: inside the worktree directory (exact path is internal to `PRStatusCacheService`).
+
+## Logs
+
+```
+{cwd}/logs/
+  console.log   # all console output
+  errors.log    # errors and stack traces
+```
+
+Logs rotate at 10 MB, keeping the old file with a timestamp suffix.
+
+## tmux session naming
+
+Sessions are named deterministically so the app can re-attach without storing IDs:
+
+```
+dev-{project}-{feature}           # AI agent session
+dev-{project}-{feature}-shell     # shell session
+dev-{project}-{feature}-run       # run/command session
+```
+
+For workspaces (multi-project):
+
+```
+dev-workspace-{workspace-name}    # single shared session
+```

--- a/docs/architecture/github-and-pr-caching.md
+++ b/docs/architecture/github-and-pr-caching.md
@@ -1,0 +1,31 @@
+# GitHub and PR Caching
+
+## Overview
+
+`GitHubCore` manages PR status for all visible worktrees. It batches GitHub API calls, caches results on disk, and throttles refreshes to avoid rate limits.
+
+## Cache design
+
+`PRStatusCacheService` stores `PRStatus` objects keyed by `{worktree-path}:{commit-hash}`.
+
+**Invalidation rule:** a cache entry is valid only when the worktree's current HEAD commit matches the cached commit. A new commit or a merge automatically causes a cache miss on the next poll.
+
+This means:
+- Reading PRs is fast (disk hit) when code hasn't changed.
+- No manual cache busting is needed; git history drives freshness.
+
+## Refresh strategy
+
+GitHubCore tracks which worktrees are currently visible on screen (`visibleWorktrees`). Only those paths are polled on each refresh cycle (~30 s). When the user scrolls, `setVisibleWorktrees()` updates the set.
+
+Batch fetches call `gh pr list` or `gh pr view` via `GitHubService`. Results are merged into the `pullRequests` map and written to the disk cache.
+
+Rate-limit avoidance: the refresh interval is deliberately long to avoid GitHub API rate limits in multi-project setups with many worktrees. See `src/cores/GitHubCore.ts` for current interval constants.
+
+## PRStatus model
+
+See [concepts/status-model.md](../concepts/status-model.md) for the full `PRStatus` definition.
+
+## PR operations
+
+`GitHubContext` exposes `createPR()` and `mergePR()`. Both call through to `GitHubService` which shells out to `gh pr create` / `gh pr merge`. After a successful operation the cache entry for the affected worktree is cleared and a refresh is triggered.

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -1,0 +1,71 @@
+# Architecture Overview
+
+DevTeam coordinates four external systems — git, tmux, AI CLIs, and GitHub — through a React/Ink CLI interface.
+
+## Major components
+
+```
+┌─────────────────────────────────────────────────────┐
+│  Ink CLI (React for terminals)                      │
+│                                                     │
+│  App.tsx                                            │
+│  ├─ InputFocusProvider                              │
+│  ├─ GitHubProvider  (GitHubCore engine)             │
+│  └─ WorktreeProvider (WorktreeCore engine)          │
+│      └─ UIProvider   (navigation state machine)     │
+│          └─ AppContent (screen router)              │
+└─────────────────────────────────────────────────────┘
+          │                    │
+    WorktreeCore          GitHubCore
+          │                    │
+    ┌─────┴──────┐       ┌────┴──────────┐
+    │  Services  │       │  PRStatusCache │
+    │  Git       │       │  GitHubService │
+    │  Tmux      │       └───────────────┘
+    │  Workspace │
+    │  AITool    │
+    └────────────┘
+```
+
+## Boundaries
+
+**Core engines** (`src/cores/`) hold all mutable state and business logic. They are plain TypeScript classes that implement `CoreBase<T>` and expose a `subscribe(fn)` method for React to observe.
+
+**Contexts** (`src/contexts/`) are thin React wrappers around Core engines. They call `useEffect` to subscribe to the Core and re-render on state change. All operations the UI needs are re-exported from the context.
+
+**Services** (`src/services/`) are stateless. They execute external commands (git, tmux, gh CLI) and return data. They hold no mutable state and have no knowledge of React.
+
+**Screens** (`src/screens/`) and **components** (`src/components/`) are pure UI. They read state and dispatch operations through contexts; they contain no business logic.
+
+**UIContext** is the exception: it is a pure React state machine with no Core engine behind it. It owns only navigation mode and transient dialog data.
+
+## Data flow
+
+```
+External system (git/tmux/github)
+   → Service method (fetch/parse)
+   → Core engine (update state, notify subscribers)
+   → Context (re-render React tree)
+   → Screen/component (display)
+```
+
+User actions flow in reverse: keyboard shortcut → context method → Core method → Service call → state update → re-render.
+
+## Screens
+
+Three full-screen components exist:
+- `WorktreeListScreen` — main list; always rendered, shown/hidden by UI mode
+- `CreateFeatureScreen` — multi-project worktree creation
+- `ArchiveConfirmScreen` — archive confirmation with untracked file warning
+
+All other views (diff, dialogs, overlays) are rendered as layered components on top of the list screen, not as separate screens.
+
+## Source of truth
+
+| Data | Owner |
+|------|-------|
+| Worktree list, git status, session status | `WorktreeCore` |
+| PR status | `GitHubCore` + disk cache (`PRStatusCacheService`) |
+| UI navigation mode | `UIContext` |
+| Project config | `.devteam/config.json` on disk |
+| AI tool preference | `.devteam/config.json` (written by `AIToolService`) |

--- a/docs/architecture/state-and-data-flow.md
+++ b/docs/architecture/state-and-data-flow.md
@@ -1,0 +1,93 @@
+# State and Data Flow
+
+## Core Engine Pattern
+
+Both `WorktreeCore` and `GitHubCore` implement `CoreBase<T>` from `src/engine/core-types.ts`:
+
+```typescript
+interface CoreBase<T> {
+  getState(): T;
+  subscribe(fn: (state: T) => void): () => void;  // returns unsubscribe fn
+}
+```
+
+Context providers subscribe on mount and call `setState` on every emission:
+
+```typescript
+useEffect(() => {
+  return core.subscribe(state => setLocalState(state));
+}, []);
+```
+
+This keeps React concerns out of the business logic and makes Cores testable without React.
+
+## WorktreeCore state
+
+```typescript
+{
+  worktrees: WorktreeInfo[];   // sorted, workspace-grouped list
+  loading: boolean;
+  lastRefreshed: number;
+  selectedIndex: number;
+  memoryStatus: MemoryStatus | null;
+  versionInfo: any | null;
+}
+```
+
+**Refresh loops inside WorktreeCore:**
+- AI/session status: every ~2 s (only visible rows)
+- Git status: every ~5 s
+- Full refresh (discovers new worktrees): every ~30 s
+- Memory check: every ~30 s
+
+`refreshVisibleStatus()` and `forceRefreshVisible()` are also called explicitly after navigation events.
+
+## GitHubCore state
+
+```typescript
+{
+  pullRequests: Record<string, PRStatus>;  // keyed by worktree path
+  loading: boolean;
+  lastUpdated: number;
+  visibleWorktrees: string[];              // paths currently on screen
+}
+```
+
+**Refresh strategy:** GitHubCore only refreshes PRs for currently-visible worktrees. When the visible set changes (user scrolls), `setVisibleWorktrees()` is called and the next poll fetches only those paths. Batch fetches are throttled to reduce GitHub API calls. Results are written to a disk cache (`PRStatusCacheService`) keyed by commit hash; stale cache entries are invalidated when the commit hash changes.
+
+## UIContext state machine
+
+UIContext holds a single `mode` string plus per-mode auxiliary data:
+
+```
+'list'                 → main view (no auxiliary data)
+'create'               → createProjects: ProjectInfo[]
+'confirmArchive'       → pendingArchive: WorktreeInfo
+'help'                 → (none)
+'pickProjectForBranch' → createProjects: ProjectInfo[]
+'pickBranch'           → branchProject, branchList
+'diff'                 → diffWorktree, diffType
+'selectAITool'         → pendingWorktree: WorktreeInfo
+'tmuxAttachLoading'    → (none, brief overlay)
+'noProjects'           → (none)
+'info'                 → info: string
+'settings'             → settingsProject, settingsAIResult
+```
+
+Transitions always go through a named method (`showList()`, `showDiffView()`, etc.) that sets mode and clears unrelated auxiliary data.
+
+`resetUIState()` clears transient data but preserves `settingsAIResult` so an in-flight AI settings operation can complete even if the user navigates away.
+
+## Keyboard input
+
+`useKeyboardShortcuts` in `WorktreeListScreen` handles all global keys. It reads current UI mode from `UIContext` and dispatches to `WorktreeContext` or `UIContext` accordingly. Dialogs and overlays request focus via `InputFocusContext` to capture keys before the global handler sees them.
+
+## Provider nesting order
+
+```
+InputFocusProvider        (must be outermost — focus state is global)
+  GitHubProvider          (independent of worktree state)
+    WorktreeProvider      (may read GitHub context for PR data)
+      UIProvider          (needs both for navigation guards)
+        AppContent
+```

--- a/docs/architecture/testing-strategy.md
+++ b/docs/architecture/testing-strategy.md
@@ -1,0 +1,63 @@
+# Testing Strategy
+
+## Three test layers
+
+### 1. Unit tests (`tests/unit/`)
+
+Test services and Core engines in isolation with fake implementations.
+
+```typescript
+test('creates worktree', async () => {
+  const git = new FakeGitService();
+  const core = new WorktreeCore({ gitService: git });
+  await core.createFeature('myproject', 'my-feature');
+  expect(git.store.worktrees).toHaveLength(1);
+});
+```
+
+Fakes live in `tests/fakes/`. Each fake implements the same interface as its real counterpart but operates on in-memory stores (`tests/fakes/stores.ts`).
+
+### 2. E2E tests (`tests/e2e/`)
+
+Full user workflows using `tests/utils/renderApp.tsx`. The app renders with real React/Ink but uses fake services instead of real git/tmux/GitHub. Tests interact via `stdin` writes and assert on rendered output.
+
+```typescript
+const { lastFrame, stdin } = renderApp({ fakeGit, fakeTmux });
+stdin.write('n');           // open create dialog
+await delay(100);
+stdin.write('\r');          // select project
+expect(lastFrame()).toContain('my-feature');
+```
+
+This layer catches cross-component bugs that unit tests miss while remaining fast and deterministic.
+
+### 3. Terminal tests (`tests/e2e/terminal/`)
+
+Node scripts (not Jest) that render real Ink components in a real TTY to verify terminal output. These exist because Jest's TTY/raw-mode handling is unreliable for Ink.
+
+Scripts import from `dist/` and `dist-tests/`; run `npm run test:terminal` which compiles both before executing.
+
+Current scripts:
+- `run-smoke.mjs` — Ink `<Text>` renders
+- `run-mainview-list.mjs` — main list rows appear
+- `run-app-full.mjs` — full app with providers renders
+
+### Running tests
+
+```bash
+npm test                  # unit + E2E (Jest)
+npm run test:watch        # Jest watch
+npm run typecheck         # TypeScript only
+npm run test:terminal     # terminal rendering (Node runner)
+```
+
+## Fake service design
+
+Fakes use shared in-memory `stores.ts` objects so multiple fakes can observe the same state (e.g., `FakeGitService` and `FakeWorktreeService` share the same worktree store). This keeps E2E tests coherent without real filesystem operations.
+
+## Philosophy
+
+- Mock only at the external boundary (git, tmux, gh CLI).
+- Run real app logic and real React components in tests.
+- Test through user interactions (keyboard input), not internal implementation.
+- Prefer E2E tests for cross-service flows; unit tests for edge cases in a single service.

--- a/docs/architecture/tmux-and-ai-sessions.md
+++ b/docs/architecture/tmux-and-ai-sessions.md
@@ -1,0 +1,46 @@
+# Tmux and AI Sessions
+
+## Session types per worktree
+
+Each feature worktree can have up to three tmux sessions:
+
+| Session suffix | Purpose | Attach shortcut |
+|---|---|---|
+| (none) | AI agent (Claude or Gemini) | `a` |
+| `-shell` | Interactive terminal | `s` |
+| `-run` | Running a command/server | `r` |
+
+Sessions are created lazily: the agent session is created at feature-creation time; shell and run sessions are created on first attach.
+
+## AI status polling
+
+`TmuxService` polls the visible pane output every ~2 s to determine AI status. It looks for known strings in the last few lines:
+
+| Text found | `ai_status` |
+|---|---|
+| `esc to interrupt` | `working` |
+| Numbered prompt like `1. ` | `waiting` |
+| Thinking indicator | `thinking` |
+| Standard shell prompt | `idle` |
+
+The status drives the indicator shown next to each worktree row in the list.
+
+## AI tool abstraction
+
+`AIToolService` (`src/services/AIToolService.ts`) abstracts over multiple AI CLIs (currently Claude and Gemini). It:
+
+- Detects which tools are installed (`getAvailableAITools()`)
+- Reads the stored preference from `.devteam/config.json`
+- Provides `needsToolSelection()` to gate the attach flow
+
+If multiple tools are available and no preference is stored, the UI shows the `selectAITool` dialog before attaching.
+
+The `AI_TOOLS` constant in `src/constants.ts` lists all supported tools and their launch commands.
+
+## Workspace sessions
+
+A workspace is a single tmux session that opens panes for multiple projects side by side. `WorkspaceService` constructs the layout. See [features/session-lifecycle.md](../features/session-lifecycle.md) for the user flow.
+
+## tmuxAttachLoading mode
+
+Attaching to a tmux session temporarily exits the Ink rendering loop (the terminal is handed to tmux). UIContext's `tmuxAttachLoading` mode shows a minimal overlay before the handoff. After the user detaches from tmux, the app re-renders.

--- a/docs/concepts/project-config.md
+++ b/docs/concepts/project-config.md
@@ -1,0 +1,36 @@
+# Project Config
+
+Each project stores its config at `{project-root}/.devteam/config.json`.
+
+## Structure
+
+The config is a JSON object written and read by `AIToolService` and `WorktreeCore`. Fields currently used:
+
+```json
+{
+  "aiTool": "claude",          // preferred AI CLI for this project
+  "workspace": "my-workspace", // workspace name if part of a workspace
+  "workspaceChildren": [       // list of child worktree feature names
+    "project-b/my-feature"
+  ]
+}
+```
+
+The schema is intentionally loose; the app reads only the fields it knows about and ignores others.
+
+## AI editing
+
+The settings workflow lets users generate or edit the config with an AI agent. See [features/settings-ai-editing.md](../features/settings-ai-editing.md) for the user flow.
+
+`WorktreeCore` exposes:
+- `readConfigContent(project)` — reads raw JSON string
+- `generateConfigWithAI(project)` — AI creates a new config from scratch
+- `editConfigWithAI(project, instructions)` — AI edits existing config
+
+Under the hood these open a tmux session where the AI agent edits the file, then the session is closed and the app re-reads the file.
+
+## File copying
+
+When a new feature worktree is created, `.devteam/config.json` from the main worktree is **not** automatically copied. The settings in the main worktree's config apply to the project as a whole, not to individual feature branches.
+
+The files that **are** copied to new worktrees are listed in [architecture/filesystem-and-layout.md](../architecture/filesystem-and-layout.md).

--- a/docs/concepts/projects-worktrees-workspaces.md
+++ b/docs/concepts/projects-worktrees-workspaces.md
@@ -1,0 +1,69 @@
+# Projects, Worktrees, and Workspaces
+
+## Project
+
+A **project** is a git repository. DevTeam discovers projects by scanning the root directory for directories that match the naming convention. The main worktree for a project lives at `{root}/{project-name}/`.
+
+`ProjectInfo`:
+```typescript
+{ name: string; path: string; }
+```
+
+## Worktree
+
+A **worktree** is a checked-out branch in a separate directory, managed by `git worktree`. Each worktree:
+- Has its own working tree and HEAD
+- Shares the git object store with the main worktree
+- Can have its own tmux sessions
+
+Feature worktrees live at `{root}/{project-name}-branches/{feature-name}/`.
+
+`WorktreeInfo` is the central model. Key fields:
+
+```typescript
+{
+  project: string;       // project name
+  feature: string;       // branch / feature name
+  path: string;          // absolute path on disk
+  branch: string;        // git branch name
+
+  git: GitStatus;        // ahead/behind, modified files, etc.
+  session: SessionInfo;  // tmux session state and AI status
+  pr?: PRStatus;         // GitHub PR (loaded async)
+
+  // workspace fields — only set for workspace rows
+  is_workspace: boolean;
+  is_workspace_header: boolean;
+  is_workspace_child: boolean;
+  parent_feature?: string;
+  children?: WorktreeInfo[];
+  is_last_workspace_child: boolean;
+}
+```
+
+## Workspace
+
+A **workspace** groups multiple worktrees from different projects into a single tmux session. It represents a cross-repo feature being worked on together.
+
+In the list view, workspaces appear as header rows with their children indented below. The header row shows aggregate status; child rows show per-worktree status.
+
+Workspace membership is stored in `.devteam/config.json`. A worktree is a workspace child if its `parent_feature` field is set.
+
+`is_workspace_header` rows are not real worktrees on disk — they are synthetic list rows inserted by `WorktreeCore` for display grouping.
+
+## Session
+
+A **session** is a tmux session attached to a worktree. Each worktree can have:
+- An AI agent session (default)
+- A shell session (`-shell` suffix)
+- A run session (`-run` suffix)
+
+See [status-model.md](status-model.md) for the `SessionInfo` field definitions.
+
+## Invariants
+
+- A project always has exactly one main worktree.
+- Feature worktrees are always in `{project}-branches/`.
+- Archived worktrees are always in `{project}-archived/` and are not shown in the list.
+- Workspace headers always appear before their children in the list.
+- `WorktreeInfo.path` is always an absolute path.

--- a/docs/concepts/status-model.md
+++ b/docs/concepts/status-model.md
@@ -1,0 +1,75 @@
+# Status Model
+
+Three independent status objects attach to each `WorktreeInfo`.
+
+## GitStatus
+
+Represents local git state. Set by `GitService` during refresh.
+
+```typescript
+{
+  has_changes: boolean;      // any uncommitted changes
+  modified_files: number;
+  added_lines: number;
+  deleted_lines: number;
+  untracked_files: string[]; // relevant for archive safety check
+
+  has_remote: boolean;
+  ahead: number;             // commits ahead of remote
+  behind: number;            // commits behind remote
+  is_pushed: boolean;        // ahead === 0
+}
+```
+
+`needs_attention` on `WorktreeInfo` returns true if `has_changes || !is_pushed`.
+
+## SessionInfo
+
+Represents tmux session state. Polled by `TmuxService` every ~2 s for visible rows.
+
+```typescript
+{
+  session_name: string;
+  attached: boolean;           // someone is currently in this tmux session
+  ai_status: 'working' | 'waiting' | 'thinking' | 'idle' | 'none';
+  ai_tool: string;             // 'claude', 'gemini', etc.
+  shell_attached: boolean;
+  run_attached: boolean;
+}
+```
+
+`ai_status: 'none'` means the session does not exist yet.
+
+## PRStatus
+
+Represents GitHub PR state. Loaded async by `GitHubCore`.
+
+```typescript
+{
+  loadingStatus: 'not_checked' | 'loading' | 'no_pr' | 'exists' | 'error';
+
+  // only present when loadingStatus === 'exists'
+  number?: number;
+  state?: 'OPEN' | 'MERGED' | 'CLOSED';
+  title?: string;
+  checks?: { passing: number; failing: number; pending: number; };
+  mergeable?: 'MERGEABLE' | 'CONFLICTING' | 'UNKNOWN';
+
+  // computed helpers
+  is_merged: boolean;
+  is_open: boolean;
+  needs_attention: boolean;    // open + checks failing or review needed
+  is_ready_to_merge: boolean;  // open + all checks green + mergeable
+}
+```
+
+PRStatus is not computed during the main refresh cycle. It is fetched separately by `GitHubCore` and merged into the worktree model before the context emits a state update.
+
+## action_priority
+
+`WorktreeInfo.action_priority` aggregates all three statuses into a single sort key used to order worktrees by urgency:
+1. PR needs attention
+2. Uncommitted changes
+3. Not pushed
+4. Session active (AI working)
+5. No notable state

--- a/docs/documentation-gap-analysis.md
+++ b/docs/documentation-gap-analysis.md
@@ -1,0 +1,108 @@
+# Documentation Gap Analysis
+
+## Current State
+
+The repo has very little real product or architecture documentation today. The main sources are [README.md](../README.md), [AGENTS.md](../AGENTS.md), [tests/README.md](../tests/README.md), and one narrow doc at [version-check-and-publish.md](./version-check-and-publish.md).
+
+### What is useful
+
+- [README.md](../README.md) explains installation, basic usage, and the product pitch.
+- [AGENTS.md](../AGENTS.md) has good intent: concepts, conventions, and testing philosophy.
+- [version-check-and-publish.md](./version-check-and-publish.md) is a good example of a focused subsystem doc.
+- The code itself is structured enough to document cleanly:
+  - App shell in [src/App.tsx](../src/App.tsx)
+  - State engines in [src/cores/WorktreeCore.ts](../src/cores/WorktreeCore.ts) and [src/cores/GitHubCore.ts](../src/cores/GitHubCore.ts)
+  - UI routing in [src/contexts/UIContext.tsx](../src/contexts/UIContext.tsx)
+  - List screen in [src/screens/WorktreeListScreen.tsx](../src/screens/WorktreeListScreen.tsx)
+  - Diff workflow in [src/components/views/DiffView.tsx](../src/components/views/DiffView.tsx)
+
+### What is inaccurate or stale
+
+- [AGENTS.md](../AGENTS.md) describes files that no longer exist or are no longer the primary architecture: `usePRStatus.ts`, `useWorktrees.ts`, `ArchivedScreen.tsx`, `WorktreeService.ts`.
+- It says the architecture is mainly services plus contexts, but the actual runtime model now centers on `Core` classes exposed through contexts.
+- [tests/README.md](../tests/README.md) is stale. It still talks about old ESM and Jest issues and older test layout, while the repo now has broad unit, E2E, and terminal coverage.
+
+## Big Gaps
+
+The missing docs are mostly architectural, not API-level:
+
+- No system overview explaining the major runtime pieces and how state flows through the app.
+- No concepts doc for `projects`, `worktrees`, `workspaces`, `sessions`, and `project config`.
+- No feature docs for the main workflows:
+  - create feature and multi-project workspace
+  - attach agent, shell, and run sessions
+  - diff review and comment-send loop
+  - branch picker and create-from-remote
+  - settings generation and reapply flow
+  - PR status caching and refresh behavior
+- No doc that explains the current UI mode and state machine.
+- No doc describing how tmux integration actually works.
+- No doc describing what is persisted vs computed vs cached.
+- No doc map for agents telling them where to start reading.
+
+Two especially important undocumented realities:
+
+- The product is now more than a worktree manager. It is a coordinator across git, tmux, AI CLIs, GitHub PR state, and cross-repo workspaces.
+- The code has several important design decisions that deserve high-level docs: `CoreBase` state engines, workspace header rows in the main list, PR disk cache with commit-hash invalidation, AI-tool abstraction, and project-local `.devteam/config.json`.
+
+## Recommended Docs Structure
+
+`README.md` should stay short. `docs/` should become the real handbook.
+
+```text
+docs/
+  README.md
+  architecture/
+    overview.md
+    state-and-data-flow.md
+    filesystem-and-layout.md
+    tmux-and-ai-sessions.md
+    github-and-pr-caching.md
+    testing-strategy.md
+  concepts/
+    projects-worktrees-workspaces.md
+    project-config.md
+    status-model.md
+  features/
+    feature-creation.md
+    session-lifecycle.md
+    diff-review-comments.md
+    branch-picking.md
+    settings-ai-editing.md
+    archive-and-restore.md
+  reference/
+    code-map.md
+    glossary.md
+    decisions.md
+  operations/
+    release-and-version-check.md
+```
+
+### What each area should do
+
+- `docs/README.md`: entrypoint for humans and agents. Start here, then read these few docs first.
+- `architecture/overview.md`: major components, boundaries, and the one-page mental model.
+- `architecture/state-and-data-flow.md`: `App -> contexts -> cores -> services`, refresh loops, cache ownership, and UI modes.
+- `concepts/*.md`: stable nouns and invariants, not implementation details.
+- `features/*.md`: one workflow per file, with goal, user path, main modules, and notable edge cases.
+- `reference/code-map.md`: if you need X, open these files.
+- `reference/decisions.md`: short ADR-style records for non-obvious choices.
+
+## AI-Friendly Documentation Guidelines
+
+For AI readability, keep each doc:
+
+- One topic per file.
+- Front-loaded with a short summary.
+- Explicit about source of truth in code, with file links.
+- Focused on invariants, boundaries, and call paths.
+- Free of low-level mechanics that are already obvious from code.
+- Updated when architecture changes, especially when files move.
+
+## Suggested Next Step
+
+Turn this into an actual docs skeleton and rewrite the stale parts of:
+
+- [README.md](../README.md)
+- [AGENTS.md](../AGENTS.md)
+- [tests/README.md](../tests/README.md)

--- a/docs/features/archive-and-restore.md
+++ b/docs/features/archive-and-restore.md
@@ -1,0 +1,38 @@
+# Archive and Restore
+
+## Archive
+
+Archiving moves a worktree directory to `{root}/{project}-archived/archived-{timestamp}_{feature}/` and removes the git worktree registration. The branch itself is preserved.
+
+### User path
+
+1. Press `x` on a worktree row in the list.
+2. `WorktreeCore` checks for untracked files in the worktree.
+3. UIContext transitions to `confirmArchive` with `pendingArchive` set.
+4. `ArchiveConfirmScreen` shows the worktree name and lists any untracked files (which will be lost).
+5. User confirms; `WorktreeCore.archiveFeature()` is called:
+   - Runs `git worktree remove --force`
+   - Moves the directory to the archived location
+   - Refreshes the list
+6. The worktree disappears from the list.
+
+### Untracked file warning
+
+Untracked files are not tracked by git and will not be recoverable from git history. The archive confirmation screen lists them explicitly so the user can decide whether to commit or discard them first.
+
+### tmux sessions
+
+Archiving does **not** kill tmux sessions. If an agent session is running, it continues until the user kills it manually (`tmux kill-session -t dev-{project}-{feature}`).
+
+## Restore
+
+Archived worktrees can be restored (re-attached as a git worktree) from the branch picker. Press `b` to open the branch picker, select the archived branch, and a new worktree is created.
+
+If the original branch name is already in use by another worktree, a numeric suffix is appended automatically.
+
+## Modules
+
+- `src/screens/ArchiveConfirmScreen.tsx` — confirmation UI
+- `src/cores/WorktreeCore.ts` — `archiveFeature()`
+- `src/services/GitService.ts` — worktree removal
+- `src/contexts/UIContext.tsx` — `showArchiveConfirmation()`

--- a/docs/features/branch-picking.md
+++ b/docs/features/branch-picking.md
@@ -1,0 +1,29 @@
+# Branch Picking
+
+## Goal
+
+Create a new worktree from an existing remote branch, without having to type the branch name manually.
+
+## User path
+
+1. Press `b` on the list screen.
+2. If multiple projects exist, UIContext transitions to `pickProjectForBranch` and a project picker dialog appears.
+3. After selecting a project, UIContext transitions to `pickBranch`.
+4. `WorktreeCore.getRemoteBranches(project)` fetches remote branches via `GitService`.
+5. `BranchPickerDialog` renders a searchable list of remote branches.
+6. User selects a branch; `WorktreeCore.createFromBranch(project, branch)` is called.
+7. A worktree is created at `{root}/{project}-branches/{branch}/` checked out to that branch.
+
+## createFromBranch vs createFeature
+
+`createFromBranch` differs from `createFeature`:
+- It checks out an existing remote branch rather than creating a new one.
+- It does not create a new AI session automatically.
+- If the branch name conflicts with an existing worktree directory, a numeric suffix is appended automatically.
+
+## Modules
+
+- `src/components/dialogs/` — `ProjectPickerDialog`, `BranchPickerDialog`
+- `src/cores/WorktreeCore.ts` — `getRemoteBranches()`, `createFromBranch()`
+- `src/services/GitService.ts` — remote branch listing
+- `src/contexts/UIContext.tsx` — `showBranchPicker()`, `showBranchListForProject()`

--- a/docs/features/diff-review-comments.md
+++ b/docs/features/diff-review-comments.md
@@ -1,0 +1,49 @@
+# Diff Review and Comments
+
+## Goal
+
+View the git diff for a worktree inline in the CLI, annotate lines with comments, and send those comments to the AI agent session.
+
+## User path
+
+1. Press `d` on a worktree row in the list.
+2. UIContext transitions to `diff` mode with `diffWorktree` and `diffType` set.
+3. `DiffView` renders the diff using `GitService.getDiff()`.
+4. User navigates lines with arrow keys, presses `c` to add a comment on the current line.
+5. Comments accumulate in `CommentStoreManager` (in-memory, keyed by worktree path).
+6. User presses `Enter` to send all comments to the AI agent tmux session via `TmuxService.sendKeys()`.
+7. UIContext returns to `list` mode.
+
+## Diff types
+
+`diffType` in UIContext can be:
+- `'staged'` — only staged changes
+- `'unstaged'` — only unstaged changes
+- `'all'` — full working tree diff
+
+The user can cycle between types from within `DiffView`.
+
+## Comment model
+
+```typescript
+class DiffComment {
+  lineNumber: number;
+  lineContent: string;
+  comment: string;
+  file: string;
+}
+
+class CommentStore {
+  worktreePath: string;
+  comments: DiffComment[];
+}
+```
+
+Comments are cleared from memory after they are sent. They are not persisted to disk.
+
+## Modules
+
+- `src/components/views/DiffView.tsx` — UI rendering and keyboard handling
+- `src/services/GitService.ts` — `getDiff()`
+- `src/services/CommentStoreManager.ts` — comment accumulation
+- `src/services/TmuxService.ts` — `sendKeys()` to deliver comments to agent

--- a/docs/features/feature-creation.md
+++ b/docs/features/feature-creation.md
@@ -1,0 +1,34 @@
+# Feature Creation
+
+## Goal
+
+Create one or more git worktrees (one per selected project) for a new feature branch, copy environment files into each, and start an AI agent session.
+
+## User path
+
+1. Press `n` on the list screen.
+2. If no projects are discovered, the `noProjects` dialog appears instead.
+3. `CreateFeatureScreen` shows a project picker (multi-select).
+4. User types a feature name and confirms.
+5. For each selected project, `WorktreeCore.createFeature(project, name)` is called:
+   - Creates git worktree at `{root}/{project}-branches/{name}/`
+   - Copies `.env.local`, `.claude/settings.local.json`, `CLAUDE.md` from the main worktree
+   - Creates tmux session `dev-{project}-{name}`
+6. List refreshes and the new worktrees appear.
+
+## Multi-project creation
+
+Selecting multiple projects in step 3 creates one worktree per project, all using the same feature name. This is the entry point for workspace-style development.
+
+## Modules
+
+- `src/screens/CreateFeatureScreen.tsx` — UI
+- `src/cores/WorktreeCore.ts` — `createFeature()`
+- `src/services/GitService.ts` — `createWorktree()`
+- `src/services/TmuxService.ts` — `createSession()`
+
+## Edge cases
+
+- If the branch name already exists as a git branch, `GitService` returns an error and the screen shows it inline.
+- If the worktree directory already exists on disk, creation fails; the user must delete it manually.
+- Auto-suffix on conflict: when creating a worktree from an archived branch, if the branch name is taken the app auto-appends a numeric suffix.

--- a/docs/features/session-lifecycle.md
+++ b/docs/features/session-lifecycle.md
@@ -1,0 +1,38 @@
+# Session Lifecycle
+
+## Session types
+
+Each worktree supports three tmux sessions. They are created lazily on first attach.
+
+| Key | Session | Suffix |
+|-----|---------|--------|
+| `a` | AI agent | (none) |
+| `s` | Shell | `-shell` |
+| `r` | Run | `-run` |
+
+## Attach flow
+
+1. User presses `a`, `s`, or `r` on a worktree row.
+2. If attaching AI session and multiple AI tools are available with no stored preference, UIContext transitions to `selectAITool` mode. User picks a tool; preference is saved to `.devteam/config.json`.
+3. UIContext transitions to `tmuxAttachLoading` (brief overlay).
+4. `WorktreeCore.attachSession()` (or `attachShellSession()` / `attachRunSession()`) calls `TmuxService.attachSession()`.
+5. Ink rendering pauses; the terminal is handed to tmux.
+6. When user detaches (`Ctrl-b d`), Ink re-renders and `tmuxAttachLoading` clears.
+
+## Workspace sessions
+
+A workspace session (`w` key on a workspace header row) opens a single tmux session with multiple panes — one per child project. `WorkspaceService` builds the pane layout using `tmux split-window` commands.
+
+`WorktreeCore.createWorkspace()` creates the workspace and sets `parent_feature` on each child worktree's config.
+
+## Session naming
+
+Sessions are named deterministically from project + feature name, so the app can re-attach after a restart without storing any session IDs. See [architecture/filesystem-and-layout.md](../architecture/filesystem-and-layout.md).
+
+## AI status in the list
+
+`TmuxService.getAIStatus()` reads the last few lines of the pane buffer and returns `working`, `waiting`, `thinking`, or `idle`. This is polled every ~2 s for visible rows and shown as a status indicator in the list.
+
+## Session cleanup
+
+Sessions are not deleted automatically. Archiving a worktree does not kill its tmux sessions; the user must run `tmux kill-session` manually if desired. This is intentional — an agent may still be running during archive.

--- a/docs/features/settings-ai-editing.md
+++ b/docs/features/settings-ai-editing.md
@@ -1,0 +1,40 @@
+# Settings and AI Editing
+
+## Goal
+
+Let users generate or modify the per-project `.devteam/config.json` using an AI agent, without leaving the CLI.
+
+## User path
+
+1. Press `S` (capital) on a worktree row, or access settings from the info dialog.
+2. UIContext transitions to `settings` mode with `settingsProject` set.
+3. `SettingsDialog` shows current config content (read via `WorktreeCore.readConfigContent()`).
+4. User chooses:
+   - **Generate** — AI creates a new config from scratch
+   - **Edit** — User types instructions; AI edits the existing config
+5. `WorktreeCore.generateConfigWithAI()` or `editConfigWithAI()` is called:
+   - Opens a temporary tmux session
+   - Sends a prompt to the AI agent
+   - Waits for the agent to write the file and exit
+   - Closes the session
+6. UIContext stores the result in `settingsAIResult` (`{ project, success, content, error }`).
+7. The result is shown in the settings dialog or as a notification.
+
+## Re-apply files
+
+After the AI edits config, the user can press **Re-apply** to copy the updated files from the main worktree into all feature worktrees. This is useful when `CLAUDE.md` or other shared files were also updated.
+
+## settingsAIResult persistence
+
+`settingsAIResult` is not cleared by `resetUIState()`. This allows the AI to finish its work even if the user navigates away from the settings dialog. The result is surfaced the next time the settings dialog is opened.
+
+## Timeout
+
+AI editing has a 5-minute timeout. If the agent session does not complete within that window, the operation is marked as failed and the result reflects the error.
+
+## Modules
+
+- `src/components/dialogs/SettingsDialog.tsx` — UI
+- `src/cores/WorktreeCore.ts` — `readConfigContent()`, `generateConfigWithAI()`, `editConfigWithAI()`, `applyConfig()`
+- `src/services/AIToolService.ts` — tool detection
+- `src/contexts/UIContext.tsx` — `beginSettingsAI()`, `finishSettingsAI()`, `clearSettingsAIResult()`

--- a/docs/operations/release-and-version-check.md
+++ b/docs/operations/release-and-version-check.md
@@ -1,0 +1,55 @@
+# Version Update Banner and Publishing Guide
+
+This app shows a brief update notice when a newer version is available on npm, including a short “what’s new” message for quick context.
+
+## How It Works
+
+- Source package: The app checks npm for `@agent-era/devteam` (see `src/constants.ts: PACKAGE_NAME`).
+- When it runs: On startup and every 24 hours (see `VERSION_CHECK_INTERVAL`).
+- Current version: Read from the app’s `package.json` at runtime.
+- Latest version: From `https://registry.npmjs.org/@agent-era/devteam` (`dist-tags.latest`).
+- What’s new message: The first bullet/line under the newest section in `CHANGELOG.md` fetched from unpkg: `https://unpkg.com/@agent-era/devteam@<latest>/CHANGELOG.md`. Falls back to the npm package description if `CHANGELOG.md` is absent.
+
+
+## Authoring “What’s New”
+
+For a clear, one-line summary:
+- Maintain `CHANGELOG.md` using “Keep a Changelog” style with a heading per release.
+- Put a concise first bullet under each release heading. Aim for ~90 characters.
+- Example:
+
+```
+## 0.2.0 - 2025-09-07
+- Add version update banner; fetches notes from CHANGELOG via unpkg
+
+## 0.1.1 - 2025-08-31
+- Improve memory warning thresholds on Linux
+```
+
+Ensure `CHANGELOG.md` is included in the published package (do not exclude it via `.npmignore`, or explicitly list it under `files` in `package.json`).
+
+## Publishing So Clients See Updates
+
+The update banner looks for the latest version of `@agent-era/devteam` on npm. To publish a new version:
+
+1. Update `CHANGELOG.md` with a new release section and a concise first bullet.
+2. Bump the version in `package.json`:
+   - `npm version <patch|minor|major>`
+3. Publish the package under the public scope:
+   - `npm publish --access public`
+
+Notes:
+- The publishing branch (see `feature/npm-publish` in git history) sets up a scoped package, README, and publish config. If you’re publishing from this repo, align `package.json` fields with that branch (name, files, bin, prepublish) when preparing a release to `@agent-era/devteam`.
+- Verify that `CHANGELOG.md` is included in the package tarball (`npm pack`), so the app can fetch it from unpkg.
+
+## Verifying The Release
+
+- Check npm dist-tag:
+  - `curl -s https://registry.npmjs.org/@agent-era%2Fdevteam | jq '."dist-tags".latest'`
+- Check changelog availability over unpkg:
+  - `curl -I https://unpkg.com/@agent-era/devteam@<latest>/CHANGELOG.md`
+- Run the app and confirm the banner shows: `⬆ Update available: vX → vY — <what’s new>`
+
+## Customizing (optional)
+
+- Change the checked package name or check cadence in code if needed.

--- a/docs/reference/code-map.md
+++ b/docs/reference/code-map.md
@@ -1,0 +1,75 @@
+# Code Map
+
+If you need to find or change X, start here.
+
+## Entry points
+
+| What | File |
+|------|------|
+| CLI entry | `src/bin/devteam.ts` |
+| App bootstrap | `src/bootstrap.tsx` |
+| Root React component | `src/App.tsx` |
+
+## State and business logic
+
+| What | File |
+|------|------|
+| Worktree list, sessions, git status | `src/cores/WorktreeCore.ts` |
+| PR status, GitHub cache | `src/cores/GitHubCore.ts` |
+| CoreBase interface | `src/engine/core-types.ts` |
+| UI navigation state machine | `src/contexts/UIContext.tsx` |
+| Worktree context (React wrapper) | `src/contexts/WorktreeContext.tsx` |
+| GitHub context (React wrapper) | `src/contexts/GitHubContext.tsx` |
+| Keyboard focus | `src/contexts/InputFocusContext.tsx` |
+
+## Services (external I/O)
+
+| What | File |
+|------|------|
+| Git operations | `src/services/GitService.ts` |
+| GitHub API (gh CLI) | `src/services/GitHubService.ts` |
+| Tmux sessions | `src/services/TmuxService.ts` |
+| Workspace layout | `src/services/WorkspaceService.ts` |
+| PR disk cache | `src/services/PRStatusCacheService.ts` |
+| AI tool detection | `src/services/AIToolService.ts` |
+| Memory monitoring | `src/services/MemoryMonitorService.ts` |
+| Diff comment store | `src/services/CommentStoreManager.ts` |
+| Version checking | `src/services/VersionCheckService.ts` |
+
+## Data models
+
+| What | File |
+|------|------|
+| WorktreeInfo, PRStatus, GitStatus, SessionInfo, ProjectInfo | `src/models.ts` |
+| App constants (AI_TOOLS, refresh intervals) | `src/constants.ts` |
+| App configuration (projects dir, etc.) | `src/config.ts` |
+
+## Screens
+
+| What | File |
+|------|------|
+| Main worktree list | `src/screens/WorktreeListScreen.tsx` |
+| Feature creation | `src/screens/CreateFeatureScreen.tsx` |
+| Archive confirmation | `src/screens/ArchiveConfirmScreen.tsx` |
+
+## Key components
+
+| What | File |
+|------|------|
+| Diff viewer | `src/components/views/DiffView.tsx` |
+| Global keyboard shortcuts | `src/hooks/useKeyboardShortcuts.ts` |
+| Settings dialog | `src/components/dialogs/SettingsDialog.tsx` |
+| Branch picker | `src/components/dialogs/BranchPickerDialog.tsx` |
+| AI tool picker | `src/components/dialogs/AIToolDialog.tsx` |
+| Help overlay | `src/components/dialogs/HelpOverlay.tsx` |
+
+## Tests
+
+| What | Where |
+|------|-------|
+| Unit tests | `tests/unit/` |
+| E2E tests (React + fakes) | `tests/e2e/` |
+| Terminal rendering tests | `tests/e2e/terminal/` |
+| Fake service implementations | `tests/fakes/` |
+| In-memory data stores for fakes | `tests/fakes/stores.ts` |
+| App renderer for tests | `tests/utils/renderApp.tsx` |

--- a/docs/reference/decisions.md
+++ b/docs/reference/decisions.md
@@ -1,0 +1,65 @@
+# Design Decisions
+
+Short ADR-style records for non-obvious choices.
+
+---
+
+## Core Engine pattern (not custom hooks)
+
+**Decision:** Business logic lives in plain TypeScript classes (`WorktreeCore`, `GitHubCore`) that implement a `CoreBase<T>` observer interface. React contexts subscribe to them.
+
+**Why:** React hooks tie logic to the render lifecycle, making it hard to test without rendering. Cores are testable as plain objects. The observer pattern lets React re-render on state change without polling.
+
+**Trade-off:** Extra indirection (Core → Context → Component). Worth it because Cores can be unit-tested without fake React environments.
+
+---
+
+## PR status in a separate Core
+
+**Decision:** `GitHubCore` is separate from `WorktreeCore`, not a field on the worktree refresh loop.
+
+**Why:** PR fetching is network I/O with its own rate-limit budget. Keeping it separate lets us throttle and batch independently of the local git/tmux polling. It also means a slow GitHub API call does not delay the local refresh.
+
+---
+
+## Disk cache keyed by commit hash
+
+**Decision:** `PRStatusCacheService` stores entries keyed by `{path}:{commitHash}`. No TTL.
+
+**Why:** PR status is invalidated by new commits, not by time. A TTL would either expire too quickly (repeated API calls) or be stale for old commits. Commit-hash keying means reads are cache hits until the user actually pushes new work.
+
+---
+
+## Deterministic tmux session naming
+
+**Decision:** Session names are derived from project + feature name, not stored IDs.
+
+**Why:** The app may restart between user sessions. Storing session IDs would require a persistence layer. Deterministic names let the app re-attach after restart with no state.
+
+**Trade-off:** If the user renames a branch, the old session is orphaned. The app does not clean up orphaned sessions automatically.
+
+---
+
+## Workspace header rows are synthetic
+
+**Decision:** Workspace group headers in the list are `WorktreeInfo` objects with `is_workspace_header: true`, not a separate type.
+
+**Why:** `WorktreeListScreen` renders a flat array of `WorktreeInfo`. A separate type would require union type handling throughout the render path. Synthetic rows with a flag are simpler.
+
+**Trade-off:** Callers must guard against `is_workspace_header` rows when doing operations that only apply to real worktrees.
+
+---
+
+## ArchivedScreen removed
+
+**Decision:** Archived worktrees are not shown in the main list. There is no separate archived view.
+
+**Why:** The archived view added complexity without much utility. Users can restore archived branches via the branch picker (`b`).
+
+---
+
+## GitHub API polling frequency increase
+
+**Decision:** PR refresh interval is deliberately long to reduce GitHub API rate-limit hits.
+
+**Why:** In multi-project setups with many worktrees, a short interval causes consistent rate-limit errors during the workday. The longer interval trades freshness for reliability.

--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -1,0 +1,29 @@
+# Glossary
+
+**Project** — A git repository discovered by scanning the root directory. Always has a main worktree at `{root}/{name}/`.
+
+**Worktree** — A git worktree: a checked-out branch in a separate directory on disk, sharing the object store with the main worktree. In this app, "worktree" usually means a feature worktree at `{root}/{project}-branches/{feature}/`.
+
+**Feature** — The name of a branch and its associated worktree directory. Used interchangeably with "worktree" in UI copy.
+
+**Workspace** — A named group of worktrees from different projects, opened together in a single tmux session with multiple panes.
+
+**Session** — A tmux session. Each worktree can have an AI session, a shell session, and a run session.
+
+**AI status** — The detected state of the AI agent inside a tmux pane: `working`, `waiting`, `thinking`, `idle`, or `none`.
+
+**Core engine** — A plain TypeScript class (`WorktreeCore`, `GitHubCore`) that owns mutable state and exposes it via a `subscribe()` observer pattern. No React dependency.
+
+**Context** — A React Context Provider that wraps a Core engine and makes its state and operations available to the component tree via hooks.
+
+**CoreBase** — The interface that Core engines implement: `getState()` and `subscribe(fn)`.
+
+**PR cache** — The disk-based cache of GitHub PR status, keyed by worktree path + commit hash. Managed by `PRStatusCacheService`.
+
+**Visible worktrees** — The subset of worktrees currently rendered on screen (after pagination). `GitHubCore` only polls PRs for visible worktrees.
+
+**Workspace header** — A synthetic list row in `WorktreeListScreen` that represents a workspace group. Not a real worktree on disk; `is_workspace_header === true`.
+
+**AI tool** — The CLI program used as the AI agent: currently `claude` or `gemini`. Stored in `.devteam/config.json` as `aiTool`.
+
+**action_priority** — A computed field on `WorktreeInfo` that ranks worktrees by urgency for display ordering.

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,247 +1,46 @@
-# E2E Testing Framework
+# Testing
 
-This directory contains a comprehensive end-to-end testing framework for the tmux session manager app, built following the philosophy of minimal mocking and maximum real code execution.
+See [`docs/architecture/testing-strategy.md`](../docs/architecture/testing-strategy.md) for the full testing philosophy and layer overview.
 
-## Architecture Overview
-
-### 🎯 **Testing Philosophy Implementation**
-
-✅ **Minimal Mocking**: Only external dependencies (git, tmux, gh commands) are mocked  
-✅ **Real App Code**: All UI components and business logic run unchanged  
-✅ **In-Memory Database**: Fake services use memory stores instead of external systems  
-✅ **Database Verification**: All tests verify data mutations in memory stores  
-✅ **UI-Driven Testing**: Operations happen through simulated user interactions  
-
-### 📁 **Directory Structure**
-
-```
-tests/
-├── fakes/                 # Fake service implementations
-│   ├── FakeGitService.ts     # Git operations in memory
-│   ├── FakeTmuxService.ts    # Session management in memory
-│   ├── FakeWorktreeService.ts # Worktree orchestration
-│   └── stores.ts             # In-memory data stores
-├── utils/                 # Test utilities
-│   ├── renderApp.tsx        # App rendering with fake services
-│   └── testHelpers.ts       # Setup helpers and assertions
-├── unit/                  # Unit tests
-│   └── services.test.ts     # Service layer testing
-└── e2e/                   # End-to-end tests (UI focused)
-    ├── worktree.test.tsx    # Worktree management flows
-    ├── session.test.tsx     # Session management flows
-    ├── navigation.test.tsx  # UI navigation and shortcuts
-    └── data-flow.test.tsx   # Complete lifecycle testing
-```
-
-## 🚀 **Running Tests**
+## Quick reference
 
 ```bash
-# Run all tests
-npm test
-
-# Run specific test file
-npm test services.test.ts
-
-# Run test pattern
-npm test -- --testNamePattern="should create worktree"
-
-# Watch mode
-npm run test:watch
-
-# Run a subset by name pattern
-npm test -- unit
+npm test                  # unit + E2E (Jest)
+npm run test:watch        # Jest watch mode
+npm run typecheck         # TypeScript only
+npm run test:terminal     # terminal rendering (Node runner, builds first)
 ```
 
-## 🏗️ **Fake Service Architecture**
+## Test layers
 
-### **In-Memory Stores (`stores.ts`)**
+### Unit tests (`tests/unit/`)
 
-Central data storage that replaces real filesystem/database operations:
+Test Core engines and services in isolation using fake implementations.
 
+### E2E tests (`tests/e2e/`)
+
+Full user workflows. The real app renders with fake services (no git/tmux/GitHub). Tests interact via `stdin` writes and assert on rendered output using `tests/utils/renderApp.tsx`.
+
+### Terminal tests (`tests/e2e/terminal/`)
+
+Node scripts (not Jest) that render real Ink components in a real TTY. These exist because Jest's TTY/raw-mode handling is unreliable for Ink. Scripts import from `dist/` and `dist-tests/` — `npm run test:terminal` compiles both before running.
+
+## Fake services
+
+Fakes live in `tests/fakes/`. Each implements the same interface as its real counterpart but operates on shared in-memory stores (`tests/fakes/stores.ts`).
+
+| Fake | Replaces |
+|------|---------|
+| `FakeGitService` | `GitService` |
+| `FakeTmuxService` | `TmuxService` |
+
+Reset stores between tests:
 ```typescript
-export const memoryStore = {
-  projects: Map<string, ProjectInfo>(),
-  worktrees: Map<string, WorktreeInfo>(),
-  sessions: Map<string, SessionInfo>(),
-  prStatus: Map<string, PRStatus>(),
-  gitStatus: Map<string, GitStatus>(),
-  remoteBranches: Map<string, BranchInfo[]>(),
-  archivedWorktrees: Map<string, WorktreeInfo[]>()
-};
+beforeEach(() => resetTestData());
 ```
 
-### **Service Implementations**
+## Philosophy
 
-Each fake service mirrors the real service API exactly:
-
-**`FakeGitService`**
-- ✅ Project discovery from memory
-- ✅ Worktree creation/management
-- ✅ Git status simulation
-- ✅ PR data fetching
-- ✅ Remote branch operations
-- ✅ Archive/delete operations
-
-**`FakeTmuxService`**
-- ✅ Session creation/management
-- ✅ Claude status tracking
-- ✅ Pane capture simulation
-- ✅ Session cleanup
-- ✅ Status transitions
-
-**`FakeWorktreeService`**
-- ✅ Feature creation workflow
-- ✅ Session coordination
-- ✅ Archive operations
-- ✅ Environment setup
-
-## 📝 **Test Examples**
-
-### **Unit Test Example**
-
-```typescript
-test('should create worktree in memory', () => {
-  const gitService = new FakeGitService();
-  setupTestProject('test-project');
-  
-  const result = gitService.createWorktree('test-project', 'new-feature');
-  
-  expect(result).toBe(true);
-  
-  // Verify data in memory store
-  const worktrees = Array.from(memoryStore.worktrees.values());
-  const created = worktrees.find(w => 
-    w.project === 'test-project' && w.feature === 'new-feature'
-  );
-  
-  expect(created).toBeDefined();
-  expect(created?.branch).toBe('new-feature');
-});
-```
-
-### **Service Interaction Example (now E2E or Unit)**
-
-```typescript
-// Service-level workflow as unit
-test('should handle complete worktree lifecycle (service-level)', () => {
-  setupTestProject('full-test');
-  const worktreeService = new FakeWorktreeService(gitService, tmuxService);
-  const created = worktreeService.createFeature('full-test', 'complete-feature');
-  expect(created).not.toBeNull();
-  expect(memoryStore.worktrees.size).toBe(1);
-  expect(memoryStore.sessions.size).toBe(1);
-});
-```
-
-### **E2E Test Example (Conceptual - UI tests have ESM config issues)**
-
-```typescript
-test('should create worktree through UI', async () => {
-  setupBasicProject('my-project');
-  
-  const {stdin, lastFrame} = renderTestApp();
-  
-  // Simulate keyboard interaction
-  stdin.write('n'); // Create new feature
-  stdin.write('\r'); // Select project  
-  stdin.write('new-feature\r'); // Enter feature name
-  
-  await simulateTimeDelay(100);
-  
-  // Verify UI shows new worktree
-  expect(lastFrame()).toContain('my-project/new-feature');
-  
-  // Verify data was created in memory
-  const worktree = expectWorktreeInMemory('my-project', 'new-feature');
-  expect(worktree.branch).toBe('new-feature');
-});
-```
-
-## 🧪 **Test Utilities**
-
-### **Setup Helpers**
-
-```typescript
-// Basic project setup
-setupBasicProject('project-name');
-
-// Project with multiple worktrees
-setupProjectWithWorktrees('project', ['feature-1', 'feature-2']);
-
-// Full worktree with all status data
-setupFullWorktree('project', 'feature', {
-  claudeStatus: 'working',
-  gitOverrides: {has_changes: true, ahead: 2},
-  prOverrides: {number: 123, state: 'OPEN'}
-});
-```
-
-### **Assertion Helpers**
-
-```typescript
-// Verify data exists in memory
-expectWorktreeInMemory('project', 'feature');
-expectSessionInMemory('session-name');
-expectArchivedWorktree('project', 'feature');
-
-// Verify data doesn't exist
-expectWorktreeNotInMemory('project', 'feature');
-expectSessionNotInMemory('session-name');
-```
-
-### **Test Data Management**
-
-```typescript
-beforeEach(() => {
-  resetTestData(); // Clear all memory stores
-});
-```
-
-## ✅ **Working Test Coverage**
-
-**Currently Passing:**
-- ✅ **Unit Tests** (service and state logic)
-- ✅ **E2E Tests** (UI and workflow flows)
-
-**Test Scenarios Covered:**
-1. **Service Operations**
-   - Project discovery and management
-   - Worktree creation and lifecycle
-   - Session management and status tracking
-   - Git status and PR data handling
-   - Archive and cleanup operations
-
-2. **Data Consistency**
-   - Multi-operation workflows
-   - Cross-service coordination
-   - Memory store mutations
-   - Error handling and edge cases
-
-3. **Service + Workflow Flows**
-   - Complete worktree lifecycle (service-level or E2E)
-   - Context-driven operations
-   - Status updates and transitions
-   - Remote branch operations
-
-## 🚧 **Known Issues**
-
-**ESM Configuration Issues with UI Tests:**
-- The E2E tests in `/e2e/` directory may have Jest ESM configuration issues with `ink-testing-library`
-- Unit tests work well; service-level flows can be validated as unit tests
-
-**Potential Solutions:**
-1. Switch to Vitest (better ESM support)
-2. Use different React testing utilities
-3. Update Jest configuration for better ESM handling
-4. Mock ink components directly
-
-## 🎯 **Benefits Achieved**
-
-✅ **Fast Execution**: All operations happen in memory  
-✅ **Deterministic**: Full control over test data and state  
-✅ **Comprehensive**: Tests cover complete application workflows  
-✅ **Maintainable**: Clear separation between real and fake implementations  
-✅ **Debuggable**: Easy to inspect memory store state  
-✅ **Isolated**: Each test starts with clean state  
-
-The framework successfully implements your testing philosophy with minimal external mocking while exercising the complete application stack through realistic service operations and data flows.
+- Mock only at the external boundary (git, tmux, gh CLI).
+- Run real app logic and real React components.
+- Test through keyboard interactions, not internal implementation details.


### PR DESCRIPTION
## Summary

- Adds a complete `docs/` handbook (20 files) covering architecture, concepts, features, reference, and operations — based on the gap analysis in `docs/documentation-gap-analysis.md`
- Fixes stale references in `AGENTS.md`: removes `usePRStatus.ts`, `useWorktrees.ts`, `ArchivedScreen.tsx`, `WorktreeService.ts`; updates architecture layers, context/best-practice examples, and project structure tree to reflect the current Core Engine pattern
- Rewrites `tests/README.md` from 247 stale lines to an accurate 46-line reference

## Key new docs

- `docs/architecture/overview.md` — one-page mental model with component diagram
- `docs/architecture/state-and-data-flow.md` — CoreBase pattern, context subscriptions, UIContext state machine
- `docs/reference/code-map.md` — "if you need X, open these files"
- `docs/reference/decisions.md` — ADR-style records for non-obvious design choices
- `docs/features/*.md` — one file per major workflow (feature creation, sessions, diff, branch picking, settings AI, archive)

## Test plan

- [ ] Verify all relative links in new docs resolve correctly (checked by review agent — all clean)
- [ ] Verify AGENTS.md no longer references removed files
- [ ] Verify `docs/README.md` indexes all 19 subdoc files

🤖 Generated with [Claude Code](https://claude.com/claude-code)