### PR TITLE
feat(tracker): archive tracker item when archiving worktree from kanban

### DIFF
--- a/src/contexts/UIContext.tsx
+++ b/src/contexts/UIContext.tsx
@@ -22,7 +22,7 @@ interface UIContextType {
   mode: UIMode;
   shouldExit: boolean;
   createProjects: any[] | null;
-  pendingArchive: {project: string; feature: string; path: string} | null;
+  pendingArchive: {project: string; feature: string; path: string; projectPath?: string} | null;
   branchProject: string | null;
   branchList: any[];
   diffWorktree: string | null;
@@ -45,7 +45,7 @@ interface UIContextType {
   // UI navigation operations - self-documenting methods
   showList: () => void;
   showCreateFeature: (projects: any[]) => void;
-  showArchiveConfirmation: (worktree: WorktreeInfo, options?: {onReturn?: () => void}) => void;
+  showArchiveConfirmation: (worktree: WorktreeInfo, options?: {onReturn?: () => void; projectPath?: string}) => void;
   showHelp: () => void;
   showBranchPicker: (projects: any[], defaultProject?: string) => void;
   showBranchListForProject: (project: string, branches: any[]) => void;
@@ -84,7 +84,7 @@ export function UIProvider({children}: UIProviderProps) {
   const [mode, setMode] = useState<UIMode>('list');
   const [shouldExit, setShouldExit] = useState(false);
   const [createProjects, setCreateProjects] = useState<any[] | null>(null);
-  const [pendingArchive, setPendingArchive] = useState<{project: string; feature: string; path: string} | null>(null);
+  const [pendingArchive, setPendingArchive] = useState<{project: string; feature: string; path: string; projectPath?: string} | null>(null);
   const [branchProject, setBranchProject] = useState<string | null>(null);
   const [branchList, setBranchList] = useState<any[]>([]);
   const [diffWorktree, setDiffWorktree] = useState<string | null>(null);
@@ -139,7 +139,7 @@ export function UIProvider({children}: UIProviderProps) {
     setCreateProjects(projects);
   };
 
-  const showArchiveConfirmation = (worktree: WorktreeInfo, options?: {onReturn?: () => void}) => {
+  const showArchiveConfirmation = (worktree: WorktreeInfo, options?: {onReturn?: () => void; projectPath?: string}) => {
     // Set mode first so the very next render leaves the WorktreeListScreen branch
     // (and its stdin handler) immediately, even if pendingArchive arrives one tick
     // later. Otherwise the stale handler can intercept the next keystroke.
@@ -147,7 +147,8 @@ export function UIProvider({children}: UIProviderProps) {
     setPendingArchive({
       project: worktree.project,
       feature: worktree.feature,
-      path: worktree.path
+      path: worktree.path,
+      projectPath: options?.projectPath,
     });
     setArchiveReturn(options?.onReturn ? () => options.onReturn! : null);
   };

--- a/src/screens/ArchiveConfirmScreen.tsx
+++ b/src/screens/ArchiveConfirmScreen.tsx
@@ -2,12 +2,14 @@ import React, {useEffect, useState} from 'react';
 import {Box, Text, useInput, useStdin} from 'ink';
 import {useWorktreeContext} from '../contexts/WorktreeContext.js';
 import ProgressDialog from '../components/dialogs/ProgressDialog.js';
+import {TrackerService} from '../services/TrackerService.js';
 
 
 interface ArchiveFeatureInfo {
   project: string;
   feature: string;
   path: string;
+  projectPath?: string;
 }
 
 interface ArchiveConfirmScreenProps {
@@ -29,7 +31,7 @@ export default function ArchiveConfirmScreen({
   const [untrackedFiles, setUntrackedFiles] = useState<string[]>([]);
 
   useEffect(() => {
-    if (featureInfo.project === 'workspace') return;
+    if (featureInfo.project === 'workspace' || !featureInfo.path) return;
     try {
       setUntrackedFiles(getUntrackedNonIgnoredFiles(featureInfo.path));
     } catch {
@@ -40,15 +42,16 @@ export default function ArchiveConfirmScreen({
   const handleConfirm = async () => {
     try {
       setIsArchiving(true);
-      if (featureInfo.project === 'workspace') {
-        await archiveWorkspace(featureInfo.feature);
-      } else {
-        // Archive single feature
-        await archiveFeature(
-          featureInfo.project,
-          featureInfo.path,
-          featureInfo.feature
-        );
+      const hasWorktree = !!featureInfo.path;
+      if (hasWorktree) {
+        if (featureInfo.project === 'workspace') {
+          await archiveWorkspace(featureInfo.feature);
+        } else {
+          await archiveFeature(featureInfo.project, featureInfo.path, featureInfo.feature);
+        }
+      }
+      if (featureInfo.projectPath && featureInfo.project !== 'workspace') {
+        new TrackerService().moveItem(featureInfo.projectPath, featureInfo.feature, 'archive');
       }
       onSuccess();
     } catch (error) {

--- a/src/screens/ArchiveConfirmScreen.tsx
+++ b/src/screens/ArchiveConfirmScreen.tsx
@@ -1,4 +1,4 @@
-import React, {useEffect, useState} from 'react';
+import React, {useEffect, useMemo, useState} from 'react';
 import {Box, Text, useInput, useStdin} from 'ink';
 import {useWorktreeContext} from '../contexts/WorktreeContext.js';
 import ProgressDialog from '../components/dialogs/ProgressDialog.js';
@@ -27,6 +27,7 @@ export default function ArchiveConfirmScreen({
 }: ArchiveConfirmScreenProps) {
   const {archiveFeature, archiveWorkspace, getUntrackedNonIgnoredFiles} = useWorktreeContext();
   const {isRawModeSupported} = useStdin();
+  const trackerService = useMemo(() => new TrackerService(), []);
   const [isArchiving, setIsArchiving] = useState(false);
   const [untrackedFiles, setUntrackedFiles] = useState<string[]>([]);
 
@@ -51,7 +52,7 @@ export default function ArchiveConfirmScreen({
         }
       }
       if (featureInfo.projectPath && featureInfo.project !== 'workspace') {
-        new TrackerService().moveItem(featureInfo.projectPath, featureInfo.feature, 'archive');
+        trackerService.moveItem(featureInfo.projectPath, featureInfo.feature, 'archive');
       }
       onSuccess();
     } catch (error) {

--- a/src/screens/TrackerBoardScreen.tsx
+++ b/src/screens/TrackerBoardScreen.tsx
@@ -5,7 +5,7 @@ import {useKeyboardShortcuts} from '../hooks/useKeyboardShortcuts.js';
 import {useTerminalDimensions} from '../hooks/useTerminalDimensions.js';
 import {useUIContext} from '../contexts/UIContext.js';
 import {useWorktreeContext} from '../contexts/WorktreeContext.js';
-import {WorktreeInfo, SessionInfo} from '../models.js';
+import {WorktreeInfo} from '../models.js';
 import type {AIStatus} from '../models.js';
 import {truncateDisplay} from '../shared/utils/formatting.js';
 import TrackerProjectPickerDialog from '../components/dialogs/TrackerProjectPickerDialog.js';
@@ -234,7 +234,6 @@ export default function TrackerBoardScreen({
       project: currentItem.project,
       feature: currentItem.slug,
       path: '',
-      session: new SessionInfo(),
     });
     showArchiveConfirmation(worktreeInfo, {
       onReturn: backToTracker,

--- a/src/screens/TrackerBoardScreen.tsx
+++ b/src/screens/TrackerBoardScreen.tsx
@@ -5,7 +5,7 @@ import {useKeyboardShortcuts} from '../hooks/useKeyboardShortcuts.js';
 import {useTerminalDimensions} from '../hooks/useTerminalDimensions.js';
 import {useUIContext} from '../contexts/UIContext.js';
 import {useWorktreeContext} from '../contexts/WorktreeContext.js';
-import {WorktreeInfo} from '../models.js';
+import {WorktreeInfo, SessionInfo} from '../models.js';
 import type {AIStatus} from '../models.js';
 import {truncateDisplay} from '../shared/utils/formatting.js';
 import TrackerProjectPickerDialog from '../components/dialogs/TrackerProjectPickerDialog.js';
@@ -230,8 +230,16 @@ export default function TrackerBoardScreen({
   const handleArchiveItem = React.useCallback(() => {
     if (!currentItem) return;
     const wt = getWorktreeForItem(currentItem);
-    if (!wt) return;
-    showArchiveConfirmation(wt, {onReturn: backToTracker});
+    const worktreeInfo = wt ?? new WorktreeInfo({
+      project: currentItem.project,
+      feature: currentItem.slug,
+      path: '',
+      session: new SessionInfo(),
+    });
+    showArchiveConfirmation(worktreeInfo, {
+      onReturn: backToTracker,
+      projectPath: currentItem.projectPath,
+    });
   }, [currentItem, getWorktreeForItem, showArchiveConfirmation, backToTracker]);
 
   const handleCreateSubmit = React.useCallback(() => {
@@ -308,7 +316,7 @@ export default function TrackerBoardScreen({
     onExecuteRun: hasWorktree ? handleExecuteRun : undefined,
     onDiff: hasWorktree ? () => handleDiff('full') : undefined,
     onDiffUncommitted: hasWorktree ? () => handleDiff('uncommitted') : undefined,
-    onArchive: hasWorktree ? handleArchiveItem : undefined,
+    onArchive: currentItem ? handleArchiveItem : undefined,
     // `t` toggles between tracker and worktree list. Symmetric with `t` on the
     // worktree list which routes to the tracker.
     onTracker: showList,
@@ -556,14 +564,14 @@ export default function TrackerBoardScreen({
           <Text color={proposalStatus.color}>{proposalStatus.text}</Text>
         )}
         {!inputActive && (
-          <Footer hasSession={!!currentItemSession} hasWorktree={hasWorktree} />
+          <Footer hasSession={!!currentItemSession} hasWorktree={hasWorktree} hasItem={!!currentItem} />
         )}
       </Box>
     </Box>
   );
 }
 
-const Footer = React.memo(function Footer({hasSession, hasWorktree}: {hasSession: boolean; hasWorktree: boolean}) {
+const Footer = React.memo(function Footer({hasSession, hasWorktree, hasItem}: {hasSession: boolean; hasWorktree: boolean; hasItem: boolean}) {
   const sep = <Text dimColor>  ·  </Text>;
   return (
     <Box>
@@ -593,6 +601,10 @@ const Footer = React.memo(function Footer({hasSession, hasWorktree}: {hasSession
           <Text>  </Text>
           <Text color="magenta">d</Text>
           <Text dimColor> diff</Text>
+        </>
+      )}
+      {hasItem && (
+        <>
           <Text>  </Text>
           <Text dimColor>archi</Text>
           <Text color="magenta">v</Text>

--- a/tracker/items/archiving-worktree-f/implementation.md
+++ b/tracker/items/archiving-worktree-f/implementation.md
@@ -1,0 +1,13 @@
+## What was built
+
+Two fixes to tracker item archiving from the kanban board:
+
+1. **Archiving a worktree now also archives the tracker item**: `ArchiveConfirmScreen` calls `TrackerService.moveItem(projectPath, feature, 'archive')` after the worktree is removed. `projectPath` is threaded through `UIContext.pendingArchive` and `showArchiveConfirmation`'s options.
+
+2. **Tracker items without a worktree are now archivable**: `TrackerBoardScreen` no longer guards `onArchive` with `hasWorktree` — any selected item gets the `v` shortcut. When no worktree exists, a stub `WorktreeInfo` with `path: ''` is passed; `ArchiveConfirmScreen` detects this and skips git operations.
+
+## Key decisions
+
+- Kept changes minimal: no new UI mode, just gate on `featureInfo.path` being truthy inside `ArchiveConfirmScreen`.
+- `projectPath` only flows through the kanban path — the main worktree list (`App.tsx`) doesn't pass it, so the main list's archive flow is unchanged (worktree-only, no tracker side effect). This is correct since the main list isn't tracker-aware.
+- Footer archive hint (`v`) now shows for all items, with worktree-specific hints (s/x/d) remaining worktree-gated.

--- a/tracker/items/archiving-worktree-f/requirements.md
+++ b/tracker/items/archiving-worktree-f/requirements.md
@@ -1,0 +1,7 @@
+---
+title: archiving-worktree-f
+slug: archiving-worktree-f
+updated: 2026-04-20
+---
+
+archiving-worktree-f


### PR DESCRIPTION
## Summary

- Archiving a worktree from the kanban board now also moves the tracker item to the archive stage in `tracker/index.json`
- Tracker items without a worktree are now archivable (the `v` shortcut works for any selected item, not just items with an active worktree)
- Footer archive hint (`v`) is shown for all items; worktree-specific shortcuts (s/x/d) remain worktree-gated

## Implementation

`projectPath` is threaded through `showArchiveConfirmation` → `UIContext.pendingArchive` → `ArchiveConfirmScreen`. The screen checks `featureInfo.path` to decide whether to do git operations (worktree removal) and `featureInfo.projectPath` to decide whether to move the tracker item.

## Test plan

- [ ] Archive a kanban item that has a worktree → verify worktree is removed AND item moves to archive column on board reload
- [ ] Archive a kanban item that has no worktree (backlog/discovery item) → verify item moves to archive column, no crash
- [ ] Archive from the main worktree list (no `projectPath` passed) → verify worktree is removed, no tracker side effects
- [ ] Archive a workspace → unchanged behaviour

🤖 Generated with [Claude Code](https://claude.com/claude-code)