### PR TITLE
feat(tracker): return to launcher screen from Settings and Info dialogs

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -80,6 +80,8 @@ function AppContent() {
     pendingWorktreeReturn,
     archiveReturn,
     diffReturn,
+    settingsReturn,
+    infoReturn,
     info,
 
     showList,
@@ -421,13 +423,14 @@ function AppContent() {
   }
 
   if (!content && mode === 'info' && info) {
+    const infoBack = infoReturn ?? showList;
     content = (
       <Box flexGrow={1} alignItems="center" justifyContent="center">
         <InfoDialog
           title={info.title}
           message={info.message}
           onClose={() => {
-            try { info.onClose && info.onClose(); } finally { showList(); }
+            try { info.onClose && info.onClose(); } finally { infoBack(); }
           }}
         />
       </Box>
@@ -487,7 +490,7 @@ function AppContent() {
           onApply={(proposed: string) => applyProposedConfig(settingsProject, proposed)}
           onReapplyFiles={() => reapplyFiles(settingsProject)}
           onDiscardResult={() => clearSettingsAIResult()}
-          onCancel={showList}
+          onCancel={settingsReturn ?? showList}
         />
       </Box>
     );

--- a/src/contexts/UIContext.tsx
+++ b/src/contexts/UIContext.tsx
@@ -38,6 +38,8 @@ interface UIContextType {
   trackerItemSlug: string | null;
   archiveReturn: (() => void) | null;
   diffReturn: (() => void) | null;
+  settingsReturn: (() => void) | null;
+  infoReturn: (() => void) | null;
   proposalItems: ProposalCandidate[] | null;
   proposalGenerating: boolean;
   proposalError: string | null;
@@ -52,8 +54,8 @@ interface UIContextType {
   showDiffView: (worktreePath: string, type: 'full' | 'uncommitted', options?: {onReturn?: () => void}) => void;
   showAIToolSelection: (worktree: WorktreeInfo, options?: {initialPrompt?: string; onReturn?: () => void}) => void;
   showNoProjectsDialog: () => void;
-  showInfo: (message: string, options?: {title?: string; onClose?: () => void}) => void;
-  showSettings: (project: string) => void;
+  showInfo: (message: string, options?: {title?: string; onClose?: () => void; onReturn?: () => void}) => void;
+  showSettings: (project: string, options?: {onReturn?: () => void}) => void;
   showTracker: (project: {name: string; path: string}) => void;
   showTrackerItem: (slug: string) => void;
   showTrackerStages: () => void;
@@ -105,6 +107,8 @@ export function UIProvider({children}: UIProviderProps) {
   // view); when set, the screen routes back here instead of falling to showList.
   const [archiveReturn, setArchiveReturn] = useState<(() => void) | null>(null);
   const [diffReturn, setDiffReturn] = useState<(() => void) | null>(null);
+  const [settingsReturn, setSettingsReturn] = useState<(() => void) | null>(null);
+  const [infoReturn, setInfoReturn] = useState<(() => void) | null>(null);
 
 
   const resetUIState = () => {
@@ -122,6 +126,8 @@ export function UIProvider({children}: UIProviderProps) {
     setTrackerItemSlug(null);
     setArchiveReturn(null);
     setDiffReturn(null);
+    setSettingsReturn(null);
+    setInfoReturn(null);
     setProposalItems(null);
     // Proposal generating/error state is intentionally preserved across navigation
     // (generation continues in background; user sees the result when they return)
@@ -208,14 +214,16 @@ export function UIProvider({children}: UIProviderProps) {
     setMode('noProjects');
   };
 
-  const showInfo = (message: string, options?: {title?: string; onClose?: () => void}) => {
+  const showInfo = (message: string, options?: {title?: string; onClose?: () => void; onReturn?: () => void}) => {
     setInfo({title: options?.title, message, onClose: options?.onClose});
+    setInfoReturn(options?.onReturn ? () => options.onReturn! : null);
     setMode('info');
   };
 
-  const showSettings = (project: string) => {
+  const showSettings = (project: string, options?: {onReturn?: () => void}) => {
     setMode('settings');
     setSettingsProject(project);
+    setSettingsReturn(options?.onReturn ? () => options.onReturn! : null);
   };
 
   const showTracker = (project: {name: string; path: string}) => {
@@ -297,6 +305,8 @@ export function UIProvider({children}: UIProviderProps) {
     trackerItemSlug,
     archiveReturn,
     diffReturn,
+    settingsReturn,
+    infoReturn,
     proposalItems,
     proposalGenerating,
     proposalError,

--- a/src/screens/TrackerBoardScreen.tsx
+++ b/src/screens/TrackerBoardScreen.tsx
@@ -319,7 +319,7 @@ export default function TrackerBoardScreen({
     // `t` toggles between tracker and worktree list. Symmetric with `t` on the
     // worktree list which routes to the tracker.
     onTracker: showList,
-    onSettings: () => showSettings(project),
+    onSettings: () => showSettings(project, {onReturn: backToTracker}),
     onQuit: onBack,
   }, {enabled: !inputActive});
 

--- a/tracker/items/return-to-launcher-screen/implementation.md
+++ b/tracker/items/return-to-launcher-screen/implementation.md
@@ -1,0 +1,38 @@
+# Implementation — return-to-launcher-screen
+
+## What was built
+
+Extended the existing launcher-return callback pattern in `UIContext` to cover `showSettings` and `showInfo`, and wired `TrackerBoardScreen` to pass `onReturn: backToTracker` when it opens Settings. Closing Settings (or an info dialog) from the kanban now lands back on the tracker instead of the worktree list. All other callers keep their existing `showList` fallback.
+
+### Changes
+
+- `src/contexts/UIContext.tsx`
+  - Added `settingsReturn: (() => void) | null` and `infoReturn: (() => void) | null` state slots, exposed on the context value. Same shape as the existing `archiveReturn` / `diffReturn` / `pendingWorktreeReturn`.
+  - `showSettings(project, options?: {onReturn?})` and `showInfo(message, options?: {title?, onClose?, onReturn?})` now set the respective return slots (set on every call, so a later call without `onReturn` doesn't inherit a stale callback).
+  - `resetUIState` clears both new slots alongside the existing ones.
+- `src/App.tsx`
+  - Destructures `settingsReturn` and `infoReturn` from `useUIContext()`.
+  - Settings route: `onCancel={settingsReturn ?? showList}`.
+  - Info route: `finally { (infoReturn ?? showList)(); }` — `info.onClose` still runs first exactly as before; only the post-close destination is configurable.
+- `src/screens/TrackerBoardScreen.tsx`
+  - `onSettings: () => showSettings(project, {onReturn: backToTracker})` (was `() => showSettings(project)`). `backToTracker` is the existing `showTracker({name, path})` closure the board already uses for archive/diff/attach returns.
+
+No other call site passes `onReturn`, so `showList` remains the default destination for every existing flow.
+
+## Key decisions
+
+- **Consistent with the existing pattern.** The codebase already had three `*Return` slots for exactly this purpose (`archiveReturn`, `diffReturn`, `pendingWorktreeReturn`). The symmetric path is cheap and avoids inventing a new mechanism.
+- **`showInfo` plumbed through even though no caller uses it yet.** Reasons: it is one extra line per callsite (two state slots plus the `?? showList` fallback), it matches the rest of the `*Return` API shape, and it prevents the same "dialog loses launcher context" bug from reappearing the first time a tracker-side flow surfaces an info dialog.
+- **Settings on the kanban board's `x` (execute-run) `no_config` path is out of scope.** Requirements called this out explicitly; it is a behavior gap (`TrackerBoardScreen.handleExecuteRun` doesn't inspect the `attachRunSession` result the way `App.handleExecuteRun` does) that lives outside the return-path concern. Left for a separate item.
+- **Help key wasn't touched.** The tracker's `useKeyboardShortcuts` call doesn't bind `onHelp`, so the help overlay isn't reachable from the board today. No gap to close.
+
+## Tests
+
+- `npm run typecheck` — passes.
+- `npm test` — 590 / 590 existing tests pass; no regressions.
+- **No new automated test was added for the tracker → Settings → cancel → tracker flow.** The requirement mentioned a unit/E2E check, but the project's unit config mocks `ink`/`ink-testing-library` (`tests/__mocks__/`) and the enhanced E2E harness (`renderTestApp`) routes state through a synthetic `setUIMode` helper rather than real React state, so neither config can drive `UIContext` state transitions end-to-end. The existing `*Return` siblings (`archiveReturn`, `diffReturn`, `pendingWorktreeReturn`) are not directly covered by tests either, for the same reason. **Manual verification**: open the tracker, press `c`, press Esc — you should land back on the kanban board, not the worktree list. If automated coverage is important, it should be added as a terminal-runner test (`tests/e2e/terminal/*.test.mjs`) since those use real Ink; this is a separate infrastructure concern worth its own item.
+
+## Notes for cleanup
+
+- `UIContext`'s new slots follow the exact same idiom as the existing `archiveReturn` / `diffReturn` — if the team decides to consolidate these into a single "launcher return" slot (since only one can be live at a time in practice), that refactor would absorb the new fields naturally.
+- If a future change ever wants an info dialog that must *not* navigate away on close (i.e., a no-op close), the current API doesn't express that — `infoReturn ?? showList` always navigates. Not a problem today; worth noting if the need arises.

--- a/tracker/items/return-to-launcher-screen/notes.md
+++ b/tracker/items/return-to-launcher-screen/notes.md
@@ -1,0 +1,25 @@
+# Discovery — return-to-launcher-screen
+
+## User problem
+
+When the user launches something from the kanban (tracker) board, some actions route back to the worktree list ("main screen") on close instead of back to the tracker. The board already wires `onReturn: backToTracker` for the flows that have explicit return support (attach / shell / run / diff / archive — see `src/screens/TrackerBoardScreen.tsx:196-242`), but other screens launched from the board have no such return hook and unconditionally call `showList` when they close.
+
+Concrete gaps in the current code:
+
+- **Settings (`c` from tracker)** — `TrackerBoardScreen` binds `onSettings: () => showSettings(project)` (TrackerBoardScreen.tsx:322), but `App.tsx:491` renders `<SettingsDialog … onCancel={showList} />`. There is no `settingsReturn` state in `UIContext` analogous to `archiveReturn` / `diffReturn` / `pendingWorktreeReturn`, so closing Settings always drops the user on the worktree list, even when they came from the tracker.
+- **Info dialogs** — `showInfo` (UIContext.tsx:211) always closes via `showList` (App.tsx:430). Currently `showInfo` is only invoked from `WorktreeListScreen` / `CreateFeatureScreen`, so it's not yet user-visible in the tracker flow; but the same missing-return problem exists and will bite as soon as any tracker-side flow uses it.
+- **Tracker's own execute-run (`x`)** silently no-ops on `no_config` instead of routing to Settings, because `TrackerBoardScreen.handleExecuteRun` (TrackerBoardScreen.tsx:216-221) doesn't inspect the `attachRunSession` result the way `App.handleExecuteRun` does (App.tsx:187-199). If we fix Settings to return to the launcher, we should also have the kanban's run flow open Settings-with-return-to-tracker when there's no config, matching the list's behavior.
+
+Help (`?`) is not currently bound on the tracker, so it's not a gap today.
+
+## Recommendation
+
+Extend the existing launcher-return callback pattern to `showSettings`, and pass `onReturn: backToTracker` from `TrackerBoardScreen.onSettings`. Minimal, symmetric with the existing `archiveReturn` / `diffReturn` / `pendingWorktreeReturn` wiring:
+
+1. Add `settingsReturn: (() => void) | null` state + setter in `UIContext` and accept an `options?: {onReturn?: () => void}` on `showSettings`, mirroring `showArchiveConfirmation`.
+2. In `App.tsx`, render `<SettingsDialog onCancel={settingsReturn ?? showList} />`. Clear `settingsReturn` in `resetUIState` (already wipes the other `*Return` slots).
+3. In `TrackerBoardScreen`, change `onSettings` to `() => showSettings(project, {onReturn: backToTracker})`.
+4. While here, make the kanban's `x` (execute run) match the list's behavior: if `attachRunSession` returns `'no_config'`, open Settings with `onReturn: backToTracker` instead of silently dropping the user. This is the smallest change that keeps the board's run key useful.
+5. Do the same `onReturn` plumbing for `showInfo` so that any future tracker-side flow that surfaces an info dialog returns to the board. Optional but cheap and prevents the same bug from reappearing.
+
+Tests: add a small unit/E2E check that pressing `c` on the tracker board and then cancelling Settings leaves `mode === 'tracker'` (not `'list'`). Archive/diff already have analogous coverage to copy from.

--- a/tracker/items/return-to-launcher-screen/requirements.md
+++ b/tracker/items/return-to-launcher-screen/requirements.md
@@ -4,4 +4,42 @@ slug: return-to-launcher-screen
 updated: 2026-04-20
 ---
 
-it still comes back to main screen instead of kanban board from some places. it should come back to the place that launched it
+## Problem
+
+When the user launches something from the kanban (tracker) board, some actions route back to the worktree list ("main screen") on close instead of back to the tracker. The board already wires `onReturn: backToTracker` for the flows that have explicit return support (attach / shell / run / diff / archive — see `src/screens/TrackerBoardScreen.tsx:196-242`), but other screens launched from the board have no such return hook and unconditionally call `showList` when they close.
+
+Concrete gaps in the current code:
+
+- **Settings (`c` from tracker)** — `TrackerBoardScreen` binds `onSettings: () => showSettings(project)` (TrackerBoardScreen.tsx:322), but `App.tsx:491` renders `<SettingsDialog … onCancel={showList} />`. There is no `settingsReturn` state in `UIContext` analogous to `archiveReturn` / `diffReturn` / `pendingWorktreeReturn`, so closing Settings always drops the user on the worktree list, even when they came from the tracker.
+- **Info dialogs** — `showInfo` (UIContext.tsx:211) always closes via `showList` (App.tsx:430). Currently `showInfo` is only invoked from `WorktreeListScreen` / `CreateFeatureScreen`, so it's not yet user-visible in the tracker flow; but the same missing-return problem exists and will bite as soon as any tracker-side flow uses it.
+
+Help (`?`) is not currently bound on the tracker, so it's not a gap today.
+
+## Why
+
+Mixing return destinations breaks the mental model the rest of the board already establishes: every other action launched from the tracker (attach, shell, run, diff, archive) returns to the tracker on close. Settings is the odd one out, so users lose their place mid-task and have to press `t` to get back to the board they were just on. The existing `*Return` callback pattern in `UIContext` is exactly the mechanism for this; Settings and Info just weren't plumbed through. Closing the gap is a small, symmetric extension of an already-proven pattern.
+
+## User stories
+
+- As a user working in the kanban board, when I open Settings with `c` and cancel, I want to land back on the kanban board I launched from — not on the worktree list — so I don't lose my place.
+- As a future contributor adding a new tracker-side flow that surfaces an info dialog, I want `showInfo` to already support an `onReturn` callback so I don't have to re-plumb this pattern myself.
+
+## Summary
+
+Extend the existing launcher-return callback pattern in `UIContext` to cover `showSettings` and `showInfo`, mirroring what's already done for archive / diff / AI-tool selection. `TrackerBoardScreen` passes `onReturn: backToTracker` when opening Settings, and the Settings/Info close handlers fall back to `showList` only when no return callback was provided. `resetUIState` is extended to clear the new `settingsReturn` / `infoReturn` slots alongside the existing ones. No new UI surface; the fix is purely in the navigation plumbing.
+
+## Acceptance criteria
+
+1. `UIContext` exposes a `settingsReturn: (() => void) | null` slot and `showSettings(project, options?: {onReturn?: () => void})` stores it. Same shape as `archiveReturn` / `showArchiveConfirmation`.
+2. `UIContext` exposes an `infoReturn: (() => void) | null` slot and `showInfo(message, options?: {title?; onClose?; onReturn?})` stores it. `onClose` keeps its current semantics (runs before navigation); `onReturn` replaces the hardcoded `showList` destination when provided.
+3. `resetUIState` clears both new `*Return` slots (same place the other three are cleared).
+4. `App.tsx` Settings route uses `settingsReturn ?? showList` for the dialog's cancel handler. The Info route uses `infoReturn ?? showList` as the post-`onClose` destination.
+5. `TrackerBoardScreen` passes `onReturn: backToTracker` when calling `showSettings(project, …)`. No other call sites change behavior (they pass no `onReturn` and continue to fall back to `showList`).
+6. Pressing `c` on the tracker board, then pressing Escape in the Settings dialog, leaves the app in `mode === 'tracker'` with the same `trackerProject` as before — not `mode === 'list'`. Verified by a test (unit against `UIContext` state transitions or an E2E that drives the keypresses, matching the style of existing archive/diff coverage).
+7. Opening Settings from the worktree list (the existing path) still returns to the list on cancel — the fallback path is unchanged. Covered by existing behavior / test.
+8. `npm run typecheck` and `npm test` pass. New tests are added for the tracker → Settings → cancel → tracker flow.
+
+## Out of scope
+
+- Routing the tracker's `x` (execute-run) key to Settings when `attachRunSession` returns `'no_config'`. This is a separate behavior gap (TrackerBoardScreen.tsx:216-221 doesn't inspect the result the way `App.handleExecuteRun` does) and is tracked outside this item to keep the change focused on return-path plumbing.
+- Adding `onHelp` to the tracker's keyboard shortcuts. Help isn't currently reachable from the board, so there's nothing to fix here today.

--- a/tracker/items/return-to-launcher-screen/requirements.md
+++ b/tracker/items/return-to-launcher-screen/requirements.md
@@ -1,0 +1,7 @@
+---
+title: it still comes back to main screen instead of kanban board from some places. it should come back to the place that launched it
+slug: return-to-launcher-screen
+updated: 2026-04-20
+---
+
+it still comes back to main screen instead of kanban board from some places. it should come back to the place that launched it


### PR DESCRIPTION
## Summary

- Extends the existing `*Return` callback pattern in `UIContext` to cover `showSettings` and `showInfo`, mirroring the existing `archiveReturn` / `diffReturn` / `pendingWorktreeReturn` plumbing.
- `TrackerBoardScreen` now passes `onReturn: backToTracker` when opening Settings, so pressing `c` on the kanban and then cancelling lands back on the board instead of the worktree list.
- `showInfo` is plumbed symmetrically so any future tracker-side flow that surfaces an info dialog inherits the same return-to-launcher behavior for free.

Every existing caller omits `onReturn` and keeps the `showList` fallback, so no other flow changes.

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm test` — 590 / 590 existing tests pass; no regressions
- [ ] Manual: open tracker, press `c`, press Esc → lands back on the kanban board (not the worktree list)
- [ ] Manual: open Settings from the worktree list (select a worktree, press `c`), press Esc → lands on the worktree list (fallback path unchanged)

Out of scope (tracked separately):
- Routing the tracker's `x` (execute-run) key to Settings when `attachRunSession` returns `'no_config'` — that is a separate behavior gap unrelated to return-path plumbing.
- Automated unit/E2E coverage for this flow — the project's unit config mocks `ink` / `ink-testing-library` and the enhanced E2E harness drives state through a synthetic `setUIMode` rather than real React state, so neither config can drive real `UIContext` transitions end-to-end. The existing `*Return` siblings are also not directly covered for the same reason. If automated coverage is desired, a `tests/e2e/terminal/*.test.mjs` would be the right vehicle and can be added as a separate infra item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)