### PR TITLE
fix(main-view): make [project] bracket match [workspace] color

### DIFF
--- a/src/components/views/MainView/WorktreeRow.tsx
+++ b/src/components/views/MainView/WorktreeRow.tsx
@@ -143,15 +143,18 @@ export const WorktreeRow = memo<WorktreeRowProps>(({
 
     const contentWidth = stringDisplayWidth(visible);
     const pad = Math.max(0, width - contentWidth);
+    const fg = getCellForeground(COLUMNS.PROJECT_FEATURE);
 
-    // Avoid double-dimming the bracket when the whole row is already dimmed
-    const renderBracket = (content: string) => <Text dimColor={!isDimmed || selected}>{content}</Text>;
+    // Skip self-dim when the row wrapper already dims (avoids double-dim).
+    const renderBracket = (content: string) => (
+      <Text color={fg} dimColor={!isDimmed || selected}>{content}</Text>
+    );
 
     if (justify === 'flex-end') {
       return (
         <>
           {' '.repeat(pad)}
-          <Text color={getCellForeground(COLUMNS.PROJECT_FEATURE)} dimColor={isDimmed && !selected}>{left}</Text>
+          <Text color={fg} dimColor={isDimmed && !selected}>{left}</Text>
           {bracketed ? renderBracket(bracketed) : null}
         </>
       );
@@ -162,9 +165,9 @@ export const WorktreeRow = memo<WorktreeRowProps>(({
       return (
         <>
           {' '.repeat(leftPad)}
-          <Text color={getCellForeground(COLUMNS.PROJECT_FEATURE)} dimColor={isDimmed && !selected}>{left}</Text>
+          <Text color={fg} dimColor={isDimmed && !selected}>{left}</Text>
           {bracketed ? (selected && isDimmed
-            ? <Text color={getCellForeground(COLUMNS.PROJECT_FEATURE)}>{bracketed}</Text>
+            ? <Text color={fg}>{bracketed}</Text>
             : renderBracket(bracketed))
           : null}
           {' '.repeat(rightPad)}
@@ -174,9 +177,9 @@ export const WorktreeRow = memo<WorktreeRowProps>(({
     // flex-start
     return (
       <>
-        <Text color={getCellForeground(COLUMNS.PROJECT_FEATURE)} dimColor={isDimmed && !selected}>{left}</Text>
+        <Text color={fg} dimColor={isDimmed && !selected}>{left}</Text>
         {bracketed ? (selected && isDimmed
-          ? <Text color={getCellForeground(COLUMNS.PROJECT_FEATURE)}>{bracketed}</Text>
+          ? <Text color={fg}>{bracketed}</Text>
           : renderBracket(bracketed))
         : null}
         {' '.repeat(pad)}


### PR DESCRIPTION
## Summary
- On selected worktree rows (white background), the `[project]` tag was rendering with no explicit color, so `dimColor` fell back to the default terminal foreground — barely visible on white.
- The outer cell wrapper intentionally passes `color=undefined` for the PROJECT_FEATURE column so inner Texts control their own color; the bracket Text was missing that color prop.
- Fix: hoist the cell's foreground into a local `fg` and apply it to every Text inside `renderProjectFeatureCell`, including the bracket. Now selected rows render dim-black on white, matching the `[workspace]` tag on `WorkspaceGroupRow`.

## Test plan
- [ ] Open the main view with a mix of worktree rows and workspace rows
- [ ] Select a worktree row — `[project]` should be legible (dim-black on white), not nearly invisible
- [ ] Select a workspace row — `[workspace]` tag should look the same as before
- [ ] Merged/dimmed worktree rows still render dimmed
- [ ] Selected + merged worktree rows still show the bracket in the non-dim selection color

🤖 Generated with [Claude Code](https://claude.com/claude-code)