### PR TITLE
fix(diff): modifier guards, p/n file nav, fix StdinStub for e2e tests

### DIFF
--- a/src/components/views/DiffView.tsx
+++ b/src/components/views/DiffView.tsx
@@ -464,10 +464,10 @@ export default function DiffView({worktreePath, title = 'Diff Viewer', onClose, 
     const currentLines = viewMode === 'unified' ? lines : sideBySideLines;
     const maxLineIndex = Math.max(0, currentLines.length - 1);
     
-    if (key.upArrow || input === 'k') {
+    if ((key.upArrow || input === 'k') && !key.shift && !key.ctrl) {
       setSelectedLine(prev => Math.max(0, prev - 1));
     }
-    if (key.downArrow || input === 'j') {
+    if ((key.downArrow || input === 'j') && !key.shift && !key.ctrl) {
       setSelectedLine(prev => Math.min(maxLineIndex, prev + 1));
     }
     if (key.pageUp || input === 'b') {
@@ -613,8 +613,8 @@ export default function DiffView({worktreePath, title = 'Diff Viewer', onClose, 
       }
     }
     
-    // Previous file: Shift+Up or Ctrl+Up (undocumented)
-    if (key.upArrow && (key.shift || key.ctrl)) {
+    // Previous file: Shift+Up, Ctrl+Up, or p
+    if ((key.upArrow && (key.shift || key.ctrl)) || input === 'p') {
       // First, find the current file header
       let currentFileHeaderIndex = -1;
       for (let i = selectedLine; i >= 0; i--) {
@@ -645,8 +645,8 @@ export default function DiffView({worktreePath, title = 'Diff Viewer', onClose, 
       }
     }
     
-    // Next file: Shift+Down or Ctrl+Down (undocumented)
-    if (key.downArrow && (key.shift || key.ctrl)) {
+    // Next file: Shift+Down, Ctrl+Down, or n
+    if ((key.downArrow && (key.shift || key.ctrl)) || input === 'n') {
       const maxIndex = viewMode === 'unified' ? lines.length : sideBySideLines.length;
       for (let i = selectedLine + 1; i < maxIndex; i++) {
         if (isFileHeader(i)) {
@@ -1250,7 +1250,7 @@ export default function DiffView({worktreePath, title = 'Diff Viewer', onClose, 
         <AnnotatedText
           color="magenta"
           wrap="truncate"
-          text={truncateDisplay(`Shift+↑/↓ prev/next file  [v]iew (${viewMode})  [w]rap (${wrapMode})  [c]omment  [C] show all  [d]elete  [S]end to agent  [q] close`, terminalWidth)}
+          text={truncateDisplay(`Shift+↑/↓ or [p]/[n] prev/next file  [v]iew (${viewMode})  [w]rap (${wrapMode})  [c]omment  [C] show all  [d]elete  [S]end to agent  [q] close`, terminalWidth)}
         />
       )}
       

--- a/tests/e2e/terminal/_utils.js
+++ b/tests/e2e/terminal/_utils.js
@@ -18,35 +18,30 @@ export class CapturingStdout extends EventEmitter {
 }
 
 export class StdinStub extends EventEmitter {
-  constructor(){ super(); this.isTTY=true; }
+  constructor(){ super(); this.isTTY=true; this._readQueue=[]; }
   setEncoding(){}
   setRawMode(){}
   resume(){}
   pause(){}
   ref(){}
   unref(){}
-  read(){ return null; }
+  // Ink reads via readable + read(), not 'data' events.
+  // Queue chunks here so handleReadable can dequeue them.
+  read(){ return this._readQueue.length > 0 ? this._readQueue.shift() : null; }
   write(data){
-    const s = typeof data === 'string' ? data : String(data);
-    this.emit('data', Buffer.from(s, 'utf8'));
+    const buf = Buffer.isBuffer(data) ? data : Buffer.from(typeof data === 'string' ? data : String(data), 'utf8');
+    this._push(buf);
     return true;
   }
+  _push(buf){
+    this._readQueue.push(buf);
+    super.emit('readable');
+  }
   emit(event, ...args){
-    // Also emit a keypress event for Ink's useInput parsing
     if (event === 'data') {
-      try {
-        const chunk = args[0];
-        const str = typeof chunk === 'string' ? chunk : String(chunk);
-        const key = {
-          name: str,
-          ctrl: false,
-          meta: false,
-          shift: false,
-          escape: str === '\u001b',
-          return: str === '\r'
-        };
-        super.emit('keypress', str, key);
-      } catch {}
+      const chunk = args[0];
+      const buf = Buffer.isBuffer(chunk) ? chunk : Buffer.from(typeof chunk === 'string' ? chunk : String(chunk), 'utf8');
+      this._push(buf);
     }
     return super.emit(event, ...args);
   }


### PR DESCRIPTION
- Guard plain arrow/j/k handlers with !key.shift && !key.ctrl so
  Shift+Down no longer accidentally moves cursor before jumping to
  the next file header
- Add p/n keybindings as fallback for prev/next file navigation
  (terminals that strip Shift modifier from arrow keys)
- Update help bar: "Shift+↑/↓ or [p]/[n] prev/next file"
- Fix StdinStub in terminal e2e tests: route data through readable+read()
  so Ink actually receives simulated key presses

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
