### PR TITLE
tracker: derive-first item creation with tool picker + fast per-project polling

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -31,6 +31,7 @@ import {InputFocusProvider} from './contexts/InputFocusContext.js';
 import {WorktreeCore} from './cores/WorktreeCore.js';
 import {GitHubCore} from './cores/GitHubCore.js';
 import {TrackerService, type TrackerItem, type TrackerStage} from './services/TrackerService.js';
+import type {AITool} from './models.js';
 
 
 function AppContent() {
@@ -62,6 +63,7 @@ function AppContent() {
     reapplyFiles,
     getAvailableAITools,
     needsToolSelection,
+    launchSessionBackground,
   } = useWorktreeContext();
   
   const {refreshPRStatus, getPRStatus} = useGitHubContext();
@@ -233,29 +235,44 @@ function AppContent() {
     return tracker.buildPlanningPrompt(item, stageConf, itemDirOverride);
   };
 
-  // Reuse the existing worktree if present, recover one from the branch if it was
-  // obliterated, or create a fresh one. Item tracker files are seeded into the
-  // worktree so the agent works entirely with paths relative to its repo root.
-  const launchSessionForItem = async (
+  const prepareItemSession = async (
     project: {name: string; path: string},
     item: TrackerItem,
     stage: TrackerStage,
   ) => {
     let worktree = worktrees.find(wt => wt.project === project.name && wt.feature === item.slug) || null;
     if (!worktree) worktree = await recreateImplementWorktree(project.name, item.slug);
-    if (!worktree) { showTracker(project); return; }
-
+    if (!worktree) return null;
     const worktreeItemDir = path.join(worktree.path, 'tracker', 'items', item.slug);
     tracker.ensureItemFiles(project.path, item.slug, worktree.path, item);
-    const fullPrompt = buildPromptForItem(item, stage, worktreeItemDir);
+    return {worktree, prompt: buildPromptForItem(item, stage, worktreeItemDir)};
+  };
 
-    const needsSelection = await needsToolSelection(worktree);
+  const launchSessionForItem = async (
+    project: {name: string; path: string},
+    item: TrackerItem,
+    stage: TrackerStage,
+  ) => {
+    const prepared = await prepareItemSession(project, item, stage);
+    if (!prepared) { showTracker(project); return; }
+    const needsSelection = await needsToolSelection(prepared.worktree);
     if (needsSelection) {
-      showAIToolSelection(worktree, {initialPrompt: fullPrompt, onReturn: () => showTracker(project)});
+      showAIToolSelection(prepared.worktree, {initialPrompt: prepared.prompt, onReturn: () => showTracker(project)});
     } else {
-      await attachSession(worktree, undefined, fullPrompt);
+      await attachSession(prepared.worktree, undefined, prepared.prompt);
       showTracker(project);
     }
+  };
+
+  const launchSessionForItemBackground = async (
+    project: {name: string; path: string},
+    item: TrackerItem,
+    stage: TrackerStage,
+    aiTool?: AITool,
+  ) => {
+    const prepared = await prepareItemSession(project, item, stage);
+    if (!prepared) return;
+    await launchSessionBackground(prepared.worktree, aiTool, prepared.prompt);
   };
 
   const handleCurrentStageWork = (item: TrackerItem) => {
@@ -530,7 +547,9 @@ function AppContent() {
         projectPath={trackerProject.path}
         onBack={requestExit}
         onOpenItem={(item) => showTrackerItem(item.slug)}
-        onLaunchItem={handleCurrentStageWork}
+        onLaunchItemBackground={(item, tool) =>
+          launchSessionForItemBackground(trackerProject!, item, item.stage, tool)
+        }
         onCustomizeStages={showTrackerStages}
       />
     );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -530,6 +530,7 @@ function AppContent() {
         projectPath={trackerProject.path}
         onBack={requestExit}
         onOpenItem={(item) => showTrackerItem(item.slug)}
+        onLaunchItem={handleCurrentStageWork}
         onCustomizeStages={showTrackerStages}
       />
     );

--- a/src/contexts/WorktreeContext.tsx
+++ b/src/contexts/WorktreeContext.tsx
@@ -21,6 +21,7 @@ interface WorktreeContextType {
   // Data operations
   refresh: (refreshPRs?: 'all' | 'visible' | 'none') => Promise<void>;
   refreshVisibleStatus: (currentPage: number, pageSize: number) => Promise<void>;
+  refreshProjectWorktrees: (projectName: string) => Promise<void>;
   forceRefreshVisible: (currentPage: number, pageSize: number) => Promise<void>;
   
   // Worktree operations
@@ -37,6 +38,7 @@ interface WorktreeContextType {
   
   // Session operations
   attachSession: (worktree: WorktreeInfo, aiTool?: AITool, initialPrompt?: string) => Promise<void>;
+  launchSessionBackground: (worktree: WorktreeInfo, aiTool?: AITool, initialPrompt?: string) => Promise<void>;
   attachShellSession: (worktree: WorktreeInfo) => Promise<void>;
   attachRunSession: (worktree: WorktreeInfo) => Promise<'success' | 'no_config'>;
   
@@ -78,6 +80,7 @@ export function WorktreeProvider({children, core: coreOverride}: WorktreeProvide
   // Data operations
   const refresh = useCallback(async () => core.refresh(), [core]);
   const refreshVisibleStatus = useCallback(async (currentPage: number, pageSize: number) => core.refreshVisibleStatus(currentPage, pageSize), [core]);
+  const refreshProjectWorktrees = useCallback(async (projectName: string) => core.refreshProjectWorktrees(projectName), [core]);
   const forceRefreshVisible = useCallback(async (currentPage: number, pageSize: number) => core.forceRefreshVisible(currentPage, pageSize), [core]);
 
   // Worktree operations
@@ -97,6 +100,7 @@ export function WorktreeProvider({children, core: coreOverride}: WorktreeProvide
 
   // Sessions
   const attachSession = useCallback(async (worktree: WorktreeInfo, aiTool?: AITool, initialPrompt?: string) => core.attachSession(worktree, aiTool, initialPrompt), [core]);
+  const launchSessionBackground = useCallback(async (worktree: WorktreeInfo, aiTool?: AITool, initialPrompt?: string) => core.launchSessionBackground(worktree, aiTool, initialPrompt), [core]);
   const attachShellSession = useCallback(async (worktree: WorktreeInfo) => core.attachShellSession(worktree), [core]);
   const attachRunSession = useCallback(async (worktree: WorktreeInfo) => core.attachRunSession(worktree), [core]);
 
@@ -132,6 +136,7 @@ export function WorktreeProvider({children, core: coreOverride}: WorktreeProvide
     // Data operations
     refresh,
     refreshVisibleStatus,
+    refreshProjectWorktrees,
     forceRefreshVisible,
     
     // Worktree operations
@@ -148,6 +153,7 @@ export function WorktreeProvider({children, core: coreOverride}: WorktreeProvide
     
     // Session operations
     attachSession,
+    launchSessionBackground,
     attachShellSession,
     attachRunSession,
 

--- a/src/cores/WorktreeCore.ts
+++ b/src/cores/WorktreeCore.ts
@@ -248,6 +248,8 @@ export class WorktreeCore implements CoreBase<State> {
   }
 
   async refreshProjectWorktrees(projectName: string): Promise<void> {
+    // Shares `isRefreshingVisible` with refreshVisibleStatus on purpose — only
+    // one concurrent poll should spawn tmux/git subprocesses at a time.
     if (this.isRefreshingVisible) return;
     this.isRefreshingVisible = true;
     try {

--- a/src/cores/WorktreeCore.ts
+++ b/src/cores/WorktreeCore.ts
@@ -24,6 +24,30 @@ type State = {
   versionInfo: any | null;
 };
 
+function worktreeStatusEquals(a: WorktreeInfo | undefined, b: WorktreeInfo): boolean {
+  if (!a) return false;
+  const sa = a.session, sb = b.session;
+  if (sa?.session_name !== sb?.session_name) return false;
+  if ((sa?.attached ?? false) !== (sb?.attached ?? false)) return false;
+  if ((sa?.ai_status ?? 'not_running') !== (sb?.ai_status ?? 'not_running')) return false;
+  if ((sa?.ai_tool ?? 'none') !== (sb?.ai_tool ?? 'none')) return false;
+  if ((sa?.shell_attached ?? false) !== (sb?.shell_attached ?? false)) return false;
+  if ((sa?.run_attached ?? false) !== (sb?.run_attached ?? false)) return false;
+  const ga = a.git, gb = b.git;
+  if (!ga || !gb) return ga === gb;
+  return ga.has_changes === gb.has_changes
+    && ga.modified_files === gb.modified_files
+    && ga.added_lines === gb.added_lines
+    && ga.deleted_lines === gb.deleted_lines
+    && ga.untracked_lines === gb.untracked_lines
+    && ga.base_added_lines === gb.base_added_lines
+    && ga.base_deleted_lines === gb.base_deleted_lines
+    && ga.has_remote === gb.has_remote
+    && ga.ahead === gb.ahead
+    && ga.behind === gb.behind
+    && ga.is_pushed === gb.is_pushed;
+}
+
 export class WorktreeCore implements CoreBase<State> {
   private state: State = {worktrees: [], loading: false, lastRefreshed: 0, selectedIndex: 0, memoryStatus: null, versionInfo: null};
   private listeners = new Set<(s: Readonly<State>) => void>();
@@ -169,35 +193,69 @@ export class WorktreeCore implements CoreBase<State> {
     }
   }
 
+  private async refreshWorktreeIndices(indices: number[]): Promise<void> {
+    if (indices.length === 0) return;
+    const sessions = await this.tmux.listSessions();
+    const current = this.state.worktrees;
+    // Fetch tmux + git status for each worktree concurrently. Serial awaits here
+    // multiply per-tick wall-clock by N worktrees; with a 2s poll that matters.
+    const results = await Promise.all(indices.map(async (i) => {
+      const wt = current[i];
+      if (!wt) return null;
+      const sessionName = this.tmux.sessionName(wt.project, wt.feature);
+      const attached = sessions.includes(sessionName);
+      const shell_attached = sessions.includes(this.tmux.shellSessionName(wt.project, wt.feature));
+      const run_attached = sessions.includes(this.tmux.runSessionName(wt.project, wt.feature));
+      const [aiResult, gitStatus] = await Promise.all([
+        attached
+          ? this.tmux.getAIStatus(sessionName)
+          : Promise.resolve({tool: 'none' as const, status: 'not_running' as const}),
+        this.git.getGitStatus(wt.path),
+      ]);
+      // working→idle: invalidate git slow-metrics cache so the next poll shows fresh committed stats.
+      if (wt.session?.ai_status === 'working' && aiResult.status !== 'working') {
+        this.git.invalidateGitSlowCache(wt.path);
+      }
+      const updated = new WorktreeInfo({...wt, git: gitStatus, session: new SessionInfo({session_name: sessionName, attached, ai_status: aiResult.status, ai_tool: aiResult.tool, shell_attached, run_attached})});
+      return {i, updated};
+    }));
+    // Only rewrite state when something actually changed — otherwise every tick
+    // invalidates the worktrees array reference and re-renders every subscriber.
+    let changed = false;
+    const arr = [...current];
+    for (const r of results) {
+      if (!r) continue;
+      if (!worktreeStatusEquals(arr[r.i], r.updated)) {
+        arr[r.i] = r.updated;
+        changed = true;
+      }
+    }
+    if (changed) this.setState({worktrees: arr, lastRefreshed: Date.now()});
+  }
+
   async refreshVisibleStatus(currentPage: number, pageSize: number): Promise<void> {
     if (this.isRefreshingVisible) return;
     this.isRefreshingVisible = true;
     try {
-      // Compute slice and refresh git/tmux status for visible rows
       const start = currentPage * pageSize;
       const end = Math.min(start + pageSize, this.state.worktrees.length);
-      const slice = this.state.worktrees.slice(start, end);
-      const sessions = await this.tmux.listSessions();
-      const updated: WorktreeInfo[] = [];
-      for (const wt of slice) {
-        const sessionName = this.tmux.sessionName(wt.project, wt.feature);
-        const attached = sessions.includes(sessionName);
-        const shell_attached = sessions.includes(this.tmux.shellSessionName(wt.project, wt.feature));
-        const run_attached = sessions.includes(this.tmux.runSessionName(wt.project, wt.feature));
-        // Fetch AI status first: if agent just finished working, invalidate the git slow-metrics
-        // cache before fetching git status so this tick shows fresh committed stats.
-        const aiResult = attached
-          ? await this.tmux.getAIStatus(sessionName)
-          : {tool: 'none' as const, status: 'not_running' as const};
-        if (wt.session?.ai_status === 'working' && aiResult.status !== 'working') {
-          this.git.invalidateGitSlowCache(wt.path);
-        }
-        const gitStatus = await this.git.getGitStatus(wt.path);
-        updated.push(new WorktreeInfo({...wt, git: gitStatus, session: new SessionInfo({session_name: sessionName, attached, ai_status: aiResult.status, ai_tool: aiResult.tool, shell_attached, run_attached})}));
+      const indices: number[] = [];
+      for (let i = start; i < end; i++) indices.push(i);
+      await this.refreshWorktreeIndices(indices);
+    } finally {
+      this.isRefreshingVisible = false;
+    }
+  }
+
+  async refreshProjectWorktrees(projectName: string): Promise<void> {
+    if (this.isRefreshingVisible) return;
+    this.isRefreshingVisible = true;
+    try {
+      const indices: number[] = [];
+      for (let i = 0; i < this.state.worktrees.length; i++) {
+        if (this.state.worktrees[i].project === projectName) indices.push(i);
       }
-      const arr = [...this.state.worktrees];
-      for (let i = 0; i < updated.length; i++) arr[start + i] = updated[i];
-      this.setState({worktrees: arr, lastRefreshed: Date.now()});
+      await this.refreshWorktreeIndices(indices);
     } finally {
       this.isRefreshingVisible = false;
     }
@@ -245,6 +303,7 @@ export class WorktreeCore implements CoreBase<State> {
     if (!created) return null;
     const worktreePath = path.join(this.git.basePath, `${projectName}${DIR_BRANCHES_SUFFIX}`, uniqueName);
     this.setupWorktreeEnvironment(projectName, worktreePath);
+    this.git.invalidateGitSlowCache(worktreePath);
     await this.refresh();
     return new WorktreeInfo({project: projectName, feature: uniqueName, path: worktreePath, branch: uniqueName});
   }
@@ -256,6 +315,7 @@ export class WorktreeCore implements CoreBase<State> {
       const created = this.git.addWorktreeOnExistingBranch(project, slug);
       if (created) {
         this.setupWorktreeEnvironment(project, worktreePath);
+        this.git.invalidateGitSlowCache(worktreePath);
         await this.refresh();
         return new WorktreeInfo({project, feature: slug, path: worktreePath, branch: slug});
       }
@@ -313,32 +373,37 @@ export class WorktreeCore implements CoreBase<State> {
   workspaceExists(featureName: string): boolean { try { return this.workspace.hasWorkspaceForFeature(this.git.basePath, featureName); } catch { return false; } }
 
   // Sessions
-  async attachSession(worktree: WorktreeInfo, aiTool?: AITool, initialPrompt?: string): Promise<void> {
+
+  // Preference order: 1. explicit arg  2. tool running in existing session  3. last-used  4. 'none'
+  private async createSessionIfNeeded(
+    worktree: WorktreeInfo, aiTool?: AITool, initialPrompt?: string,
+  ): Promise<{sessionName: string; selectedTool: AITool; created: boolean}> {
     const sessionName = this.tmux.sessionName(worktree.project, worktree.feature);
     const sessions = await this.tmux.listSessions();
     const sessionTool = worktree.session?.ai_tool as AITool | undefined;
-    let selectedTool: AITool = sessionTool && sessionTool !== 'none' ? sessionTool : 'none';
-    if (!sessions.includes(sessionName)) {
-      // Preference order for which tool to launch:
-      //   1. Explicit argument (e.g. from the tool-picker dialog)
-      //   2. Tool currently running in the session (won't apply when there's no session)
-      //   3. Last tool devteam launched here, remembered across restarts
-      //   4. First available installed tool
-      const remembered = getLastTool(worktree.path);
-      selectedTool = 'none';
-      if (aiTool && aiTool !== 'none') selectedTool = aiTool;
-      else if (sessionTool && sessionTool !== 'none') selectedTool = sessionTool;
-      else if (remembered) selectedTool = remembered;
-      if (selectedTool !== 'none') {
-        const flags = this.getAIToolFlags(worktree.project, selectedTool);
-        const flagStr = flags.length > 0 ? ' ' + flags.map(shellQuote).join(' ') : '';
-        if (selectedTool === 'claude') this.launchClaudeSessionWithFallback(sessionName, worktree.path, flagStr, `${worktree.feature} - ${worktree.project}`, initialPrompt);
-        else this.tmux.createSessionWithCommand(sessionName, worktree.path, aiLaunchCommand(selectedTool) + flagStr, true);
-        setLastTool(selectedTool, worktree.path);
-      } else {
-        this.tmux.createSession(sessionName, worktree.path, true);
-      }
+    if (sessions.includes(sessionName)) {
+      const existingTool: AITool = sessionTool && sessionTool !== 'none' ? sessionTool : 'none';
+      return {sessionName, selectedTool: existingTool, created: false};
     }
+    const remembered = getLastTool(worktree.path);
+    let selectedTool: AITool = 'none';
+    if (aiTool && aiTool !== 'none') selectedTool = aiTool;
+    else if (sessionTool && sessionTool !== 'none') selectedTool = sessionTool;
+    else if (remembered) selectedTool = remembered;
+    if (selectedTool !== 'none') {
+      const flags = this.getAIToolFlags(worktree.project, selectedTool);
+      const flagStr = flags.length > 0 ? ' ' + flags.map(shellQuote).join(' ') : '';
+      if (selectedTool === 'claude') this.launchClaudeSessionWithFallback(sessionName, worktree.path, flagStr, `${worktree.feature} - ${worktree.project}`, initialPrompt);
+      else this.tmux.createSessionWithCommand(sessionName, worktree.path, aiLaunchCommand(selectedTool) + flagStr, true);
+      setLastTool(selectedTool, worktree.path);
+    } else {
+      this.tmux.createSession(sessionName, worktree.path, true);
+    }
+    return {sessionName, selectedTool, created: true};
+  }
+
+  async attachSession(worktree: WorktreeInfo, aiTool?: AITool, initialPrompt?: string): Promise<void> {
+    const {sessionName, selectedTool} = await this.createSessionIfNeeded(worktree, aiTool, initialPrompt);
     this.tmux.attachSessionWithControls(sessionName, {
       project: worktree.project,
       worktree: worktree.feature,
@@ -347,6 +412,12 @@ export class WorktreeCore implements CoreBase<State> {
     });
     await this.refreshSingleWorktree(worktree); // working→idle transition handles cache invalidation
   }
+
+  async launchSessionBackground(worktree: WorktreeInfo, aiTool?: AITool, initialPrompt?: string): Promise<void> {
+    const {created} = await this.createSessionIfNeeded(worktree, aiTool, initialPrompt);
+    if (created) await this.refreshSingleWorktree(worktree, true);
+  }
+
   async attachShellSession(worktree: WorktreeInfo): Promise<void> {
     const name = this.tmux.shellSessionName(worktree.project, worktree.feature);
     const sessions = await this.tmux.listSessions();

--- a/src/screens/TrackerBoardScreen.tsx
+++ b/src/screens/TrackerBoardScreen.tsx
@@ -18,6 +18,8 @@ interface TrackerBoardScreenProps {
   onCustomizeStages?: () => void;
 }
 
+const SPINNER_CHARS = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
+
 const MIN_COLUMN_WIDTH = 20;
 const MAX_COLUMN_WIDTH = 50;
 const PLAN_COLOR = 'blue';
@@ -49,6 +51,8 @@ export default function TrackerBoardScreen({
   const [selectedRowByColumn, setSelectedRowByColumn] = React.useState<Record<number, number>>({});
   const [createMode, setCreateMode] = React.useState(false);
   const [createTitle, setCreateTitle] = React.useState('');
+  const [pendingCreations, setPendingCreations] = React.useState<Set<string>>(new Set());
+  const [spinnerFrame, setSpinnerFrame] = React.useState(0);
   const [proposalInputMode, setProposalInputMode] = React.useState(false);
   const [proposalPrompt, setProposalPrompt] = React.useState('');
   const [pickerMode, setPickerMode] = React.useState(false);
@@ -160,6 +164,12 @@ export default function TrackerBoardScreen({
     }
   }, [project, projectPath, service]);
 
+  React.useEffect(() => {
+    if (pendingCreations.size === 0) return;
+    const id = setInterval(() => setSpinnerFrame(f => (f + 1) % SPINNER_CHARS.length), 80);
+    return () => clearInterval(id);
+  }, [pendingCreations.size]);
+
   const reloadBoard = React.useCallback(() => {
     setBoard(service.loadBoard(project, projectPath));
   }, [service, project, projectPath]);
@@ -243,13 +253,25 @@ export default function TrackerBoardScreen({
 
   const handleCreateSubmit = React.useCallback(() => {
     const title = createTitle.trim();
-    if (title) {
-      service.createItem(projectPath, title, currentColumn?.id || 'backlog');
-      reloadBoard();
-    }
     setCreateMode(false);
     setCreateTitle('');
-  }, [createTitle, service, projectPath, currentColumn, reloadBoard]);
+    if (!title) return;
+
+    const stage = (currentColumn?.id || 'backlog') as Parameters<typeof service.createItem>[2];
+    const tempSlug = service.slugify(title);
+    if (!tempSlug) return;
+
+    service.createItem(projectPath, title, stage, tempSlug);
+    reloadBoard();
+    setPendingCreations(prev => new Set(prev).add(tempSlug));
+
+    const existingSlugs = board.columns.flatMap(col => col.items.map(it => it.slug));
+    void service.deriveSlug(title, existingSlugs).then(finalSlug => {
+      if (finalSlug !== tempSlug) service.renameItem(projectPath, tempSlug, finalSlug, title);
+      setPendingCreations(prev => { const next = new Set(prev); next.delete(tempSlug); return next; });
+      reloadBoard();
+    });
+  }, [createTitle, service, projectPath, currentColumn, reloadBoard, board]);
 
   const handleProposalSubmit = React.useCallback(() => {
     if (proposalGenerating) return;
@@ -453,8 +475,9 @@ export default function TrackerBoardScreen({
             const isWorking = aiStatus === 'working' || aiStatus === 'active';
             const hasSession = !!sessWt;
 
-            const statusGlyph = isWaiting ? '!' : isWorking ? '⟳' : hasSession ? '◆' : ' ';
-            const statusColor = isWaiting ? 'yellow' : isWorking ? 'cyan' : hasSession ? 'gray' : undefined;
+            const isPending = pendingCreations.has(item.slug);
+            const statusGlyph = isPending ? SPINNER_CHARS[spinnerFrame] : isWaiting ? '!' : isWorking ? '⟳' : hasSession ? '◆' : ' ';
+            const statusColor = isPending ? 'yellow' : isWaiting ? 'yellow' : isWorking ? 'cyan' : hasSession ? 'gray' : undefined;
 
             // Slug row eats: 2 (border) + 2 (paddingX) + 2 (cursor) + 2 (status glyph) = 8 chars
             const slug = truncateDisplay(item.slug, Math.max(4, colWidth - 8));
@@ -478,7 +501,9 @@ export default function TrackerBoardScreen({
                   </Text>
                 </Box>
                 {/* Status / secondary text */}
-                {isWaiting ? (
+                {isPending ? (
+                  <Text color="yellow" wrap="truncate">{`    ${truncateDisplay('deriving slug…', secMax)}`}</Text>
+                ) : isWaiting ? (
                   <Text color="yellow" bold wrap="truncate">{`    ${truncateDisplay('waiting for you', secMax)}`}</Text>
                 ) : isWorking ? (
                   <Text color="cyan" wrap="truncate">{`    ${truncateDisplay('running', secMax)}`}</Text>

--- a/src/screens/TrackerBoardScreen.tsx
+++ b/src/screens/TrackerBoardScreen.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import {Box, Text, useInput} from 'ink';
-import {TrackerBoard, TrackerItem, TrackerService} from '../services/TrackerService.js';
+import {TrackerBoard, TrackerItem, TrackerService, TrackerStage} from '../services/TrackerService.js';
 import {useKeyboardShortcuts} from '../hooks/useKeyboardShortcuts.js';
 import {useTerminalDimensions} from '../hooks/useTerminalDimensions.js';
 import {useUIContext} from '../contexts/UIContext.js';
@@ -257,7 +257,7 @@ export default function TrackerBoardScreen({
     setCreateTitle('');
     if (!title) return;
 
-    const stage = (currentColumn?.id || 'backlog') as Parameters<typeof service.createItem>[2];
+    const stage = (currentColumn?.id || 'backlog') as TrackerStage;
     const tempSlug = service.slugify(title);
     if (!tempSlug) return;
 
@@ -267,9 +267,9 @@ export default function TrackerBoardScreen({
 
     const existingSlugs = board.columns.flatMap(col => col.items.map(it => it.slug));
     void service.deriveSlug(title, existingSlugs).then(finalSlug => {
-      if (finalSlug !== tempSlug) service.renameItem(projectPath, tempSlug, finalSlug, title);
+      const renamed = finalSlug !== tempSlug && service.renameItem(projectPath, tempSlug, finalSlug, title);
       setPendingCreations(prev => { const next = new Set(prev); next.delete(tempSlug); return next; });
-      reloadBoard();
+      if (renamed) reloadBoard();
     });
   }, [createTitle, service, projectPath, currentColumn, reloadBoard, board]);
 

--- a/src/screens/TrackerBoardScreen.tsx
+++ b/src/screens/TrackerBoardScreen.tsx
@@ -285,7 +285,7 @@ export default function TrackerBoardScreen({
     // stale-read race when the user queues two items back-to-back within the
     // ~5s slug-derivation window.
     const slugsAtStart = new Set(service.loadBoard(project, projectPath).columns.flatMap(c => c.items.map(it => it.slug)));
-    void service.deriveSlug(pending.title, [...slugsAtStart]).then(slug => {
+    service.deriveSlug(pending.title, [...slugsAtStart]).then(slug => {
       if (unmountedRef.current) return;
       setPendingNew(null);
       // Re-check uniqueness right before creating in case a concurrent
@@ -302,6 +302,10 @@ export default function TrackerBoardScreen({
       onLaunchItemBackground(item, tool).catch(err => {
         logError('launchSessionForItemBackground failed', {error: err instanceof Error ? err.message : String(err)});
       });
+    }).catch(err => {
+      if (unmountedRef.current) return;
+      setPendingNew(null);
+      logError('deriveSlug failed', {error: err instanceof Error ? err.message : String(err)});
     });
   }, [service, projectPath, project, onLaunchItemBackground]);
 

--- a/src/screens/TrackerBoardScreen.tsx
+++ b/src/screens/TrackerBoardScreen.tsx
@@ -8,6 +8,7 @@ import {useWorktreeContext} from '../contexts/WorktreeContext.js';
 import {WorktreeInfo} from '../models.js';
 import type {AIStatus, AITool} from '../models.js';
 import {truncateDisplay} from '../shared/utils/formatting.js';
+import {logError} from '../shared/utils/logger.js';
 import {startIntervalIfEnabled} from '../shared/utils/intervals.js';
 import {VISIBLE_STATUS_REFRESH_DURATION} from '../constants.js';
 import TrackerProjectPickerDialog from '../components/dialogs/TrackerProjectPickerDialog.js';
@@ -277,18 +278,28 @@ export default function TrackerBoardScreen({
 
   const startDerivation = React.useCallback((pending: PendingNew, tool: AITool | null) => {
     setPendingNew(pending);
-    const existingSlugs = board.columns.flatMap(col => col.items.map(it => it.slug));
-    void service.deriveSlug(pending.title, existingSlugs).then(slug => {
+    // Reading slugs from disk (rather than the closure-captured board) avoids a
+    // stale-read race when the user queues two items back-to-back within the
+    // ~5s slug-derivation window.
+    const slugsAtStart = new Set(service.loadBoard(project, projectPath).columns.flatMap(c => c.items.map(it => it.slug)));
+    void service.deriveSlug(pending.title, [...slugsAtStart]).then(slug => {
       setPendingNew(null);
-      service.createItem(projectPath, pending.title, pending.stage, slug);
+      // Re-check uniqueness right before creating in case a concurrent
+      // derivation committed the same slug while this one was in flight.
+      const taken = new Set(service.loadBoard(project, projectPath).columns.flatMap(c => c.items.map(it => it.slug)));
+      let finalSlug = slug;
+      for (let i = 2; taken.has(finalSlug); i++) finalSlug = `${slug}-${i}`;
+      service.createItem(projectPath, pending.title, pending.stage, finalSlug);
       const freshBoard = service.loadBoard(project, projectPath);
       setBoard(freshBoard);
       if (!onLaunchItemBackground || !tool) return;
-      const item = freshBoard.columns.flatMap(c => c.items).find(i => i.slug === slug);
+      const item = freshBoard.columns.flatMap(c => c.items).find(i => i.slug === finalSlug);
       if (!item) return;
-      void onLaunchItemBackground(item, tool);
+      onLaunchItemBackground(item, tool).catch(err => {
+        logError('launchSessionForItemBackground failed', {error: err instanceof Error ? err.message : String(err)});
+      });
     });
-  }, [board, service, projectPath, project, onLaunchItemBackground]);
+  }, [service, projectPath, project, onLaunchItemBackground]);
 
   const handleCreateSubmit = React.useCallback(() => {
     const title = createTitle.trim();

--- a/src/screens/TrackerBoardScreen.tsx
+++ b/src/screens/TrackerBoardScreen.tsx
@@ -276,6 +276,9 @@ export default function TrackerBoardScreen({
     });
   }, [currentItem, getWorktreeForItem, showArchiveConfirmation, backToTracker]);
 
+  const unmountedRef = React.useRef(false);
+  React.useEffect(() => () => { unmountedRef.current = true; }, []);
+
   const startDerivation = React.useCallback((pending: PendingNew, tool: AITool | null) => {
     setPendingNew(pending);
     // Reading slugs from disk (rather than the closure-captured board) avoids a
@@ -283,6 +286,7 @@ export default function TrackerBoardScreen({
     // ~5s slug-derivation window.
     const slugsAtStart = new Set(service.loadBoard(project, projectPath).columns.flatMap(c => c.items.map(it => it.slug)));
     void service.deriveSlug(pending.title, [...slugsAtStart]).then(slug => {
+      if (unmountedRef.current) return;
       setPendingNew(null);
       // Re-check uniqueness right before creating in case a concurrent
       // derivation committed the same slug while this one was in flight.

--- a/src/screens/TrackerBoardScreen.tsx
+++ b/src/screens/TrackerBoardScreen.tsx
@@ -15,6 +15,7 @@ interface TrackerBoardScreenProps {
   projectPath: string;
   onBack: () => void;
   onOpenItem: (item: TrackerItem) => void;
+  onLaunchItem?: (item: TrackerItem) => void;
   onCustomizeStages?: () => void;
 }
 
@@ -43,6 +44,7 @@ export default function TrackerBoardScreen({
   projectPath,
   onBack,
   onOpenItem,
+  onLaunchItem,
   onCustomizeStages,
 }: TrackerBoardScreenProps) {
   const service = React.useMemo(() => new TrackerService(), []);
@@ -267,11 +269,17 @@ export default function TrackerBoardScreen({
 
     const existingSlugs = board.columns.flatMap(col => col.items.map(it => it.slug));
     void service.deriveSlug(title, existingSlugs).then(finalSlug => {
-      const renamed = finalSlug !== tempSlug && service.renameItem(projectPath, tempSlug, finalSlug, title);
+      const effectiveSlug = (finalSlug !== tempSlug && service.renameItem(projectPath, tempSlug, finalSlug, title))
+        ? finalSlug : tempSlug;
       setPendingCreations(prev => { const next = new Set(prev); next.delete(tempSlug); return next; });
-      if (renamed) reloadBoard();
+      const freshBoard = service.loadBoard(project, projectPath);
+      setBoard(freshBoard);
+      if (onLaunchItem) {
+        const item = freshBoard.columns.flatMap(c => c.items).find(i => i.slug === effectiveSlug);
+        if (item) onLaunchItem(item);
+      }
     });
-  }, [createTitle, service, projectPath, currentColumn, reloadBoard, board]);
+  }, [createTitle, service, projectPath, project, currentColumn, reloadBoard, board, onLaunchItem]);
 
   const handleProposalSubmit = React.useCallback(() => {
     if (proposalGenerating) return;

--- a/src/screens/TrackerBoardScreen.tsx
+++ b/src/screens/TrackerBoardScreen.tsx
@@ -6,18 +6,27 @@ import {useTerminalDimensions} from '../hooks/useTerminalDimensions.js';
 import {useUIContext} from '../contexts/UIContext.js';
 import {useWorktreeContext} from '../contexts/WorktreeContext.js';
 import {WorktreeInfo} from '../models.js';
-import type {AIStatus} from '../models.js';
+import type {AIStatus, AITool} from '../models.js';
 import {truncateDisplay} from '../shared/utils/formatting.js';
+import {startIntervalIfEnabled} from '../shared/utils/intervals.js';
+import {VISIBLE_STATUS_REFRESH_DURATION} from '../constants.js';
 import TrackerProjectPickerDialog from '../components/dialogs/TrackerProjectPickerDialog.js';
+import AIToolDialog from '../components/dialogs/AIToolDialog.js';
 
 interface TrackerBoardScreenProps {
   project: string;
   projectPath: string;
   onBack: () => void;
   onOpenItem: (item: TrackerItem) => void;
-  onLaunchItem?: (item: TrackerItem) => void;
+  onLaunchItemBackground?: (item: TrackerItem, tool: AITool) => Promise<void>;
   onCustomizeStages?: () => void;
 }
+
+type PendingNew = {
+  title: string;
+  stage: TrackerStage;
+  columnIndex: number;
+};
 
 const SPINNER_CHARS = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
 
@@ -44,7 +53,7 @@ export default function TrackerBoardScreen({
   projectPath,
   onBack,
   onOpenItem,
-  onLaunchItem,
+  onLaunchItemBackground,
   onCustomizeStages,
 }: TrackerBoardScreenProps) {
   const service = React.useMemo(() => new TrackerService(), []);
@@ -53,8 +62,9 @@ export default function TrackerBoardScreen({
   const [selectedRowByColumn, setSelectedRowByColumn] = React.useState<Record<number, number>>({});
   const [createMode, setCreateMode] = React.useState(false);
   const [createTitle, setCreateTitle] = React.useState('');
-  const [pendingCreations, setPendingCreations] = React.useState<Set<string>>(new Set());
+  const [pendingNew, setPendingNew] = React.useState<PendingNew | null>(null);
   const [spinnerFrame, setSpinnerFrame] = React.useState(0);
+  const [toolPickPending, setToolPickPending] = React.useState<PendingNew | null>(null);
   const [proposalInputMode, setProposalInputMode] = React.useState(false);
   const [proposalPrompt, setProposalPrompt] = React.useState('');
   const [pickerMode, setPickerMode] = React.useState(false);
@@ -80,7 +90,10 @@ export default function TrackerBoardScreen({
     attachShellSession,
     attachRunSession,
     discoverProjects,
+    getAvailableAITools,
+    refreshProjectWorktrees,
   } = useWorktreeContext();
+  const availableTools = React.useMemo(() => getAvailableAITools(), [getAvailableAITools]);
   const {columns: termCols, rows: termRows} = useTerminalDimensions();
 
   // Chrome per row: outer paddingX (2) + group separator (2) + n marginRights.
@@ -166,11 +179,20 @@ export default function TrackerBoardScreen({
     }
   }, [project, projectPath, service]);
 
+  const hasPendingNew = pendingNew !== null;
   React.useEffect(() => {
-    if (pendingCreations.size === 0) return;
+    if (!hasPendingNew) return;
     const id = setInterval(() => setSpinnerFrame(f => (f + 1) % SPINNER_CHARS.length), 80);
     return () => clearInterval(id);
-  }, [pendingCreations.size]);
+  }, [hasPendingNew]);
+
+  // The top-level 60s refresh is too slow to pick up ai_status transitions after
+  // a new item's session boots. Poll just this project's worktrees every 2s.
+  React.useEffect(() => {
+    return startIntervalIfEnabled(() => {
+      refreshProjectWorktrees(project).catch(() => {});
+    }, VISIBLE_STATUS_REFRESH_DURATION);
+  }, [project, refreshProjectWorktrees]);
 
   const reloadBoard = React.useCallback(() => {
     setBoard(service.loadBoard(project, projectPath));
@@ -253,33 +275,48 @@ export default function TrackerBoardScreen({
     });
   }, [currentItem, getWorktreeForItem, showArchiveConfirmation, backToTracker]);
 
+  const startDerivation = React.useCallback((pending: PendingNew, tool: AITool | null) => {
+    setPendingNew(pending);
+    const existingSlugs = board.columns.flatMap(col => col.items.map(it => it.slug));
+    void service.deriveSlug(pending.title, existingSlugs).then(slug => {
+      setPendingNew(null);
+      service.createItem(projectPath, pending.title, pending.stage, slug);
+      const freshBoard = service.loadBoard(project, projectPath);
+      setBoard(freshBoard);
+      if (!onLaunchItemBackground || !tool) return;
+      const item = freshBoard.columns.flatMap(c => c.items).find(i => i.slug === slug);
+      if (!item) return;
+      void onLaunchItemBackground(item, tool);
+    });
+  }, [board, service, projectPath, project, onLaunchItemBackground]);
+
   const handleCreateSubmit = React.useCallback(() => {
     const title = createTitle.trim();
     setCreateMode(false);
     setCreateTitle('');
-    if (!title) return;
+    if (!title || !service.slugify(title)) return;
 
     const stage = (currentColumn?.id || 'backlog') as TrackerStage;
-    const tempSlug = service.slugify(title);
-    if (!tempSlug) return;
+    const pending: PendingNew = {title, stage, columnIndex: selectedColumn};
 
-    service.createItem(projectPath, title, stage, tempSlug);
-    reloadBoard();
-    setPendingCreations(prev => new Set(prev).add(tempSlug));
+    if (onLaunchItemBackground && availableTools.length > 1) {
+      setToolPickPending(pending);
+    } else {
+      const defaultTool: AITool | null = availableTools[0] ?? null;
+      startDerivation(pending, onLaunchItemBackground ? defaultTool : null);
+    }
+  }, [createTitle, service, currentColumn, selectedColumn, availableTools, onLaunchItemBackground, startDerivation]);
 
-    const existingSlugs = board.columns.flatMap(col => col.items.map(it => it.slug));
-    void service.deriveSlug(title, existingSlugs).then(finalSlug => {
-      const effectiveSlug = (finalSlug !== tempSlug && service.renameItem(projectPath, tempSlug, finalSlug, title))
-        ? finalSlug : tempSlug;
-      setPendingCreations(prev => { const next = new Set(prev); next.delete(tempSlug); return next; });
-      const freshBoard = service.loadBoard(project, projectPath);
-      setBoard(freshBoard);
-      if (onLaunchItem) {
-        const item = freshBoard.columns.flatMap(c => c.items).find(i => i.slug === effectiveSlug);
-        if (item) onLaunchItem(item);
-      }
-    });
-  }, [createTitle, service, projectPath, project, currentColumn, reloadBoard, board, onLaunchItem]);
+  const handleToolSelect = React.useCallback((tool: AITool) => {
+    if (!toolPickPending) return;
+    const pending = toolPickPending;
+    setToolPickPending(null);
+    startDerivation(pending, tool);
+  }, [toolPickPending, startDerivation]);
+
+  const handleToolCancel = React.useCallback(() => {
+    setToolPickPending(null);
+  }, []);
 
   const handleProposalSubmit = React.useCallback(() => {
     if (proposalGenerating) return;
@@ -316,7 +353,7 @@ export default function TrackerBoardScreen({
     else if (!key.ctrl && !key.meta && input && input.length === 1) { setProposalPrompt(prev => prev + input); }
   });
 
-  const inputActive = createMode || proposalInputMode || pickerMode;
+  const inputActive = createMode || proposalInputMode || pickerMode || !!toolPickPending;
   const currentItemSession = currentItem ? getSessionForItem(currentItem) : null;
   const currentItemWorktree = currentItem ? getWorktreeForItem(currentItem) : null;
   const hasWorktree = !!currentItemWorktree;
@@ -373,6 +410,18 @@ export default function TrackerBoardScreen({
           currentProjectName={project}
           onCancel={() => setPickerMode(false)}
           onSelect={(p) => { setPickerMode(false); showTracker(p); }}
+        />
+      </Box>
+    );
+  }
+
+  if (toolPickPending) {
+    return (
+      <Box flexDirection="column" flexGrow={1} alignItems="center" justifyContent="center">
+        <AIToolDialog
+          availableTools={availableTools}
+          onSelect={handleToolSelect}
+          onCancel={handleToolCancel}
         />
       </Box>
     );
@@ -483,9 +532,8 @@ export default function TrackerBoardScreen({
             const isWorking = aiStatus === 'working' || aiStatus === 'active';
             const hasSession = !!sessWt;
 
-            const isPending = pendingCreations.has(item.slug);
-            const statusGlyph = isPending ? SPINNER_CHARS[spinnerFrame] : isWaiting ? '!' : isWorking ? '⟳' : hasSession ? '◆' : ' ';
-            const statusColor = isPending ? 'yellow' : isWaiting ? 'yellow' : isWorking ? 'cyan' : hasSession ? 'gray' : undefined;
+            const statusGlyph = isWaiting ? '!' : isWorking ? '⟳' : hasSession ? '◆' : ' ';
+            const statusColor = isWaiting ? 'yellow' : isWorking ? 'cyan' : hasSession ? 'gray' : undefined;
 
             // Slug row eats: 2 (border) + 2 (paddingX) + 2 (cursor) + 2 (status glyph) = 8 chars
             const slug = truncateDisplay(item.slug, Math.max(4, colWidth - 8));
@@ -509,9 +557,7 @@ export default function TrackerBoardScreen({
                   </Text>
                 </Box>
                 {/* Status / secondary text */}
-                {isPending ? (
-                  <Text color="yellow" wrap="truncate">{`    ${truncateDisplay('deriving slug…', secMax)}`}</Text>
-                ) : isWaiting ? (
+                {isWaiting ? (
                   <Text color="yellow" bold wrap="truncate">{`    ${truncateDisplay('waiting for you', secMax)}`}</Text>
                 ) : isWorking ? (
                   <Text color="cyan" wrap="truncate">{`    ${truncateDisplay('running', secMax)}`}</Text>
@@ -528,7 +574,18 @@ export default function TrackerBoardScreen({
             <Text dimColor>{`  ↓ ${moreBelow} more`}</Text>
           )}
 
-          {total === 0 && !(inputActive && isActiveColumn) && (
+          {pendingNew?.columnIndex === columnIndex && (
+            <Box flexDirection="column" marginBottom={1} flexShrink={0}>
+              <Box>
+                <Text color={accent} bold>{'  '}</Text>
+                <Text color="yellow" bold>{SPINNER_CHARS[spinnerFrame]} </Text>
+                <Text color="yellow" wrap="truncate">{truncateDisplay(pendingNew.title, Math.max(4, colWidth - 8))}</Text>
+              </Box>
+              <Text color="yellow" wrap="truncate">{`    ${truncateDisplay('deriving slug…', Math.max(4, colWidth - 8))}`}</Text>
+            </Box>
+          )}
+
+          {total === 0 && !pendingNew && !(inputActive && isActiveColumn) && (
             <Text dimColor>  (empty)</Text>
           )}
 

--- a/src/screens/TrackerProposalScreen.tsx
+++ b/src/screens/TrackerProposalScreen.tsx
@@ -37,7 +37,7 @@ export default function TrackerProposalScreen({
     for (const index of accepted) {
       const item = proposals[index];
       if (item) {
-        tracker.createItem(projectPath, item.title, 'backlog');
+        tracker.createItem(projectPath, item.title, 'backlog', item.slug, item.description);
       }
     }
     tracker.clearPendingProposals(projectPath);

--- a/src/services/TrackerService.ts
+++ b/src/services/TrackerService.ts
@@ -437,11 +437,12 @@ export class TrackerService {
   }
 
   async deriveSlug(title: string, existingSlugs: string[]): Promise<string> {
-    const prompt = `Generate a concise kebab-case slug (2-4 words, max 30 chars) for this tracker item. Reply with ONLY the slug, nothing else.\n\nTitle: ${title}`;
+    const maxLen = 30;
+    const prompt = `Generate a concise kebab-case slug (2-4 words, max ${maxLen} chars) for this tracker item. Reply with ONLY the slug, nothing else.\n\nTitle: ${title}`;
     const result = await runClaudeAsync(prompt, {timeoutMs: 8000});
     let derived = this.slugify(title);
     if (result.success && result.output) {
-      const candidate = this.slugify(result.output.trim(), 40);
+      const candidate = this.slugify(result.output.trim(), maxLen);
       if (candidate && this.isValidSlug(candidate)) derived = candidate;
     }
     if (!existingSlugs.includes(derived)) return derived;

--- a/src/services/TrackerService.ts
+++ b/src/services/TrackerService.ts
@@ -378,7 +378,8 @@ export class TrackerService {
   }
 
   private isValidSlug(slug: string): boolean {
-    return /^[a-z0-9][a-z0-9-]*$/.test(slug);
+    // Must start and end with alphanumeric; hyphens only in the middle.
+    return /^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/.test(slug);
   }
 
   nextStage(stage: TrackerStage): TrackerStage | null {

--- a/src/services/TrackerService.ts
+++ b/src/services/TrackerService.ts
@@ -423,10 +423,10 @@ export class TrackerService {
   private writeRequirementsStub(reqPath: string, title: string, slug: string, body: string): boolean {
     if (fs.existsSync(reqPath)) return false;
     const today = new Date().toISOString().slice(0, 10);
-    // Strip newlines in the title so they can't break out of the frontmatter
-    // into forged keys like "slug: injected".
-    const safeTitle = title.replace(/[\r\n]+/g, ' ').trim();
-    fs.writeFileSync(reqPath, `---\ntitle: ${safeTitle}\nslug: ${slug}\nupdated: ${today}\n---\n\n${body}\n`);
+    // Strip newlines and quote the title so YAML-significant characters (":",
+    // "'", "[", "!") in user-typed titles can't forge frontmatter keys.
+    const yamlTitle = JSON.stringify(title.replace(/[\r\n]+/g, ' ').trim());
+    fs.writeFileSync(reqPath, `---\ntitle: ${yamlTitle}\nslug: ${slug}\nupdated: ${today}\n---\n\n${body}\n`);
     return true;
   }
 

--- a/src/services/TrackerService.ts
+++ b/src/services/TrackerService.ts
@@ -280,6 +280,9 @@ export class TrackerService {
     // Legacy worktree path (pre-`items/` rename).
     const legacyWtDir = path.join(this.getWorktreePathForSlug(projectPath, slug), 'tracker', slug);
     if (fs.existsSync(legacyWtDir)) return legacyWtDir;
+    // Stub written by createItem before a worktree exists.
+    const mainItemDir = path.join(projectPath, 'tracker', 'items', slug);
+    if (fs.existsSync(mainItemDir)) return mainItemDir;
     // Archive lives in the main project regardless of worktree existence.
     const archiveDir = this.getArchiveItemDir(projectPath, slug);
     if (fs.existsSync(archiveDir)) return archiveDir;
@@ -366,12 +369,12 @@ export class TrackerService {
     };
   }
 
-  slugify(title: string): string {
+  slugify(title: string, maxLength = 20): string {
     return title
       .toLowerCase()
       .replace(/[^a-z0-9]+/g, '-')
       .replace(/^-|-$/g, '')
-      .slice(0, 20);
+      .slice(0, maxLength);
   }
 
   private isValidSlug(slug: string): boolean {
@@ -403,9 +406,6 @@ export class TrackerService {
       if (stageBySlug.get(slug) === stage) return;
     }
     this.ensureTracker(projectPath);
-    // Files are materialised on demand by ensureItemFiles() when a session is launched.
-    // Persist the title under sessions[slug] so we can show a meaningful title on the
-    // board before the worktree exists; frontmatter wins once files are written.
     const index = this.readIndex(projectPath);
     this.removeSlugFromIndexObj(index, slug);
     this.addSlugToIndexObj(index, slug, stage);
@@ -413,6 +413,15 @@ export class TrackerService {
     sessions[slug] = {...sessions[slug], title};
     index.sessions = sessions;
     writeJSONAtomic(this.getIndexPath(projectPath), index);
+    // Write requirements stub immediately so the item screen shows the description
+    // before a worktree session is launched. ensureItemFiles will migrate this later.
+    const mainItemDir = path.join(projectPath, 'tracker', 'items', slug);
+    ensureDirectory(mainItemDir);
+    const reqPath = path.join(mainItemDir, 'requirements.md');
+    if (!fs.existsSync(reqPath)) {
+      const today = new Date().toISOString().slice(0, 10);
+      fs.writeFileSync(reqPath, `---\ntitle: ${title}\nslug: ${slug}\nupdated: ${today}\n---\n\n${title}\n`);
+    }
   }
 
   async deriveSlug(title: string, existingSlugs: string[]): Promise<string> {
@@ -420,7 +429,7 @@ export class TrackerService {
     const result = await runClaudeAsync(prompt, {timeoutMs: 8000});
     let derived = this.slugify(title);
     if (result.success && result.output) {
-      const candidate = this.slugify(result.output.trim());
+      const candidate = this.slugify(result.output.trim(), 40);
       if (candidate && this.isValidSlug(candidate)) derived = candidate;
     }
     if (!existingSlugs.includes(derived)) return derived;
@@ -503,10 +512,12 @@ export class TrackerService {
 
     let wroteAnything = false;
 
-    // 1) Migrate from any legacy location: previous worktree path or main-project buckets.
+    // 1) Migrate from legacy locations (highest priority first), then the main-project
+    // stub written by createItem as a last resort.
     const legacySources = [
       path.join(worktreePath, 'tracker', slug),
       ...this.findLegacyMainProjectDirs(mainProjectPath, slug),
+      path.join(mainProjectPath, 'tracker', 'items', slug),
     ].filter(p => fs.existsSync(p));
     for (const src of legacySources) {
       for (const file of fs.readdirSync(src)) {

--- a/src/services/TrackerService.ts
+++ b/src/services/TrackerService.ts
@@ -411,6 +411,39 @@ export class TrackerService {
     writeJSONAtomic(this.getIndexPath(projectPath), index);
   }
 
+  async deriveSlug(title: string, existingSlugs: string[]): Promise<string> {
+    const prompt = `Generate a concise kebab-case slug (2-4 words, max 30 chars) for this tracker item. Reply with ONLY the slug, nothing else.\n\nTitle: ${title}`;
+    const result = await runClaudeAsync(prompt, {timeoutMs: 8000});
+    let derived = this.slugify(title);
+    if (result.success && result.output) {
+      const candidate = result.output.trim().toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '').slice(0, 30);
+      if (candidate && /^[a-z0-9][a-z0-9-]*$/.test(candidate)) derived = candidate;
+    }
+    if (!existingSlugs.includes(derived)) return derived;
+    let i = 2;
+    while (existingSlugs.includes(`${derived}-${i}`)) i++;
+    return `${derived}-${i}`;
+  }
+
+  renameItem(projectPath: string, oldSlug: string, newSlug: string, title: string): boolean {
+    if (oldSlug === newSlug) return false;
+    if (!newSlug || !/^[a-z0-9][a-z0-9-]*$/.test(newSlug)) return false;
+    const index = this.readIndex(projectPath);
+    const stage = this.createStageBySlug(index).get(oldSlug);
+    if (!stage) return false;
+    this.removeSlugFromIndexObj(index, oldSlug);
+    this.addSlugToIndexObj(index, newSlug, stage);
+    const sessions = (index.sessions ?? {}) as NonNullable<TrackerIndex['sessions']>;
+    delete sessions[oldSlug];
+    sessions[newSlug] = {title};
+    index.sessions = sessions;
+    writeJSONAtomic(this.getIndexPath(projectPath), index);
+    const oldDir = path.join(projectPath, 'tracker', 'items', oldSlug);
+    const newDir = path.join(projectPath, 'tracker', 'items', newSlug);
+    if (fs.existsSync(oldDir) && !fs.existsSync(newDir)) fs.renameSync(oldDir, newDir);
+    return true;
+  }
+
   moveItem(projectPath: string, slug: string, toStage: TrackerStage): boolean {
     const index = this.readIndex(projectPath);
     const currentStage = this.createStageBySlug(index).get(slug);

--- a/src/services/TrackerService.ts
+++ b/src/services/TrackerService.ts
@@ -393,7 +393,7 @@ export class TrackerService {
     return STAGE_ORDER[idx - 1];
   }
 
-  createItem(projectPath: string, title: string, stage: TrackerStage = 'discovery', explicitSlug?: string): void {
+  createItem(projectPath: string, title: string, stage: TrackerStage = 'discovery', explicitSlug?: string, body?: string): void {
     const slug = explicitSlug || this.slugify(title);
     // Reject anything that isn't a plain slug — slugs are interpolated into file
     // paths, so a stray '.' or '/' would let a crafted title escape the tracker dir.
@@ -417,11 +417,14 @@ export class TrackerService {
     // before a worktree session is launched. ensureItemFiles will migrate this later.
     const mainItemDir = path.join(projectPath, 'tracker', 'items', slug);
     ensureDirectory(mainItemDir);
-    const reqPath = path.join(mainItemDir, 'requirements.md');
-    if (!fs.existsSync(reqPath)) {
-      const today = new Date().toISOString().slice(0, 10);
-      fs.writeFileSync(reqPath, `---\ntitle: ${title}\nslug: ${slug}\nupdated: ${today}\n---\n\n${title}\n`);
-    }
+    this.writeRequirementsStub(path.join(mainItemDir, 'requirements.md'), title, slug, body || title);
+  }
+
+  private writeRequirementsStub(reqPath: string, title: string, slug: string, body: string): boolean {
+    if (fs.existsSync(reqPath)) return false;
+    const today = new Date().toISOString().slice(0, 10);
+    fs.writeFileSync(reqPath, `---\ntitle: ${title}\nslug: ${slug}\nupdated: ${today}\n---\n\n${body}\n`);
+    return true;
   }
 
   async deriveSlug(title: string, existingSlugs: string[]): Promise<string> {
@@ -537,10 +540,8 @@ export class TrackerService {
     }
 
     // 2) If we still have no requirements.md, write a fresh stub.
-    if (!fs.existsSync(reqPath)) {
-      const title = item?.title || slug;
-      const today = new Date().toISOString().slice(0, 10);
-      fs.writeFileSync(reqPath, `---\ntitle: ${title}\nslug: ${slug}\nupdated: ${today}\n---\n\n${title}\n`);
+    const stubTitle = item?.title || slug;
+    if (this.writeRequirementsStub(reqPath, stubTitle, slug, stubTitle)) {
       wroteAnything = true;
     }
 

--- a/src/services/TrackerService.ts
+++ b/src/services/TrackerService.ts
@@ -453,7 +453,15 @@ export class TrackerService {
     writeJSONAtomic(this.getIndexPath(projectPath), index);
     const oldDir = path.join(projectPath, 'tracker', 'items', oldSlug);
     const newDir = path.join(projectPath, 'tracker', 'items', newSlug);
-    if (fs.existsSync(oldDir) && !fs.existsSync(newDir)) fs.renameSync(oldDir, newDir);
+    if (fs.existsSync(oldDir) && !fs.existsSync(newDir)) {
+      fs.renameSync(oldDir, newDir);
+      // Update slug in requirements.md frontmatter so readItem returns the new slug.
+      const reqPath = path.join(newDir, 'requirements.md');
+      if (fs.existsSync(reqPath)) {
+        const content = fs.readFileSync(reqPath, 'utf8');
+        fs.writeFileSync(reqPath, content.replace(/^slug: .+$/m, `slug: ${newSlug}`), 'utf8');
+      }
+    }
     return true;
   }
 

--- a/src/services/TrackerService.ts
+++ b/src/services/TrackerService.ts
@@ -413,11 +413,17 @@ export class TrackerService {
     sessions[slug] = {...sessions[slug], title};
     index.sessions = sessions;
     writeJSONAtomic(this.getIndexPath(projectPath), index);
-    // Write requirements stub immediately so the item screen shows the description
-    // before a worktree session is launched. ensureItemFiles will migrate this later.
     const mainItemDir = path.join(projectPath, 'tracker', 'items', slug);
     ensureDirectory(mainItemDir);
-    this.writeRequirementsStub(path.join(mainItemDir, 'requirements.md'), title, slug, body || title);
+    // Requirements is just a stub with the title — it's written for real during
+    // the requirements stage. The user's initial description (the "what / why"
+    // they had in mind when they created the item) goes into notes.md, which is
+    // the discovery stage's output file.
+    this.writeRequirementsStub(path.join(mainItemDir, 'requirements.md'), title, slug, title);
+    if (body && body !== title) {
+      const notesPath = path.join(mainItemDir, 'notes.md');
+      if (!fs.existsSync(notesPath)) fs.writeFileSync(notesPath, `${body}\n`);
+    }
   }
 
   private writeRequirementsStub(reqPath: string, title: string, slug: string, body: string): boolean {

--- a/src/services/TrackerService.ts
+++ b/src/services/TrackerService.ts
@@ -423,7 +423,10 @@ export class TrackerService {
   private writeRequirementsStub(reqPath: string, title: string, slug: string, body: string): boolean {
     if (fs.existsSync(reqPath)) return false;
     const today = new Date().toISOString().slice(0, 10);
-    fs.writeFileSync(reqPath, `---\ntitle: ${title}\nslug: ${slug}\nupdated: ${today}\n---\n\n${body}\n`);
+    // Strip newlines in the title so they can't break out of the frontmatter
+    // into forged keys like "slug: injected".
+    const safeTitle = title.replace(/[\r\n]+/g, ' ').trim();
+    fs.writeFileSync(reqPath, `---\ntitle: ${safeTitle}\nslug: ${slug}\nupdated: ${today}\n---\n\n${body}\n`);
     return true;
   }
 
@@ -439,33 +442,6 @@ export class TrackerService {
     let i = 2;
     while (existingSlugs.includes(`${derived}-${i}`)) i++;
     return `${derived}-${i}`;
-  }
-
-  renameItem(projectPath: string, oldSlug: string, newSlug: string, title: string): boolean {
-    if (oldSlug === newSlug) return false;
-    if (!newSlug || !this.isValidSlug(newSlug)) return false;
-    const index = this.readIndex(projectPath);
-    const stage = this.createStageBySlug(index).get(oldSlug);
-    if (!stage) return false;
-    this.removeSlugFromIndexObj(index, oldSlug);
-    this.addSlugToIndexObj(index, newSlug, stage);
-    const sessions = (index.sessions ?? {}) as NonNullable<TrackerIndex['sessions']>;
-    delete sessions[oldSlug];
-    sessions[newSlug] = {title};
-    index.sessions = sessions;
-    writeJSONAtomic(this.getIndexPath(projectPath), index);
-    const oldDir = path.join(projectPath, 'tracker', 'items', oldSlug);
-    const newDir = path.join(projectPath, 'tracker', 'items', newSlug);
-    if (fs.existsSync(oldDir) && !fs.existsSync(newDir)) {
-      fs.renameSync(oldDir, newDir);
-      // Update slug in requirements.md frontmatter so readItem returns the new slug.
-      const reqPath = path.join(newDir, 'requirements.md');
-      if (fs.existsSync(reqPath)) {
-        const content = fs.readFileSync(reqPath, 'utf8');
-        fs.writeFileSync(reqPath, content.replace(/^slug: .+$/m, `slug: ${newSlug}`), 'utf8');
-      }
-    }
-    return true;
   }
 
   moveItem(projectPath: string, slug: string, toStage: TrackerStage): boolean {

--- a/src/services/TrackerService.ts
+++ b/src/services/TrackerService.ts
@@ -374,6 +374,10 @@ export class TrackerService {
       .slice(0, 20);
   }
 
+  private isValidSlug(slug: string): boolean {
+    return /^[a-z0-9][a-z0-9-]*$/.test(slug);
+  }
+
   nextStage(stage: TrackerStage): TrackerStage | null {
     const idx = STAGE_ORDER.indexOf(stage);
     if (idx < 0 || idx >= STAGE_ORDER.length - 1) return null;
@@ -390,7 +394,7 @@ export class TrackerService {
     const slug = explicitSlug || this.slugify(title);
     // Reject anything that isn't a plain slug — slugs are interpolated into file
     // paths, so a stray '.' or '/' would let a crafted title escape the tracker dir.
-    if (!slug || !/^[a-z0-9][a-z0-9-]*$/.test(slug)) return;
+    if (!slug || !this.isValidSlug(slug)) return;
     // Idempotent: if the slug is already in the index at the requested stage, do
     // nothing. Avoids double-create when the orphan-materialise handler races a
     // re-render that triggers Enter twice.
@@ -416,8 +420,8 @@ export class TrackerService {
     const result = await runClaudeAsync(prompt, {timeoutMs: 8000});
     let derived = this.slugify(title);
     if (result.success && result.output) {
-      const candidate = result.output.trim().toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '').slice(0, 30);
-      if (candidate && /^[a-z0-9][a-z0-9-]*$/.test(candidate)) derived = candidate;
+      const candidate = this.slugify(result.output.trim());
+      if (candidate && this.isValidSlug(candidate)) derived = candidate;
     }
     if (!existingSlugs.includes(derived)) return derived;
     let i = 2;
@@ -427,7 +431,7 @@ export class TrackerService {
 
   renameItem(projectPath: string, oldSlug: string, newSlug: string, title: string): boolean {
     if (oldSlug === newSlug) return false;
-    if (!newSlug || !/^[a-z0-9][a-z0-9-]*$/.test(newSlug)) return false;
+    if (!newSlug || !this.isValidSlug(newSlug)) return false;
     const index = this.readIndex(projectPath);
     const stage = this.createStageBySlug(index).get(oldSlug);
     if (!stage) return false;

--- a/tests/unit/tracker-board-create-flow.test.ts
+++ b/tests/unit/tracker-board-create-flow.test.ts
@@ -29,11 +29,13 @@ describe('board create-item flow (derive-first, no rename)', () => {
     expect(col.items.map(i => i.slug)).not.toContain('add-oauth-login-for'); // no temp slug
   });
 
-  test('requirements.md body contains the user-typed description', () => {
+  test('user-typed description is written to notes.md (discovery output), not requirements.md', () => {
     const description = 'Allow users to sign in with Google and GitHub via OAuth2.';
     service.createItem(tmpDir, 'OAuth Login', 'backlog', 'oauth-login', description);
+    const notesPath = path.join(tmpDir, 'tracker', 'items', 'oauth-login', 'notes.md');
+    expect(fs.readFileSync(notesPath, 'utf8')).toContain(description);
     const reqPath = path.join(tmpDir, 'tracker', 'items', 'oauth-login', 'requirements.md');
-    expect(fs.readFileSync(reqPath, 'utf8')).toContain(description);
+    expect(fs.readFileSync(reqPath, 'utf8')).not.toContain(description);
   });
 
   test('single-tool path calls onLaunchItemBackground immediately after slug derivation', async () => {

--- a/tests/unit/tracker-board-create-flow.test.ts
+++ b/tests/unit/tracker-board-create-flow.test.ts
@@ -1,0 +1,102 @@
+import {describe, test, expect, beforeEach, afterEach} from '@jest/globals';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import {TrackerService} from '../../src/services/TrackerService.js';
+import type {AITool} from '../../src/models.js';
+
+let tmpDir: string;
+let service: TrackerService;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'board-create-test-'));
+  service = new TrackerService();
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, {recursive: true, force: true});
+});
+
+describe('board create-item flow (derive-first, no rename)', () => {
+  test('item is created with the AI-derived slug directly — no temp slug', () => {
+    const title = 'Add OAuth login for users';
+    const derivedSlug = 'oauth-login';
+    service.createItem(tmpDir, title, 'backlog', derivedSlug, title);
+
+    const board = service.loadBoard('proj', tmpDir);
+    const col = board.columns.find(c => c.id === 'backlog')!;
+    expect(col.items.map(i => i.slug)).toContain('oauth-login');
+    expect(col.items.map(i => i.slug)).not.toContain('add-oauth-login-for'); // no temp slug
+  });
+
+  test('requirements.md body contains the user-typed description', () => {
+    const description = 'Allow users to sign in with Google and GitHub via OAuth2.';
+    service.createItem(tmpDir, 'OAuth Login', 'backlog', 'oauth-login', description);
+    const reqPath = path.join(tmpDir, 'tracker', 'items', 'oauth-login', 'requirements.md');
+    expect(fs.readFileSync(reqPath, 'utf8')).toContain(description);
+  });
+
+  test('single-tool path calls onLaunchItemBackground immediately after slug derivation', async () => {
+    const tools: AITool[] = ['claude'];
+    const launched: Array<{slug: string; tool: AITool}> = [];
+
+    // Simulate the board screen's handleCreateSubmit logic for single-tool case
+    const title = 'My Feature';
+    const slugPromise = Promise.resolve('my-feature');
+
+    const onLaunchItemBackground = (slug: string, tool: AITool) => launched.push({slug, tool});
+
+    const slug = await slugPromise;
+    service.createItem(tmpDir, title, 'backlog', slug, title);
+    const item = service.loadBoard('proj', tmpDir).columns.flatMap(c => c.items).find(i => i.slug === slug);
+    expect(item).toBeTruthy();
+
+    if (tools.length === 1 && item) {
+      onLaunchItemBackground(item.slug, tools[0]);
+    }
+
+    expect(launched).toHaveLength(1);
+    expect(launched[0].slug).toBe('my-feature');
+    expect(launched[0].tool).toBe('claude');
+  });
+
+  test('multi-tool path sets toolPickItem instead of auto-launching', () => {
+    const tools: AITool[] = ['claude', 'codex'];
+    let toolPickItemSet = false;
+    let autoLaunched = false;
+
+    const handleCreate = (selectedTools: AITool[]) => {
+      if (selectedTools.length > 1) {
+        toolPickItemSet = true; // sets toolPickItem state, shows picker
+      } else {
+        autoLaunched = true;
+      }
+    };
+
+    handleCreate(tools);
+    expect(toolPickItemSet).toBe(true);
+    expect(autoLaunched).toBe(false);
+  });
+
+  test('tool picker cancel does not launch but item still exists on board', async () => {
+    const slug = 'cancelled-feature';
+    service.createItem(tmpDir, 'Cancelled Feature', 'backlog', slug, 'Some description');
+
+    const launched: string[] = [];
+    // Simulate handleToolCancel: just clears toolPickItem, no launch
+    // The item remains on the board
+    const board = service.loadBoard('proj', tmpDir);
+    const item = board.columns.flatMap(c => c.items).find(i => i.slug === slug);
+
+    expect(item).toBeTruthy(); // item persists
+    expect(launched).toHaveLength(0); // no launch
+  });
+
+  test('no temp slug appears in the index during derivation window', () => {
+    // Before createItem is called, nothing should be in the index
+    service.ensureTracker(tmpDir);
+    const index = JSON.parse(fs.readFileSync(path.join(tmpDir, 'tracker', 'index.json'), 'utf8'));
+    // No temp slug like 'add-oauth-login-for-use' (truncated to 20 chars)
+    expect(JSON.stringify(index)).not.toContain('add-oauth-login-for-use');
+  });
+});

--- a/tests/unit/tracker-board-create-flow.test.ts
+++ b/tests/unit/tracker-board-create-flow.test.ts
@@ -80,18 +80,29 @@ describe('board create-item flow (derive-first, no rename)', () => {
     expect(autoLaunched).toBe(false);
   });
 
-  test('tool picker cancel does not launch but item still exists on board', async () => {
-    const slug = 'cancelled-feature';
-    service.createItem(tmpDir, 'Cancelled Feature', 'backlog', slug, 'Some description');
-
+  test('tool picker cancel abandons creation entirely — no item, no launch', () => {
+    // In the multi-tool flow, handleToolCancel fires BEFORE startDerivation, so
+    // deriveSlug never runs and createItem is never called. The board stays
+    // empty and onLaunchItemBackground is never invoked.
     const launched: string[] = [];
-    // Simulate handleToolCancel: just clears toolPickItem, no launch
-    // The item remains on the board
-    const board = service.loadBoard('proj', tmpDir);
-    const item = board.columns.flatMap(c => c.items).find(i => i.slug === slug);
+    let derivationStarted = false;
 
-    expect(item).toBeTruthy(); // item persists
-    expect(launched).toHaveLength(0); // no launch
+    let toolPickPending: {title: string} | null = {title: 'Cancelled Feature'};
+    const handleToolCancel = () => { toolPickPending = null; };
+
+    handleToolCancel();
+
+    // Only startDerivation would call createItem — it never fires after cancel.
+    if (toolPickPending) derivationStarted = true;
+
+    service.ensureTracker(tmpDir);
+    const board = service.loadBoard('proj', tmpDir);
+    const items = board.columns.flatMap(c => c.items);
+
+    expect(toolPickPending).toBeNull();
+    expect(derivationStarted).toBe(false);
+    expect(items).toHaveLength(0);
+    expect(launched).toHaveLength(0);
   });
 
   test('no temp slug appears in the index during derivation window', () => {

--- a/tests/unit/tracker-derive-slug.test.ts
+++ b/tests/unit/tracker-derive-slug.test.ts
@@ -1,0 +1,71 @@
+import {describe, test, expect, beforeEach, afterEach, jest} from '@jest/globals';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+// Mock runClaudeAsync so deriveSlug's AI path is deterministic.
+const mockRunClaudeAsync = jest.fn<(prompt: string, opts?: any) => Promise<{success: boolean; output: string; error?: string}>>();
+jest.mock('../../src/shared/utils/commandExecutor.js', () => {
+  const actual = jest.requireActual('../../src/shared/utils/commandExecutor.js') as any;
+  return {...actual, runClaudeAsync: (...args: any[]) => mockRunClaudeAsync(...(args as [string, any?]))};
+});
+
+import {TrackerService} from '../../src/services/TrackerService.js';
+
+let tmpDir: string;
+let service: TrackerService;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tracker-derive-test-'));
+  service = new TrackerService();
+  mockRunClaudeAsync.mockReset();
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, {recursive: true, force: true});
+});
+
+describe('deriveSlug fallback paths', () => {
+  test('uses AI output when it returns a clean kebab-case slug', async () => {
+    mockRunClaudeAsync.mockResolvedValue({success: true, output: 'oauth-login\n'});
+    const slug = await service.deriveSlug('Add OAuth sign-in for users', []);
+    expect(slug).toBe('oauth-login');
+  });
+
+  test('falls back to slugify(title) when AI call fails', async () => {
+    mockRunClaudeAsync.mockResolvedValue({success: false, output: '', error: 'claude not found'});
+    const slug = await service.deriveSlug('My New Feature', []);
+    expect(slug).toBe('my-new-feature');
+  });
+
+  test('falls back to slugify(title) when AI returns empty output', async () => {
+    mockRunClaudeAsync.mockResolvedValue({success: true, output: ''});
+    const slug = await service.deriveSlug('Empty Response Title', []);
+    expect(slug).toBe('empty-response-title');
+  });
+
+  test('slugifies a sloppy AI response with extra whitespace and line breaks', async () => {
+    mockRunClaudeAsync.mockResolvedValue({success: true, output: '  Oauth Login\n\n'});
+    const slug = await service.deriveSlug('Add OAuth', []);
+    // slugify normalizes the AI output
+    expect(slug).toBe('oauth-login');
+  });
+
+  test('appends -2 when derived slug already exists', async () => {
+    mockRunClaudeAsync.mockResolvedValue({success: true, output: 'oauth-login'});
+    const slug = await service.deriveSlug('OAuth Login', ['oauth-login']);
+    expect(slug).toBe('oauth-login-2');
+  });
+
+  test('increments suffix past existing -2 collisions', async () => {
+    mockRunClaudeAsync.mockResolvedValue({success: true, output: 'oauth-login'});
+    const slug = await service.deriveSlug('OAuth Login', ['oauth-login', 'oauth-login-2']);
+    expect(slug).toBe('oauth-login-3');
+  });
+
+  test('falls back to title slugify when AI returns an unslugifiable response', async () => {
+    mockRunClaudeAsync.mockResolvedValue({success: true, output: '!!!'});
+    const slug = await service.deriveSlug('A Real Title', []);
+    expect(slug).toBe('a-real-title');
+  });
+});

--- a/tests/unit/tracker-proposal-create.test.ts
+++ b/tests/unit/tracker-proposal-create.test.ts
@@ -40,24 +40,26 @@ describe('proposal acceptance: slug and description', () => {
     expect(index.backlog.backlog ?? []).not.toContain('oauth-login'.replace('-', '')); // not re-slugified
   });
 
-  test('requirements.md body contains proposal description, not just title', () => {
+  test('proposal description is written to notes.md (discovery output)', () => {
     acceptProposals(tmpDir, proposals, new Set([0]));
+    const notesPath = path.join(tmpDir, 'tracker', 'items', 'oauth-login', 'notes.md');
+    expect(fs.existsSync(notesPath)).toBe(true);
+    expect(fs.readFileSync(notesPath, 'utf8')).toContain('Implement Google and GitHub OAuth2 sign-in flows.');
     const reqPath = path.join(tmpDir, 'tracker', 'items', 'oauth-login', 'requirements.md');
-    expect(fs.existsSync(reqPath)).toBe(true);
-    const content = fs.readFileSync(reqPath, 'utf8');
-    expect(content).toContain('Implement Google and GitHub OAuth2 sign-in flows.');
-    expect(content).toMatch(/^title: "OAuth Login"$/m);
-    expect(content).toMatch(/^slug: oauth-login$/m);
+    const reqContent = fs.readFileSync(reqPath, 'utf8');
+    expect(reqContent).toMatch(/^title: "OAuth Login"$/m);
+    expect(reqContent).toMatch(/^slug: oauth-login$/m);
+    expect(reqContent).not.toContain('Implement Google and GitHub OAuth2 sign-in flows.');
   });
 
-  test('accepting multiple proposals creates all items with correct slugs and descriptions', () => {
+  test('accepting multiple proposals creates notes.md for each with its description', () => {
     acceptProposals(tmpDir, proposals, new Set([0, 1]));
     const index = JSON.parse(fs.readFileSync(path.join(tmpDir, 'tracker', 'index.json'), 'utf8'));
     expect(index.backlog.backlog).toContain('oauth-login');
     expect(index.backlog.backlog).toContain('dark-mode');
 
-    const reqDark = path.join(tmpDir, 'tracker', 'items', 'dark-mode', 'requirements.md');
-    expect(fs.readFileSync(reqDark, 'utf8')).toContain('Add a dark color scheme toggle to settings.');
+    const notesDark = path.join(tmpDir, 'tracker', 'items', 'dark-mode', 'notes.md');
+    expect(fs.readFileSync(notesDark, 'utf8')).toContain('Add a dark color scheme toggle to settings.');
   });
 
   test('unaccepted proposals are not created', () => {

--- a/tests/unit/tracker-proposal-create.test.ts
+++ b/tests/unit/tracker-proposal-create.test.ts
@@ -1,0 +1,68 @@
+import {describe, test, expect, beforeEach, afterEach} from '@jest/globals';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import {TrackerService, ProposalCandidate} from '../../src/services/TrackerService.js';
+
+let tmpDir: string;
+let service: TrackerService;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tracker-proposal-test-'));
+  service = new TrackerService();
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, {recursive: true, force: true});
+});
+
+// Mirrors the logic in TrackerProposalScreen.handleSubmit
+function acceptProposals(projectPath: string, proposals: ProposalCandidate[], accepted: Set<number>) {
+  const tracker = new TrackerService();
+  for (const index of accepted) {
+    const item = proposals[index];
+    if (item) {
+      tracker.createItem(projectPath, item.title, 'backlog', item.slug, item.description);
+    }
+  }
+}
+
+describe('proposal acceptance: slug and description', () => {
+  const proposals: ProposalCandidate[] = [
+    {title: 'OAuth Login', slug: 'oauth-login', description: 'Implement Google and GitHub OAuth2 sign-in flows.'},
+    {title: 'Dark Mode', slug: 'dark-mode', description: 'Add a dark color scheme toggle to settings.'},
+  ];
+
+  test('accepted proposal uses AI-derived slug (not slugified title)', () => {
+    acceptProposals(tmpDir, proposals, new Set([0]));
+    const index = JSON.parse(fs.readFileSync(path.join(tmpDir, 'tracker', 'index.json'), 'utf8'));
+    expect(index.backlog.backlog).toContain('oauth-login');
+    expect(index.backlog.backlog ?? []).not.toContain('oauth-login'.replace('-', '')); // not re-slugified
+  });
+
+  test('requirements.md body contains proposal description, not just title', () => {
+    acceptProposals(tmpDir, proposals, new Set([0]));
+    const reqPath = path.join(tmpDir, 'tracker', 'items', 'oauth-login', 'requirements.md');
+    expect(fs.existsSync(reqPath)).toBe(true);
+    const content = fs.readFileSync(reqPath, 'utf8');
+    expect(content).toContain('Implement Google and GitHub OAuth2 sign-in flows.');
+    expect(content).toMatch(/^title: OAuth Login$/m);
+    expect(content).toMatch(/^slug: oauth-login$/m);
+  });
+
+  test('accepting multiple proposals creates all items with correct slugs and descriptions', () => {
+    acceptProposals(tmpDir, proposals, new Set([0, 1]));
+    const index = JSON.parse(fs.readFileSync(path.join(tmpDir, 'tracker', 'index.json'), 'utf8'));
+    expect(index.backlog.backlog).toContain('oauth-login');
+    expect(index.backlog.backlog).toContain('dark-mode');
+
+    const reqDark = path.join(tmpDir, 'tracker', 'items', 'dark-mode', 'requirements.md');
+    expect(fs.readFileSync(reqDark, 'utf8')).toContain('Add a dark color scheme toggle to settings.');
+  });
+
+  test('unaccepted proposals are not created', () => {
+    acceptProposals(tmpDir, proposals, new Set([0]));
+    const darkDir = path.join(tmpDir, 'tracker', 'items', 'dark-mode');
+    expect(fs.existsSync(darkDir)).toBe(false);
+  });
+});

--- a/tests/unit/tracker-proposal-create.test.ts
+++ b/tests/unit/tracker-proposal-create.test.ts
@@ -46,7 +46,7 @@ describe('proposal acceptance: slug and description', () => {
     expect(fs.existsSync(reqPath)).toBe(true);
     const content = fs.readFileSync(reqPath, 'utf8');
     expect(content).toContain('Implement Google and GitHub OAuth2 sign-in flows.');
-    expect(content).toMatch(/^title: OAuth Login$/m);
+    expect(content).toMatch(/^title: "OAuth Login"$/m);
     expect(content).toMatch(/^slug: oauth-login$/m);
   });
 

--- a/tests/unit/tracker.test.ts
+++ b/tests/unit/tracker.test.ts
@@ -143,6 +143,30 @@ describe('createItem', () => {
     const index = JSON.parse(fs.readFileSync(path.join(tmpDir, 'tracker', 'index.json'), 'utf8'));
     expect(index.implementation.implement).toContain('build-api');
   });
+
+  test('writes provided body to requirements.md instead of title', () => {
+    service.createItem(tmpDir, 'Add auth', 'discovery', undefined, 'Implement OAuth2 login with Google and GitHub providers.');
+    const reqPath = path.join(tmpDir, 'tracker', 'items', 'add-auth', 'requirements.md');
+    const content = fs.readFileSync(reqPath, 'utf8');
+    expect(content).toContain('Implement OAuth2 login with Google and GitHub providers.');
+    expect(content).not.toMatch(/\nAdd auth\n/);
+  });
+
+  test('uses title as body when body param is omitted', () => {
+    service.createItem(tmpDir, 'My Feature', 'discovery');
+    const reqPath = path.join(tmpDir, 'tracker', 'items', 'my-feature', 'requirements.md');
+    const content = fs.readFileSync(reqPath, 'utf8');
+    expect(content).toMatch(/\nMy Feature\n/);
+  });
+
+  test('uses explicit slug when provided alongside body', () => {
+    service.createItem(tmpDir, 'Proposal Title', 'backlog', 'ai-derived-slug', 'Detailed description from proposal.');
+    const reqPath = path.join(tmpDir, 'tracker', 'items', 'ai-derived-slug', 'requirements.md');
+    expect(fs.existsSync(reqPath)).toBe(true);
+    const content = fs.readFileSync(reqPath, 'utf8');
+    expect(content).toContain('Detailed description from proposal.');
+    expect(content).toMatch(/^slug: ai-derived-slug$/m);
+  });
 });
 
 // ─── moveItem ───────────────────────────────────────────────────────────────

--- a/tests/unit/tracker.test.ts
+++ b/tests/unit/tracker.test.ts
@@ -718,7 +718,7 @@ describe('ensureItemFiles', () => {
     expect(fs.existsSync(destDir)).toBe(true);
     const reqPath = path.join(destDir, 'requirements.md');
     expect(fs.existsSync(reqPath)).toBe(true);
-    expect(fs.readFileSync(reqPath, 'utf8')).toContain('title: My Feature');
+    expect(fs.readFileSync(reqPath, 'utf8')).toContain('title: "My Feature"');
   });
 
   test('does NOT create tracker/index.json in the worktree', () => {

--- a/tests/unit/tracker.test.ts
+++ b/tests/unit/tracker.test.ts
@@ -182,6 +182,48 @@ describe('moveItem', () => {
   });
 });
 
+// ─── renameItem ─────────────────────────────────────────────────────────────
+
+describe('renameItem', () => {
+  test('renames slug in index and updates sessions title', () => {
+    service.createItem(tmpDir, 'Fix login bug', 'discovery', 'fix-login-bug');
+    const renamed = service.renameItem(tmpDir, 'fix-login-bug', 'login-bug-fix', 'Fix login bug');
+    expect(renamed).toBe(true);
+    const index = JSON.parse(fs.readFileSync(path.join(tmpDir, 'tracker', 'index.json'), 'utf8'));
+    expect(index.backlog.discovery).not.toContain('fix-login-bug');
+    expect(index.backlog.discovery).toContain('login-bug-fix');
+    expect(index.sessions['login-bug-fix'].title).toBe('Fix login bug');
+    expect(index.sessions['fix-login-bug']).toBeUndefined();
+  });
+
+  test('preserves stage when renaming', () => {
+    service.createItem(tmpDir, 'Build API', 'implement');
+    service.renameItem(tmpDir, 'build-api', 'api-build', 'Build API');
+    const index = JSON.parse(fs.readFileSync(path.join(tmpDir, 'tracker', 'index.json'), 'utf8'));
+    expect(index.implementation.implement).toContain('api-build');
+  });
+
+  test('returns false when old slug not in index', () => {
+    service.ensureTracker(tmpDir);
+    expect(service.renameItem(tmpDir, 'nonexistent', 'new-slug', 'title')).toBe(false);
+  });
+
+  test('returns false when old and new slug are the same', () => {
+    service.createItem(tmpDir, 'Feature', 'discovery');
+    expect(service.renameItem(tmpDir, 'feature', 'feature', 'Feature')).toBe(false);
+  });
+
+  test('renames item directory if it exists', () => {
+    service.createItem(tmpDir, 'My Feature', 'discovery');
+    const oldDir = path.join(tmpDir, 'tracker', 'items', 'my-feature');
+    fs.mkdirSync(oldDir, {recursive: true});
+    fs.writeFileSync(path.join(oldDir, 'requirements.md'), '---\ntitle: My Feature\nslug: my-feature\n---\n');
+    service.renameItem(tmpDir, 'my-feature', 'renamed-feature', 'My Feature');
+    expect(fs.existsSync(oldDir)).toBe(false);
+    expect(fs.existsSync(path.join(tmpDir, 'tracker', 'items', 'renamed-feature'))).toBe(true);
+  });
+});
+
 // ─── loadBoard ──────────────────────────────────────────────────────────────
 
 describe('loadBoard', () => {

--- a/tests/unit/tracker.test.ts
+++ b/tests/unit/tracker.test.ts
@@ -79,9 +79,14 @@ describe('slugify', () => {
     expect(service.slugify('  --hello--  ')).toBe('hello');
   });
 
-  test('truncates long titles', () => {
+  test('truncates long titles to default 20 chars', () => {
     const long = 'a'.repeat(80);
-    expect(service.slugify(long).length).toBeLessThanOrEqual(60);
+    expect(service.slugify(long).length).toBe(20);
+  });
+
+  test('respects custom maxLength', () => {
+    const long = 'a'.repeat(80);
+    expect(service.slugify(long, 40).length).toBe(40);
   });
 });
 
@@ -113,15 +118,16 @@ describe('nextStage / previousStage', () => {
 // ─── createItem ─────────────────────────────────────────────────────────────
 
 describe('createItem', () => {
-  test('adds slug to index.json with title metadata; does not write item files', () => {
+  test('adds slug to index.json and writes requirements stub to main project', () => {
     service.createItem(tmpDir, 'Add user auth', 'discovery');
 
     const indexPath = path.join(tmpDir, 'tracker', 'index.json');
     const index = JSON.parse(fs.readFileSync(indexPath, 'utf8'));
     expect(index.backlog.discovery).toContain('add-user-auth');
     expect(index.sessions['add-user-auth'].title).toBe('Add user auth');
-    // Item content lives in the worktree — main project bucket dirs stay empty.
-    expect(fs.existsSync(path.join(tmpDir, 'tracker', 'backlog', 'add-user-auth'))).toBe(false);
+    const reqPath = path.join(tmpDir, 'tracker', 'items', 'add-user-auth', 'requirements.md');
+    expect(fs.existsSync(reqPath)).toBe(true);
+    expect(fs.readFileSync(reqPath, 'utf8')).toContain('Add user auth');
   });
 
   test('adds slug to index.json in correct stage', () => {

--- a/tests/unit/tracker.test.ts
+++ b/tests/unit/tracker.test.ts
@@ -219,14 +219,14 @@ describe('renameItem', () => {
     expect(service.renameItem(tmpDir, 'feature', 'feature', 'Feature')).toBe(false);
   });
 
-  test('renames item directory if it exists', () => {
+  test('renames item directory and updates slug in frontmatter', () => {
     service.createItem(tmpDir, 'My Feature', 'discovery');
-    const oldDir = path.join(tmpDir, 'tracker', 'items', 'my-feature');
-    fs.mkdirSync(oldDir, {recursive: true});
-    fs.writeFileSync(path.join(oldDir, 'requirements.md'), '---\ntitle: My Feature\nslug: my-feature\n---\n');
     service.renameItem(tmpDir, 'my-feature', 'renamed-feature', 'My Feature');
+    const oldDir = path.join(tmpDir, 'tracker', 'items', 'my-feature');
+    const newReqPath = path.join(tmpDir, 'tracker', 'items', 'renamed-feature', 'requirements.md');
     expect(fs.existsSync(oldDir)).toBe(false);
-    expect(fs.existsSync(path.join(tmpDir, 'tracker', 'items', 'renamed-feature'))).toBe(true);
+    expect(fs.existsSync(newReqPath)).toBe(true);
+    expect(fs.readFileSync(newReqPath, 'utf8')).toMatch(/^slug: renamed-feature$/m);
   });
 });
 

--- a/tests/unit/tracker.test.ts
+++ b/tests/unit/tracker.test.ts
@@ -212,48 +212,6 @@ describe('moveItem', () => {
   });
 });
 
-// ─── renameItem ─────────────────────────────────────────────────────────────
-
-describe('renameItem', () => {
-  test('renames slug in index and updates sessions title', () => {
-    service.createItem(tmpDir, 'Fix login bug', 'discovery', 'fix-login-bug');
-    const renamed = service.renameItem(tmpDir, 'fix-login-bug', 'login-bug-fix', 'Fix login bug');
-    expect(renamed).toBe(true);
-    const index = JSON.parse(fs.readFileSync(path.join(tmpDir, 'tracker', 'index.json'), 'utf8'));
-    expect(index.backlog.discovery).not.toContain('fix-login-bug');
-    expect(index.backlog.discovery).toContain('login-bug-fix');
-    expect(index.sessions['login-bug-fix'].title).toBe('Fix login bug');
-    expect(index.sessions['fix-login-bug']).toBeUndefined();
-  });
-
-  test('preserves stage when renaming', () => {
-    service.createItem(tmpDir, 'Build API', 'implement');
-    service.renameItem(tmpDir, 'build-api', 'api-build', 'Build API');
-    const index = JSON.parse(fs.readFileSync(path.join(tmpDir, 'tracker', 'index.json'), 'utf8'));
-    expect(index.implementation.implement).toContain('api-build');
-  });
-
-  test('returns false when old slug not in index', () => {
-    service.ensureTracker(tmpDir);
-    expect(service.renameItem(tmpDir, 'nonexistent', 'new-slug', 'title')).toBe(false);
-  });
-
-  test('returns false when old and new slug are the same', () => {
-    service.createItem(tmpDir, 'Feature', 'discovery');
-    expect(service.renameItem(tmpDir, 'feature', 'feature', 'Feature')).toBe(false);
-  });
-
-  test('renames item directory and updates slug in frontmatter', () => {
-    service.createItem(tmpDir, 'My Feature', 'discovery');
-    service.renameItem(tmpDir, 'my-feature', 'renamed-feature', 'My Feature');
-    const oldDir = path.join(tmpDir, 'tracker', 'items', 'my-feature');
-    const newReqPath = path.join(tmpDir, 'tracker', 'items', 'renamed-feature', 'requirements.md');
-    expect(fs.existsSync(oldDir)).toBe(false);
-    expect(fs.existsSync(newReqPath)).toBe(true);
-    expect(fs.readFileSync(newReqPath, 'utf8')).toMatch(/^slug: renamed-feature$/m);
-  });
-});
-
 // ─── loadBoard ──────────────────────────────────────────────────────────────
 
 describe('loadBoard', () => {

--- a/tests/unit/tracker.test.ts
+++ b/tests/unit/tracker.test.ts
@@ -144,28 +144,30 @@ describe('createItem', () => {
     expect(index.implementation.implement).toContain('build-api');
   });
 
-  test('writes provided body to requirements.md instead of title', () => {
+  test('writes provided body to notes.md (discovery output), keeping requirements.md as a title stub', () => {
     service.createItem(tmpDir, 'Add auth', 'discovery', undefined, 'Implement OAuth2 login with Google and GitHub providers.');
-    const reqPath = path.join(tmpDir, 'tracker', 'items', 'add-auth', 'requirements.md');
-    const content = fs.readFileSync(reqPath, 'utf8');
-    expect(content).toContain('Implement OAuth2 login with Google and GitHub providers.');
-    expect(content).not.toMatch(/\nAdd auth\n/);
+    const notesPath = path.join(tmpDir, 'tracker', 'items', 'add-auth', 'notes.md');
+    expect(fs.readFileSync(notesPath, 'utf8')).toContain('Implement OAuth2 login with Google and GitHub providers.');
+    const reqContent = fs.readFileSync(path.join(tmpDir, 'tracker', 'items', 'add-auth', 'requirements.md'), 'utf8');
+    expect(reqContent).not.toContain('Implement OAuth2 login with Google and GitHub providers.');
   });
 
-  test('uses title as body when body param is omitted', () => {
+  test('does not create notes.md when body is omitted', () => {
     service.createItem(tmpDir, 'My Feature', 'discovery');
-    const reqPath = path.join(tmpDir, 'tracker', 'items', 'my-feature', 'requirements.md');
-    const content = fs.readFileSync(reqPath, 'utf8');
-    expect(content).toMatch(/\nMy Feature\n/);
+    const notesPath = path.join(tmpDir, 'tracker', 'items', 'my-feature', 'notes.md');
+    expect(fs.existsSync(notesPath)).toBe(false);
+    const reqContent = fs.readFileSync(path.join(tmpDir, 'tracker', 'items', 'my-feature', 'requirements.md'), 'utf8');
+    expect(reqContent).toMatch(/\nMy Feature\n/);
   });
 
   test('uses explicit slug when provided alongside body', () => {
     service.createItem(tmpDir, 'Proposal Title', 'backlog', 'ai-derived-slug', 'Detailed description from proposal.');
     const reqPath = path.join(tmpDir, 'tracker', 'items', 'ai-derived-slug', 'requirements.md');
     expect(fs.existsSync(reqPath)).toBe(true);
-    const content = fs.readFileSync(reqPath, 'utf8');
-    expect(content).toContain('Detailed description from proposal.');
-    expect(content).toMatch(/^slug: ai-derived-slug$/m);
+    const notesPath = path.join(tmpDir, 'tracker', 'items', 'ai-derived-slug', 'notes.md');
+    expect(fs.readFileSync(notesPath, 'utf8')).toContain('Detailed description from proposal.');
+    const reqContent = fs.readFileSync(reqPath, 'utf8');
+    expect(reqContent).toMatch(/^slug: ai-derived-slug$/m);
   });
 });
 

--- a/tracker/items/new-item/implementation.md
+++ b/tracker/items/new-item/implementation.md
@@ -6,24 +6,29 @@ updated: 2026-04-20
 
 ## What was built
 
-AI-driven slug derivation for new tracker items. When a user creates a new item by typing a full natural-language description and pressing Enter, the item now:
+Derive-first item creation for the tracker board. When the user types a title and presses Enter:
 
-1. Appears immediately on the board with the slugified version of the title as a temporary slug, paired with a braille spinner animation (`deriving slug…` secondary text) so the user knows something is in progress.
-2. Calls `claude -p` in the background via the existing `runClaudeAsync` utility asking for a concise 2–4 word kebab-case slug.
-3. Once the AI responds (or falls back after 8s timeout), renames the item to the final slug and reloads the board. If the derived slug conflicts with an existing one, a numeric suffix is appended.
-
-The full typed description is stored as `title` in `sessions[slug]` (and later in `requirements.md` frontmatter), while the slug is now meaningful and short.
+1. If multiple AI tools are available, the tool picker appears first.
+2. A placeholder row with a braille spinner ("deriving slug…") appears in the target column. The item does **not** exist on the board yet — no temp slug, no rename.
+3. `claude -p` is asked for a concise 2–4 word kebab-case slug via `runClaudeAsync`. On timeout (8s) or failure, the slugified title is used.
+4. Just before writing, slugs are re-read from disk and deduplicated with a numeric suffix so two rapid back-to-back creates can't collide.
+5. `createItem` writes the item with its final slug. `notes.md` gets the user's typed description (the discovery seed); `requirements.md` stays a frontmatter stub with just the title.
+6. The item pops onto the board and the background session launch fires via `launchSessionBackground` on `WorktreeCore` (extracted `createSessionIfNeeded` helper shared with `attachSession`).
 
 ## Key decisions
 
-- **No dialog**: kept inline typing UX, just decoupled title from slug.
-- **Immediate board appearance**: create with temp slug first, rename after AI responds. No waiting before the item is visible.
-- **Spinner animation**: `SPINNER_CHARS` braille cycle driven by a `setInterval` that only runs when `pendingCreations.size > 0` to avoid unnecessary re-renders.
-- **Graceful fallback**: on timeout or AI error, the slugified title stays as the final slug — no user-visible failure.
-- **`renameItem` is atomic**: rewrites `index.json` via `writeJSONAtomic` and optionally renames the item directory if it already exists on disk.
+- **Derive-first, not temp-slug**: user sees the placeholder spinner for ~5s, then the real item appears with its final slug. No rename, no churn.
+- **User description → notes.md**: the user's initial description is exactly the kind of "problem / why" content the discovery stage writes to `notes.md`. Requirements stays pristine.
+- **Tool picker shows BEFORE derivation**: otherwise the user would type a title, wait 5s, and only then be prompted for a tool.
+- **2s per-project poll on the board**: the top-level 60s refresh was too slow to pick up `ai_status` transitions after a new session boots. Added `refreshProjectWorktrees(project)` that reuses `refreshWorktreeIndices` with project-filtered indices.
+- **Parallel fetch + change detection** in `refreshWorktreeIndices`: tmux + git status per worktree now runs via `Promise.all` (N× wall-clock speedup), and `setState` is skipped when `worktreeStatusEquals` shows nothing changed so subscribers don't re-render every tick.
+- **Invalidate git slow cache** after worktree creation and after background session launch so committed stats appear on the next tick, not after the 60s refresh.
 
 ## Files changed
 
-- `src/services/TrackerService.ts`: added `deriveSlug()` and `renameItem()` public methods
-- `src/screens/TrackerBoardScreen.tsx`: async `handleCreateSubmit`, `pendingCreations` state, spinner animation
-- `tests/unit/tracker.test.ts`: 5 new tests for `renameItem`
+- `src/services/TrackerService.ts`: `createItem` writes body to `notes.md` (not requirements); `writeRequirementsStub` helper; `deriveSlug` unchanged; `renameItem` removed.
+- `src/screens/TrackerBoardScreen.tsx`: tool picker before derivation; placeholder spinner row in target column; 2s `refreshProjectWorktrees` effect; error logging on background launch.
+- `src/screens/TrackerProposalScreen.tsx`: passes proposal's AI-derived slug + description through to `createItem`.
+- `src/cores/WorktreeCore.ts`: extracted `createSessionIfNeeded` and `refreshWorktreeIndices` helpers; added `launchSessionBackground` and `refreshProjectWorktrees`; added `worktreeStatusEquals`; git slow cache invalidation on worktree creation.
+- `src/contexts/WorktreeContext.tsx`: exposes `launchSessionBackground` and `refreshProjectWorktrees`.
+- Tests: `tracker-board-create-flow.test.ts`, `tracker-proposal-create.test.ts`, `tracker-derive-slug.test.ts` (deriveSlug fallback paths with mocked runClaudeAsync).

--- a/tracker/items/new-item/implementation.md
+++ b/tracker/items/new-item/implementation.md
@@ -1,0 +1,29 @@
+---
+title: new-item
+slug: new-item
+updated: 2026-04-20
+---
+
+## What was built
+
+AI-driven slug derivation for new tracker items. When a user creates a new item by typing a full natural-language description and pressing Enter, the item now:
+
+1. Appears immediately on the board with the slugified version of the title as a temporary slug, paired with a braille spinner animation (`deriving slug…` secondary text) so the user knows something is in progress.
+2. Calls `claude -p` in the background via the existing `runClaudeAsync` utility asking for a concise 2–4 word kebab-case slug.
+3. Once the AI responds (or falls back after 8s timeout), renames the item to the final slug and reloads the board. If the derived slug conflicts with an existing one, a numeric suffix is appended.
+
+The full typed description is stored as `title` in `sessions[slug]` (and later in `requirements.md` frontmatter), while the slug is now meaningful and short.
+
+## Key decisions
+
+- **No dialog**: kept inline typing UX, just decoupled title from slug.
+- **Immediate board appearance**: create with temp slug first, rename after AI responds. No waiting before the item is visible.
+- **Spinner animation**: `SPINNER_CHARS` braille cycle driven by a `setInterval` that only runs when `pendingCreations.size > 0` to avoid unnecessary re-renders.
+- **Graceful fallback**: on timeout or AI error, the slugified title stays as the final slug — no user-visible failure.
+- **`renameItem` is atomic**: rewrites `index.json` via `writeJSONAtomic` and optionally renames the item directory if it already exists on disk.
+
+## Files changed
+
+- `src/services/TrackerService.ts`: added `deriveSlug()` and `renameItem()` public methods
+- `src/screens/TrackerBoardScreen.tsx`: async `handleCreateSubmit`, `pendingCreations` state, spinner animation
+- `tests/unit/tracker.test.ts`: 5 new tests for `renameItem`

--- a/tracker/items/new-item/notes.md
+++ b/tracker/items/new-item/notes.md
@@ -1,0 +1,24 @@
+---
+title: new-item
+slug: new-item
+updated: 2026-04-20
+---
+
+## User problem
+
+When creating a new tracker item, the user types inline (good UX) but whatever they type is immediately slugified and truncated to 20 chars. The user wants to type a full description like "Fix login button color on mobile devices" but the current flow loses that information — the slug becomes `fix-login-button-col` and is used as both the identifier and display name. The user's natural-language description is not a good slug, and the slug is not a good description.
+
+Root cause: `createTitle` state is used as both the display name and the slug source. `slugify()` truncates to 20 chars, so long titles lose information. The full title IS stored in `sessions[slug].title` and `requirements.md` frontmatter, but the 20-char truncation means even the title can be wrong.
+
+## Recommendation
+
+Decouple title from slug:
+
+1. **Keep inline typing** for the full title/description — user likes this UX.
+2. **After Enter**, call a small AI agent (Claude API, haiku) to derive a short memorable slug from the full title (e.g. "fix-login-button-color"). Show the proposed slug briefly or just accept it.
+3. Store the full title as the display name on the board; use the AI-derived slug as the filesystem identifier.
+4. No dialog needed — the async slug generation can happen after the item appears on the board with the full title already visible.
+
+Alternatively (simpler, no AI): generate slug from first 3-4 significant words + short hash suffix to ensure uniqueness. This avoids async complexity but produces less memorable slugs.
+
+AI approach is preferred per user's stated preference.

--- a/tracker/items/new-item/requirements.md
+++ b/tracker/items/new-item/requirements.md
@@ -4,4 +4,23 @@ slug: new-item
 updated: 2026-04-20
 ---
 
-new-item
+## User stories
+
+- As a developer, I want to type a full natural-language description when creating a tracker item so that I can capture my intent without worrying about slug constraints.
+- As a developer, I want a meaningful short slug auto-derived from my description so that the board and filesystem remain navigable without me having to manually craft one.
+- As a developer, I want visual feedback while the slug is being derived so I know something is happening.
+
+## Summary
+
+Currently, new item creation uses inline typing where the typed text is both the display title and the slug source. The slug is truncated to 20 characters, losing information when the user types a natural-language description. The fix: allow unrestricted inline typing, then call Claude Haiku async to derive a concise memorable slug. The item appears on the board immediately in a "deriving" state; once the slug is ready the item transitions to its final name. The board continues to display slugs (not full titles), but slugs will now be meaningful because they're AI-derived from a full description.
+
+## Acceptance criteria
+
+1. The inline input accepts any length of text with no truncation visible during typing.
+2. On Enter, the item immediately appears on the board with a "pending" visual state (e.g. spinner or pulsing animation on the slug placeholder).
+3. A Claude Haiku API call is made in the background with the full typed description, asking it to produce a short (2–4 word) kebab-case slug.
+4. The derived slug is unique — if it conflicts with an existing item, append a numeric suffix (e.g. `login-button-2`).
+5. Once the slug is received, the pending item transitions to its final slug with a brief visual transition (e.g. the text resolves/snaps into place).
+6. If the AI call fails (error or timeout after ~5s), fall back to the current slugify behavior (first 20 chars, kebab-cased) so creation never hangs.
+7. The full typed description is stored as the `title` in `tracker/index.json` sessions and in `requirements.md` frontmatter (not the slug).
+8. The board card continues to show the slug as the primary display text (unchanged board layout).

--- a/tracker/items/new-item/requirements.md
+++ b/tracker/items/new-item/requirements.md
@@ -1,0 +1,7 @@
+---
+title: new-item
+slug: new-item
+updated: 2026-04-20
+---
+
+new-item


### PR DESCRIPTION
## Summary

- New tracker items are now created with their AI-derived slug directly (no temp slug + rename).
- Tool picker appears before slug derivation when multiple AI tools are installed; single-tool path auto-proceeds.
- Items launch their agent session in the background via a new `launchSessionBackground` on `WorktreeCore` (extracted `createSessionIfNeeded` helper shared with `attachSession`).
- The proposals screen now passes both the AI-derived slug and the full description through to `createItem`, preserving them instead of re-slugifying the title and discarding the description.
- The tracker board polls this project's worktrees every 2s via a new `refreshProjectWorktrees` (instead of the 60s global refresh), with per-worktree tmux + git status fetched via `Promise.all` and a change-detection guard on `setState` so consumers only re-render when something actually changed.
- Git slow-metrics cache is invalidated when a worktree is created and after the background session launch so committed stats show up promptly.

## Test plan

- [x] Unit: `npm test` — 609 tests passing (adds two new files: `tracker-board-create-flow.test.ts`, `tracker-proposal-create.test.ts`)
- [x] Type check / build: `npm run build` clean
- [ ] Manual: single-tool project — create new item, verify placeholder spinner shows "deriving slug…" then item pops in and session launches
- [ ] Manual: multi-tool project — create new item, verify tool picker shows first, then derivation, then item pops in with chosen tool
- [ ] Manual: accept a proposal and verify the item uses its AI-derived slug and the proposal's description (not just the title)
- [ ] Manual: watch ai_status transitions on a new item — should show `running`/`waiting` within ~2s after the tool boots, not after 60s

🤖 Generated with [Claude Code](https://claude.com/claude-code)