### PR TITLE
feat(sessions): name Claude sessions after worktree

### DIFF
--- a/src/cores/WorktreeCore.ts
+++ b/src/cores/WorktreeCore.ts
@@ -317,7 +317,7 @@ export class WorktreeCore implements CoreBase<State> {
       if (selectedTool !== 'none') {
         const flags = this.getAIToolFlags(worktree.project, selectedTool);
         const flagStr = flags.length > 0 ? ' ' + flags.map(shellQuote).join(' ') : '';
-        if (selectedTool === 'claude') this.launchClaudeSessionWithFallback(sessionName, worktree.path, flagStr);
+        if (selectedTool === 'claude') this.launchClaudeSessionWithFallback(sessionName, worktree.path, flagStr, `${worktree.feature} - ${worktree.project}`);
         else this.tmux.createSessionWithCommand(sessionName, worktree.path, aiLaunchCommand(selectedTool) + flagStr, true);
         setLastTool(selectedTool, worktree.path);
       } else {
@@ -499,9 +499,10 @@ export class WorktreeCore implements CoreBase<State> {
     for (const name of [s, sh, rn]) { if (active.includes(name)) this.tmux.killSession(name); }
   }
 
-  private launchClaudeSessionWithFallback(sessionName: string, cwd: string, flagStr: string = ''): void {
-    const continueCmd = aiLaunchCommand('claude') + flagStr;
-    const fallbackCmd = 'claude' + flagStr;
+  private launchClaudeSessionWithFallback(sessionName: string, cwd: string, flagStr: string = '', displayName?: string): void {
+    const nameFlag = displayName ? ` -n ${shellQuote(displayName)}` : '';
+    const continueCmd = aiLaunchCommand('claude') + nameFlag + flagStr;
+    const fallbackCmd = 'claude' + nameFlag + flagStr;
     this.tmux.createSessionWithCommand(sessionName, cwd, `${continueCmd} || ${fallbackCmd}`, true);
   }
 

--- a/tests/unit/WorktreeCoreAutoResume.test.ts
+++ b/tests/unit/WorktreeCoreAutoResume.test.ts
@@ -53,7 +53,7 @@ describe('WorktreeCore auto-resume', () => {
     await core.attachSession(wt, 'claude');
 
     const sessionName = tmux.sessionName('proj', 'feat');
-    expect(getExecutedCommands(tmux, sessionName)).toEqual(['claude --continue || claude']);
+    expect(getExecutedCommands(tmux, sessionName)).toEqual([`claude --continue -n 'feat - proj' || claude -n 'feat - proj'`]);
     expect(getLastTool(wt.path)).toBe('claude');
   });
 


### PR DESCRIPTION
## Summary
- Pass Claude CLI's `-n <name>` flag when launching a session so the display name shown in the prompt box, `/resume` picker, and terminal title matches the worktree.
- Format: `<feature> - <project>` (e.g. `name-sessions - devteam`, or `<slug>-plan - <project>` for kanban planning sessions).

## Test plan
- [x] `npx jest tests/unit` — 289 tests pass
- [x] `npm run typecheck` — clean
- [ ] Manual: attach a Claude session via devteam; confirm the worktree name appears in Claude's prompt-box label and terminal title

🤖 Generated with [Claude Code](https://claude.com/claude-code)