### PR TITLE
ralph: phase automation — self-reporting status.json + idle nudger + stage UX polish

### DIFF
--- a/src/components/views/MainView/WorktreeRow.tsx
+++ b/src/components/views/MainView/WorktreeRow.tsx
@@ -31,13 +31,17 @@ export const WorktreeRow = memo<WorktreeRowProps>(({
   const highlightInfo = useHighlightPriority(worktree, prStatus);
   const isDimmed = shouldDimRow(prStatus);
 
-  // Compact ralph indicator: "⏸ brief_description" when waiting for user,
-  // "n:X/Y" when nudges fired, "!" when capped. Empty when ralph has nothing
-  // to say. Everything is truncated inside the cell width downstream.
+  // Compact ralph indicator: distinguishes the two waiting states (input vs
+  // approval) so the main view doesn't collapse them the way the old single
+  // boolean did. "n:X/Y" when nudges have fired, "!" when capped.
   const ralphSuffix = (() => {
     const r = worktree.ralph;
     if (!r) return '';
-    if (r.is_waiting_for_user) {
+    if (r.state === 'waiting_for_approval') {
+      const desc = (r.brief_description || '').trim();
+      return desc ? ` ✓ ${desc}` : ' ✓ ready';
+    }
+    if (r.state === 'waiting_for_input') {
       const desc = (r.brief_description || '').trim();
       return desc ? ` ⏸ ${desc}` : ' ⏸';
     }

--- a/src/components/views/MainView/WorktreeRow.tsx
+++ b/src/components/views/MainView/WorktreeRow.tsx
@@ -31,11 +31,26 @@ export const WorktreeRow = memo<WorktreeRowProps>(({
   const highlightInfo = useHighlightPriority(worktree, prStatus);
   const isDimmed = shouldDimRow(prStatus);
 
+  // Compact ralph indicator: "⏸ brief_description" when waiting for user,
+  // "n:X/Y" when nudges fired, "!" when capped. Empty when ralph has nothing
+  // to say. Everything is truncated inside the cell width downstream.
+  const ralphSuffix = (() => {
+    const r = worktree.ralph;
+    if (!r) return '';
+    if (r.is_waiting_for_user) {
+      const desc = (r.brief_description || '').trim();
+      return desc ? ` ⏸ ${desc}` : ' ⏸';
+    }
+    if (r.capped) return ` !`;
+    if (r.nudges_this_stage > 0) return ` n:${r.nudges_this_stage}/${r.max_nudges_per_stage}`;
+    return '';
+  })();
+
   const data = {
     number: String(globalIndex + 1),
     projectFeature: worktree.is_workspace_child
-      ? `${worktree.is_last_workspace_child ? '└─' : '├─'} [${worktree.project}]`
-      : `${worktree.feature} [${worktree.project}]`,
+      ? `${worktree.is_last_workspace_child ? '└─' : '├─'} [${worktree.project}]${ralphSuffix}`
+      : `${worktree.feature} [${worktree.project}]${ralphSuffix}`,
     diff: formatDiffStats(worktree.git?.base_added_lines || 0, worktree.git?.base_deleted_lines || 0),
     changes: formatGitChanges(worktree.git?.ahead || 0, worktree.git?.behind || 0),
     pr: formatPRStatus(prStatus),

--- a/src/contexts/WorktreeContext.tsx
+++ b/src/contexts/WorktreeContext.tsx
@@ -4,6 +4,11 @@ import type {AITool} from '../models.js';
 import {MemoryStatus} from '../services/MemoryMonitorService.js';
 import type {VersionInfo} from '../services/versionTypes.js';
 import {WorktreeCore} from '../cores/WorktreeCore.js';
+import {RalphCore, loadRalphConfig} from '../cores/RalphCore.js';
+import {TrackerService} from '../services/TrackerService.js';
+import {TmuxService} from '../services/TmuxService.js';
+import {GitService} from '../services/GitService.js';
+import {getProjectsDirectory} from '../config.js';
 
 interface WorktreeContextType {
   // State
@@ -70,8 +75,34 @@ interface WorktreeProviderProps {
 export function WorktreeProvider({children, core: coreOverride}: WorktreeProviderProps) {
   const coreRef = React.useRef(coreOverride || new WorktreeCore());
   const core = coreRef.current;
+
+  // Ralph runs alongside the worktree core. It samples on its own schedule
+  // and only fires nudges when enabled per-project via tracker/ralph.json.
+  // We build it lazily so tests that don't care about ralph aren't forced to
+  // instantiate it (they won't hit the code path because there are no
+  // projects with ralph enabled).
+  const trackerRef = React.useRef(new TrackerService());
+  const tmuxRef = React.useRef(new TmuxService());
+  const gitRef = React.useRef(new GitService(getProjectsDirectory()));
+  const ralphRef = React.useRef<RalphCore | null>(null);
+  if (!ralphRef.current) {
+    ralphRef.current = new RalphCore({
+      tracker: trackerRef.current,
+      tmux: tmuxRef.current,
+      getWorktrees: () => coreRef.current.get().worktrees,
+      getProjectPath: (project) => {
+        const projects = gitRef.current.discoverProjects();
+        const match = projects.find(p => p.name === project);
+        return match?.path ?? '';
+      },
+    });
+  }
+  const ralph = ralphRef.current!;
+
   React.useEffect(() => { core.start(); return () => core.stop(); }, [core]);
+  React.useEffect(() => { ralph.start(); return () => ralph.stop(); }, [ralph]);
   const state = React.useSyncExternalStore(core.subscribe.bind(core), core.get.bind(core), core.get.bind(core));
+  const ralphState = React.useSyncExternalStore(ralph.subscribe.bind(ralph), ralph.get.bind(ralph), ralph.get.bind(ralph));
 
   // Navigation
   const selectWorktree = useCallback((index: number) => core.selectWorktree(index), [core]);
@@ -120,9 +151,36 @@ export function WorktreeProvider({children, core: coreOverride}: WorktreeProvide
   const applyConfig = useCallback((project: string, content: string) => core.applyConfig(project, content), [core]);
   const reapplyFiles = useCallback((project: string) => core.reapplyFiles(project), [core]);
 
+  // Decorate worktrees with ralph + agent status info so the list row can
+  // render a compact chip. Lookup is O(projects × worktrees) but only on
+  // state changes, and the maps are small in practice.
+  const worktreesWithRalph = React.useMemo(() => {
+    const projects = gitRef.current.discoverProjects();
+    const projectPathByName = new Map(projects.map(p => [p.name, p.path]));
+    return state.worktrees.map(wt => {
+      const projectPath = projectPathByName.get(wt.project);
+      if (!projectPath) return wt;
+      const status = trackerRef.current.getItemStatus(projectPath, wt.feature);
+      const ralphWt = ralphState.worktrees[`${wt.project}::${wt.feature}`];
+      const cfg = loadRalphConfig(projectPath);
+      if (!status && !ralphWt) return wt;
+      const freshWaiting =
+        !!status && status.is_waiting_for_user && !trackerRef.current.isItemStatusStale(status);
+      const decorated = new WorktreeInfo({...wt});
+      decorated.ralph = {
+        is_waiting_for_user: freshWaiting,
+        brief_description: status?.brief_description,
+        nudges_this_stage: ralphWt?.nudgesThisStage ?? 0,
+        max_nudges_per_stage: cfg.maxNudgesPerStage,
+        capped: ralphWt?.capped ?? false,
+      };
+      return decorated;
+    });
+  }, [state.worktrees, ralphState]);
+
   const contextValue: WorktreeContextType = {
     // State
-    worktrees: state.worktrees,
+    worktrees: worktreesWithRalph,
     loading: state.loading,
     lastRefreshed: state.lastRefreshed,
     selectedIndex: state.selectedIndex,

--- a/src/contexts/WorktreeContext.tsx
+++ b/src/contexts/WorktreeContext.tsx
@@ -157,13 +157,24 @@ export function WorktreeProvider({children, core: coreOverride}: WorktreeProvide
   const worktreesWithRalph = React.useMemo(() => {
     const projects = gitRef.current.discoverProjects();
     const projectPathByName = new Map(projects.map(p => [p.name, p.path]));
+    // Dedupe `loadRalphConfig` reads — a worktree list with N items in the
+    // same project was firing N readFileSync calls per refresh. One per
+    // unique project is enough.
+    const ralphConfigByProject = new Map<string, ReturnType<typeof loadRalphConfig>>();
+    const getCfg = (projectPath: string) => {
+      const cached = ralphConfigByProject.get(projectPath);
+      if (cached) return cached;
+      const fresh = loadRalphConfig(projectPath);
+      ralphConfigByProject.set(projectPath, fresh);
+      return fresh;
+    };
     return state.worktrees.map(wt => {
       const projectPath = projectPathByName.get(wt.project);
       if (!projectPath) return wt;
       const status = trackerRef.current.getItemStatus(projectPath, wt.feature);
       const ralphWt = ralphState.worktrees[`${wt.project}::${wt.feature}`];
-      const cfg = loadRalphConfig(projectPath);
       if (!status && !ralphWt) return wt;
+      const cfg = getCfg(projectPath);
       const decorated = new WorktreeInfo({...wt});
       decorated.ralph = {
         state: trackerRef.current.isItemWaiting(status) ? status!.state : 'working',

--- a/src/contexts/WorktreeContext.tsx
+++ b/src/contexts/WorktreeContext.tsx
@@ -164,11 +164,9 @@ export function WorktreeProvider({children, core: coreOverride}: WorktreeProvide
       const ralphWt = ralphState.worktrees[`${wt.project}::${wt.feature}`];
       const cfg = loadRalphConfig(projectPath);
       if (!status && !ralphWt) return wt;
-      const freshWaiting =
-        !!status && status.state !== 'working' && !trackerRef.current.isItemStatusStale(status);
       const decorated = new WorktreeInfo({...wt});
       decorated.ralph = {
-        is_waiting_for_user: freshWaiting,
+        state: trackerRef.current.isItemWaiting(status) ? status!.state : 'working',
         brief_description: status?.brief_description,
         nudges_this_stage: ralphWt?.nudgesThisStage ?? 0,
         max_nudges_per_stage: cfg.maxNudgesPerStage,

--- a/src/contexts/WorktreeContext.tsx
+++ b/src/contexts/WorktreeContext.tsx
@@ -165,7 +165,7 @@ export function WorktreeProvider({children, core: coreOverride}: WorktreeProvide
       const cfg = loadRalphConfig(projectPath);
       if (!status && !ralphWt) return wt;
       const freshWaiting =
-        !!status && status.is_waiting_for_user && !trackerRef.current.isItemStatusStale(status);
+        !!status && status.state !== 'working' && !trackerRef.current.isItemStatusStale(status);
       const decorated = new WorktreeInfo({...wt});
       decorated.ralph = {
         is_waiting_for_user: freshWaiting,

--- a/src/cores/RalphCore.ts
+++ b/src/cores/RalphCore.ts
@@ -178,10 +178,21 @@ export class RalphCore implements CoreBase<State> {
     const nowMs = this.now();
     let changed = false;
 
+    // Many worktrees typically share a project; reading ralph.json once per
+    // unique project per sample avoids N × 60s file reads.
+    const configByProject = new Map<string, RalphConfig>();
+    const loadCfg = (projectPath: string): RalphConfig => {
+      const cached = configByProject.get(projectPath);
+      if (cached) return cached;
+      const fresh = loadRalphConfig(projectPath);
+      configByProject.set(projectPath, fresh);
+      return fresh;
+    };
+
     for (const wt of worktrees) {
       const key = stateKey(wt.project, wt.feature);
       const cur = this.state.worktrees[key] ?? this.blankState(wt.project, wt.feature);
-      const next = this.sampleWorktree(wt, cur, nowMs);
+      const next = this.sampleWorktree(wt, cur, nowMs, loadCfg);
       if (!shallowEqual(cur, next)) {
         this.state.worktrees[key] = next;
         changed = true;
@@ -214,11 +225,12 @@ export class RalphCore implements CoreBase<State> {
     wt: WorktreeInfo,
     prev: RalphWorktreeState,
     nowMs: number,
+    loadCfg: (projectPath: string) => RalphConfig = loadRalphConfig,
   ): RalphWorktreeState {
     const projectPath = this.getProjectPath(wt.project);
     if (!projectPath) return prev;
 
-    const config = loadRalphConfig(projectPath);
+    const config = loadCfg(projectPath);
     const stage = this.tracker.getItemStage(projectPath, wt.feature);
     const status = this.tracker.getItemStatus(projectPath, wt.feature);
     const aiStatus = wt.session?.ai_status ?? 'not_running';
@@ -281,10 +293,9 @@ export class RalphCore implements CoreBase<State> {
       return next;
     }
 
-    // Stage has to have been unchanged for the idle window as well. We proxy
-    // this via lastStage — if the stage hasn't changed since the previous
-    // sample *and* we've been idle long enough, that's a stall.
-    if (prev.lastStage !== null && prev.lastStage !== stage) return next;
+    // (A stage change is already handled up top — it zeros idleSince, which
+    // the earlier idleSince guard catches — so we don't need a second check
+    // here.)
 
     // Fire the nudge. `stage !== 'archive'` has already been guarded above,
     // so stage is Exclude<TrackerStage, 'archive'> here. inputMode is

--- a/src/cores/RalphCore.ts
+++ b/src/cores/RalphCore.ts
@@ -281,13 +281,15 @@ export class RalphCore implements CoreBase<State> {
     if (prev.lastStage !== null && prev.lastStage !== stage) return next;
 
     // Fire the nudge. `stage !== 'archive'` has already been guarded above,
-    // so stage is Exclude<TrackerStage, 'archive'> here.
+    // so stage is Exclude<TrackerStage, 'archive'> here. inputMode is
+    // project-global (WorkStyle); gate_on_advance is per-stage.
     const stageSettings = this.tracker.loadStagesConfig(projectPath);
     const settings = stageSettings?.[stage as Exclude<TrackerStage, 'archive'>]?.settings ?? {};
+    const workStyle = this.tracker.loadWorkStyle(projectPath);
     const nudgeText = buildNudgeText({
       slug: wt.feature,
       stage,
-      inputMode: settings['input_mode'] ?? 'ask_questions',
+      inputMode: workStyle.inputMode,
       gateOnAdvance: settings['gate_on_advance'] ?? 'none',
     });
 

--- a/src/cores/RalphCore.ts
+++ b/src/cores/RalphCore.ts
@@ -1,0 +1,333 @@
+import path from 'node:path';
+import fs from 'node:fs';
+import {CoreBase} from '../engine/core-types.js';
+import {TmuxService} from '../services/TmuxService.js';
+import {TrackerService, TrackerStage} from '../services/TrackerService.js';
+import {WorktreeInfo} from '../models.js';
+import {startIntervalIfEnabled} from '../shared/utils/intervals.js';
+import {logError, logInfo} from '../shared/utils/logger.js';
+
+export interface RalphConfig {
+  enabled: boolean;
+  idleThresholdMs: number;
+  maxNudgesPerStage: number;
+}
+
+export const DEFAULT_RALPH_CONFIG: RalphConfig = {
+  enabled: false,
+  idleThresholdMs: 3 * 60 * 1000,
+  maxNudgesPerStage: 3,
+};
+
+// Minimum gap between sampling cycles. Keeps the loop cheap and aligned with
+// the convention noted in auto-memory (poll intervals ≥ 60s).
+const SAMPLE_INTERVAL_MS = 60_000;
+
+export interface RalphWorktreeState {
+  project: string;
+  slug: string;
+  // First timestamp in an unbroken run of ai_status === 'idle'. null when
+  // the agent is not currently idle.
+  idleSince: number | null;
+  // Stage value observed on the previous sample. null before the first sample.
+  lastStage: TrackerStage | null;
+  // Nudges sent during the current stage. Reset on stage change or on a
+  // fresh is_waiting_for_user flip.
+  nudgesThisStage: number;
+  // Timestamp of the most recent nudge sent to this worktree.
+  lastNudgeAt: number | null;
+  // True once nudgesThisStage has reached the cap and the worktree is
+  // flagged "needs attention" until the stage advances.
+  capped: boolean;
+}
+
+type State = {
+  // Keyed by `${project}::${slug}` so look-ups stay cheap.
+  worktrees: Record<string, RalphWorktreeState>;
+};
+
+export interface RalphDependencies {
+  tracker: TrackerService;
+  tmux: TmuxService;
+  // Lazy producer for the current worktree snapshot from WorktreeCore. Kept as
+  // a function so RalphCore doesn't depend on WorktreeCore's lifecycle.
+  getWorktrees: () => readonly WorktreeInfo[];
+  getProjectPath: (project: string) => string;
+  // Injection points for testability.
+  now?: () => number;
+  logger?: (line: string) => void;
+}
+
+// Per-project ralph config persists at <projectPath>/tracker/ralph.json.
+export function ralphConfigPath(projectPath: string): string {
+  return path.join(projectPath, 'tracker', 'ralph.json');
+}
+
+export function loadRalphConfig(projectPath: string): RalphConfig {
+  try {
+    const raw = fs.readFileSync(ralphConfigPath(projectPath), 'utf8');
+    const parsed = JSON.parse(raw) as Partial<RalphConfig>;
+    return {
+      enabled: typeof parsed.enabled === 'boolean' ? parsed.enabled : DEFAULT_RALPH_CONFIG.enabled,
+      idleThresholdMs:
+        typeof parsed.idleThresholdMs === 'number' && parsed.idleThresholdMs > 0
+          ? parsed.idleThresholdMs
+          : DEFAULT_RALPH_CONFIG.idleThresholdMs,
+      maxNudgesPerStage:
+        typeof parsed.maxNudgesPerStage === 'number' && parsed.maxNudgesPerStage >= 0
+          ? parsed.maxNudgesPerStage
+          : DEFAULT_RALPH_CONFIG.maxNudgesPerStage,
+    };
+  } catch {
+    return {...DEFAULT_RALPH_CONFIG};
+  }
+}
+
+export function saveRalphConfig(projectPath: string, config: RalphConfig): void {
+  const dir = path.dirname(ralphConfigPath(projectPath));
+  if (!fs.existsSync(dir)) fs.mkdirSync(dir, {recursive: true});
+  fs.writeFileSync(ralphConfigPath(projectPath), JSON.stringify(config, null, 2));
+}
+
+// Build the stage-specific nudge text. The agent pastes this back into its
+// own context, so it's written in the second person, names the stage guide
+// path, and references the status.json protocol it should be maintaining.
+export function buildNudgeText(opts: {
+  slug: string;
+  stage: TrackerStage;
+  inputMode: string;
+  gateOnAdvance: string;
+}): string {
+  const outputFile =
+    opts.stage === 'discovery' ? 'notes.md'
+    : opts.stage === 'requirements' ? 'requirements.md'
+    : opts.stage === 'implement' ? 'implementation.md'
+    : opts.stage === 'cleanup' ? 'implementation.md'
+    : '—';
+  const stageFile = `tracker/stages/${stageFileNumber(opts.stage)}-${opts.stage}.md`;
+  return [
+    `[ralph] You're still in stage "${opts.stage}" for ${opts.slug} and appear idle.`,
+    `Re-read ${stageFile} (gate: ${opts.gateOnAdvance}; input_mode: ${opts.inputMode}).`,
+    `Expected output: ${outputFile}. When work is done, advance by updating tracker/items/${opts.slug}/status.json (canonical) then the index.`,
+    `If you're blocked, set is_waiting_for_user: true in status.json with a brief_description — or use ask_questions if that's your input_mode. Otherwise keep going.`,
+  ].join(' ');
+}
+
+function stageFileNumber(stage: TrackerStage): number {
+  switch (stage) {
+    case 'backlog': return 1;
+    case 'discovery': return 2;
+    case 'requirements': return 3;
+    case 'implement': return 4;
+    case 'cleanup': return 5;
+    default: return 0;
+  }
+}
+
+function stateKey(project: string, slug: string): string {
+  return `${project}::${slug}`;
+}
+
+export class RalphCore implements CoreBase<State> {
+  private state: State = {worktrees: {}};
+  private listeners = new Set<(s: Readonly<State>) => void>();
+  private timers: Array<() => void> = [];
+  private tracker: TrackerService;
+  private tmux: TmuxService;
+  private getWorktrees: () => readonly WorktreeInfo[];
+  private getProjectPath: (project: string) => string;
+  private now: () => number;
+  private log: (line: string) => void;
+
+  constructor(deps: RalphDependencies) {
+    this.tracker = deps.tracker;
+    this.tmux = deps.tmux;
+    this.getWorktrees = deps.getWorktrees;
+    this.getProjectPath = deps.getProjectPath;
+    this.now = deps.now ?? (() => Date.now());
+    this.log = deps.logger ?? ((line: string) => {
+      try {
+        const logPath = path.join(process.cwd(), 'logs', 'ralph.log');
+        fs.mkdirSync(path.dirname(logPath), {recursive: true});
+        fs.appendFileSync(logPath, line + '\n');
+      } catch {
+        // silent — logging must never crash the loop
+      }
+    });
+  }
+
+  get(): Readonly<State> { return this.state; }
+  subscribe(fn: (s: Readonly<State>) => void): () => void {
+    this.listeners.add(fn);
+    return () => this.listeners.delete(fn);
+  }
+  start(): void {
+    const clear = startIntervalIfEnabled(() => {
+      try { this.sampleOnce(); } catch (err) { logError('ralph sample failed', err); }
+    }, SAMPLE_INTERVAL_MS);
+    this.timers.push(clear);
+  }
+  stop(): void {
+    for (const t of this.timers) t?.();
+    this.timers = [];
+  }
+
+  // Exposed for tests and for the app to drive an immediate sample after a
+  // settings change. Runs one pass across every known worktree and fires any
+  // nudges that the guard conditions allow.
+  sampleOnce(): void {
+    const worktrees = this.getWorktrees();
+    const nowMs = this.now();
+    let changed = false;
+
+    for (const wt of worktrees) {
+      const key = stateKey(wt.project, wt.feature);
+      const cur = this.state.worktrees[key] ?? this.blankState(wt.project, wt.feature);
+      const next = this.sampleWorktree(wt, cur, nowMs);
+      if (!shallowEqual(cur, next)) {
+        this.state.worktrees[key] = next;
+        changed = true;
+      } else if (!this.state.worktrees[key]) {
+        this.state.worktrees[key] = cur;
+        changed = true;
+      }
+    }
+
+    if (changed) this.emit();
+  }
+
+  private blankState(project: string, slug: string): RalphWorktreeState {
+    return {
+      project,
+      slug,
+      idleSince: null,
+      lastStage: null,
+      nudgesThisStage: 0,
+      lastNudgeAt: null,
+      capped: false,
+    };
+  }
+
+  private sampleWorktree(
+    wt: WorktreeInfo,
+    prev: RalphWorktreeState,
+    nowMs: number,
+  ): RalphWorktreeState {
+    const projectPath = this.getProjectPath(wt.project);
+    if (!projectPath) return prev;
+
+    const config = loadRalphConfig(projectPath);
+    const stage = this.tracker.getItemStage(projectPath, wt.feature);
+    const status = this.tracker.getItemStatus(projectPath, wt.feature);
+    const aiStatus = wt.session?.ai_status ?? 'not_running';
+    const sessionName = wt.session?.session_name;
+
+    // Track stage for reset semantics. Any stage change clears the cap and
+    // the nudge counter — the agent has made real progress.
+    let nudgesThisStage = prev.nudgesThisStage;
+    let capped = prev.capped;
+    let idleSince = prev.idleSince;
+    const stageChanged = prev.lastStage !== null && prev.lastStage !== stage;
+    if (stageChanged) {
+      nudgesThisStage = 0;
+      capped = false;
+      idleSince = null;
+    }
+
+    // Any fresh waiting flag also resets the cap — the agent explicitly said
+    // it's waiting on a human, so any prior stuck-ness is moot.
+    const fresh = status && status.is_waiting_for_user && !this.tracker.isItemStatusStale(status, new Date(nowMs));
+    if (fresh && (prev.idleSince !== null || prev.nudgesThisStage > 0 || prev.capped)) {
+      nudgesThisStage = 0;
+      capped = false;
+      idleSince = null;
+    }
+
+    // Track the idle run.
+    if (aiStatus === 'idle') {
+      if (idleSince === null) idleSince = nowMs;
+    } else {
+      idleSince = null;
+    }
+
+    // Build the next state *before* the nudge decision so we can short-circuit
+    // cleanly if any guard fails.
+    const next: RalphWorktreeState = {
+      project: wt.project,
+      slug: wt.feature,
+      idleSince,
+      lastStage: stage,
+      nudgesThisStage,
+      lastNudgeAt: prev.lastNudgeAt,
+      capped,
+    };
+
+    // ── nudge guards ─────────────────────────────────────────────────────────
+    if (!config.enabled) return next;
+    if (!sessionName || !wt.session?.attached) return next;
+    if (aiStatus === 'working' || aiStatus === 'waiting') return next;
+    if (aiStatus !== 'idle') return next;
+    if (idleSince === null || nowMs - idleSince < config.idleThresholdMs) return next;
+    if (fresh) return next;
+    if (stage === 'archive') return next;
+    if (nudgesThisStage >= config.maxNudgesPerStage) {
+      next.capped = true;
+      return next;
+    }
+
+    // Stage has to have been unchanged for the idle window as well. We proxy
+    // this via lastStage — if the stage hasn't changed since the previous
+    // sample *and* we've been idle long enough, that's a stall.
+    if (prev.lastStage !== null && prev.lastStage !== stage) return next;
+
+    // Fire the nudge. `stage !== 'archive'` has already been guarded above,
+    // so stage is Exclude<TrackerStage, 'archive'> here.
+    const stageSettings = this.tracker.loadStagesConfig(projectPath);
+    const settings = stageSettings?.[stage as Exclude<TrackerStage, 'archive'>]?.settings ?? {};
+    const nudgeText = buildNudgeText({
+      slug: wt.feature,
+      stage,
+      inputMode: settings['input_mode'] ?? 'ask_questions',
+      gateOnAdvance: settings['gate_on_advance'] ?? 'none',
+    });
+
+    try {
+      this.tmux.sendText(sessionName, nudgeText, {executeCommand: true});
+    } catch (err) {
+      logError('ralph: failed to send nudge', err);
+      return next;
+    }
+
+    next.nudgesThisStage = nudgesThisStage + 1;
+    next.lastNudgeAt = nowMs;
+    next.capped = next.nudgesThisStage >= config.maxNudgesPerStage;
+    next.idleSince = null; // reset the idle clock so we don't double-fire
+
+    this.log(JSON.stringify({
+      timestamp: new Date(nowMs).toISOString(),
+      project: wt.project,
+      slug: wt.feature,
+      stage,
+      nudgeNumber: next.nudgesThisStage,
+      idleMs: nowMs - (idleSince ?? nowMs),
+    }));
+    logInfo('ralph nudged worktree', {project: wt.project, slug: wt.feature, stage, nudge: next.nudgesThisStage});
+
+    return next;
+  }
+
+  private emit(): void {
+    const snapshot: State = {worktrees: {...this.state.worktrees}};
+    for (const listener of this.listeners) listener(snapshot);
+  }
+}
+
+function shallowEqual(a: RalphWorktreeState, b: RalphWorktreeState): boolean {
+  return a.project === b.project
+    && a.slug === b.slug
+    && a.idleSince === b.idleSince
+    && a.lastStage === b.lastStage
+    && a.nudgesThisStage === b.nudgesThisStage
+    && a.lastNudgeAt === b.lastNudgeAt
+    && a.capped === b.capped;
+}

--- a/src/cores/RalphCore.ts
+++ b/src/cores/RalphCore.ts
@@ -113,10 +113,10 @@ export function buildNudgeText(opts: {
   return [
     `Quick check-in — this session has been idle for a while, so I wanted to make sure you're not stuck.`,
     `Current stage is \`${opts.stage}\` (guide: ${stageFile}, gate: ${opts.gateOnAdvance}, input_mode: ${opts.inputMode}). The expected output for this stage is \`${outputFile}\`.`,
-    `Please update \`${statusPath}\` to reflect where you are right now:`,
-    `set \`stage\` to your current stage, then either set \`is_waiting_for_user: true\` with a short \`brief_description\` if you need my input before you can continue, or \`is_waiting_for_user: false\` with a note of what you're actively working on.`,
-    `If you're waiting on me, flipping that flag in status.json (or using ask_questions if that's your input_mode) will stop these check-ins from firing.`,
-    `Otherwise, please keep making progress on \`${outputFile}\` and advance the stage when ready.`,
+    `Please update \`${statusPath}\` so the kanban reflects where you are — the \`brief_description\` field is rendered directly on the card and should describe the *work* (what you're doing, or what you need), not the stage (that's already visible).`,
+    `If the stage work is done and you're waiting on my approval to advance, set \`is_waiting_for_user: true\` AND \`awaiting_advance_approval: true\` with a concrete summary of what I should review.`,
+    `If you're blocked mid-stage on something else, set \`is_waiting_for_user: true\` with a \`brief_description\` of the specific thing you need (or use ask_questions if that's your input_mode).`,
+    `Either flag stops these check-ins from firing. Otherwise please keep making progress on \`${outputFile}\` and advance when ready.`,
   ].join(' ');
 }
 
@@ -242,8 +242,11 @@ export class RalphCore implements CoreBase<State> {
     }
 
     // Any fresh waiting flag also resets the cap — the agent explicitly said
-    // it's waiting on a human, so any prior stuck-ness is moot.
-    const fresh = status && status.is_waiting_for_user && !this.tracker.isItemStatusStale(status, new Date(nowMs));
+    // it's waiting on a human, so any prior stuck-ness is moot. We treat
+    // `awaiting_advance_approval` as an equivalent suppressor: work is done,
+    // the agent is waiting for the go-ahead, that's not a stall.
+    const nonStale = status && !this.tracker.isItemStatusStale(status, new Date(nowMs));
+    const fresh = nonStale && (status.is_waiting_for_user || !!status.awaiting_advance_approval);
     if (fresh && (prev.idleSince !== null || prev.nudgesThisStage > 0 || prev.capped)) {
       nudgesThisStage = 0;
       capped = false;

--- a/src/cores/RalphCore.ts
+++ b/src/cores/RalphCore.ts
@@ -108,27 +108,15 @@ export function buildNudgeText(opts: {
     : opts.stage === 'implement' ? 'implementation.md'
     : opts.stage === 'cleanup' ? 'implementation.md'
     : '—';
-  const stageFile = `tracker/stages/${stageFileNumber(opts.stage)}-${opts.stage}.md`;
+  const stageFile = `tracker/stages/${opts.stage}.md`;
   const statusPath = `tracker/items/${opts.slug}/status.json`;
   return [
     `Quick check-in — this session has been idle for a while, so I wanted to make sure you're not stuck.`,
     `Current stage is \`${opts.stage}\` (guide: ${stageFile}, gate: ${opts.gateOnAdvance}, input_mode: ${opts.inputMode}). The expected output for this stage is \`${outputFile}\`.`,
     `Please update \`${statusPath}\` so the kanban reflects where you are — the \`brief_description\` field is rendered directly on the card and should describe the *work* (what you're doing, or what you need), not the stage (that's already visible).`,
-    `If the stage work is done and you're waiting on my approval to advance, set \`is_waiting_for_user: true\` AND \`awaiting_advance_approval: true\` with a concrete summary of what I should review.`,
-    `If you're blocked mid-stage on something else, set \`is_waiting_for_user: true\` with a \`brief_description\` of the specific thing you need (or use ask_questions if that's your input_mode).`,
-    `Either flag stops these check-ins from firing. Otherwise please keep making progress on \`${outputFile}\` and advance when ready.`,
+    `If you're blocked on a clarification, set \`state: "waiting_for_input"\` in \`status.json\` with a \`brief_description\` of the specific thing you need. If stage work is complete and you're waiting on my approval to advance, set \`state: "waiting_for_approval"\` instead (kanban renders those distinctly so I can approve them fast). Or use ask_questions if that's your input_mode.`,
+    `Either waiting state stops these check-ins from firing. Otherwise please keep making progress on \`${outputFile}\` and advance when ready.`,
   ].join(' ');
-}
-
-function stageFileNumber(stage: TrackerStage): number {
-  switch (stage) {
-    case 'backlog': return 1;
-    case 'discovery': return 2;
-    case 'requirements': return 3;
-    case 'implement': return 4;
-    case 'cleanup': return 5;
-    default: return 0;
-  }
 }
 
 function stateKey(project: string, slug: string): string {
@@ -241,12 +229,11 @@ export class RalphCore implements CoreBase<State> {
       idleSince = null;
     }
 
-    // Any fresh waiting flag also resets the cap — the agent explicitly said
-    // it's waiting on a human, so any prior stuck-ness is moot. We treat
-    // `awaiting_advance_approval` as an equivalent suppressor: work is done,
-    // the agent is waiting for the go-ahead, that's not a stall.
+    // A fresh non-working state resets the cap — the agent explicitly said
+    // it's waiting on a human, so any prior stuck-ness is moot. Both
+    // waiting states (for_input and for_approval) suppress nudges equally.
     const nonStale = status && !this.tracker.isItemStatusStale(status, new Date(nowMs));
-    const fresh = nonStale && (status.is_waiting_for_user || !!status.awaiting_advance_approval);
+    const fresh = nonStale && status.state !== 'working';
     if (fresh && (prev.idleSince !== null || prev.nudgesThisStage > 0 || prev.capped)) {
       nudgesThisStage = 0;
       capped = false;

--- a/src/cores/RalphCore.ts
+++ b/src/cores/RalphCore.ts
@@ -31,8 +31,8 @@ export interface RalphWorktreeState {
   idleSince: number | null;
   // Stage value observed on the previous sample. null before the first sample.
   lastStage: TrackerStage | null;
-  // Nudges sent during the current stage. Reset on stage change or on a
-  // fresh is_waiting_for_user flip.
+  // Nudges sent during the current stage. Reset on stage change or when
+  // the agent freshly flips state to waiting_for_input / waiting_for_approval.
   nudgesThisStage: number;
   // Timestamp of the most recent nudge sent to this worktree.
   lastNudgeAt: number | null;
@@ -230,10 +230,8 @@ export class RalphCore implements CoreBase<State> {
     }
 
     // A fresh non-working state resets the cap — the agent explicitly said
-    // it's waiting on a human, so any prior stuck-ness is moot. Both
-    // waiting states (for_input and for_approval) suppress nudges equally.
-    const nonStale = status && !this.tracker.isItemStatusStale(status, new Date(nowMs));
-    const fresh = nonStale && status.state !== 'working';
+    // it's waiting on a human, so any prior stuck-ness is moot.
+    const fresh = this.tracker.isItemWaiting(status, new Date(nowMs));
     if (fresh && (prev.idleSince !== null || prev.nudgesThisStage > 0 || prev.capped)) {
       nudgesThisStage = 0;
       capped = false;

--- a/src/cores/RalphCore.ts
+++ b/src/cores/RalphCore.ts
@@ -102,20 +102,23 @@ export function buildNudgeText(opts: {
   inputMode: string;
   gateOnAdvance: string;
 }): string {
-  const outputFile =
-    opts.stage === 'discovery' ? 'notes.md'
-    : opts.stage === 'requirements' ? 'requirements.md'
-    : opts.stage === 'implement' ? 'implementation.md'
-    : opts.stage === 'cleanup' ? 'implementation.md'
-    : '—';
+  // Cleanup polishes the implementation in place and (optionally) drafts
+  // the PR description — there's no single output file, so we describe the
+  // work more generically for that stage.
+  const progressTarget =
+    opts.stage === 'discovery' ? '`notes.md`'
+    : opts.stage === 'requirements' ? '`requirements.md`'
+    : opts.stage === 'implement' ? '`implementation.md`'
+    : opts.stage === 'cleanup' ? 'the cleanup checklist (tests, review, PR prep)'
+    : 'this stage';
   const stageFile = `tracker/stages/${opts.stage}.md`;
   const statusPath = `tracker/items/${opts.slug}/status.json`;
   return [
     `Quick check-in — this session has been idle for a while, so I wanted to make sure you're not stuck.`,
-    `Current stage is \`${opts.stage}\` (guide: ${stageFile}, gate: ${opts.gateOnAdvance}, input_mode: ${opts.inputMode}). The expected output for this stage is \`${outputFile}\`.`,
+    `Current stage is \`${opts.stage}\` (guide: ${stageFile}, gate: ${opts.gateOnAdvance}, input_mode: ${opts.inputMode}).`,
     `Please update \`${statusPath}\` so the kanban reflects where you are — the \`brief_description\` field is rendered directly on the card and should describe the *work* (what you're doing, or what you need), not the stage (that's already visible).`,
     `If you're blocked on a clarification, set \`state: "waiting_for_input"\` in \`status.json\` with a \`brief_description\` of the specific thing you need. If stage work is complete and you're waiting on my approval to advance, set \`state: "waiting_for_approval"\` instead (kanban renders those distinctly so I can approve them fast). Or use ask_questions if that's your input_mode.`,
-    `Either waiting state stops these check-ins from firing. Otherwise please keep making progress on \`${outputFile}\` and advance when ready.`,
+    `Either waiting state stops these check-ins from firing. Otherwise please keep making progress on ${progressTarget} and advance when ready.`,
   ].join(' ');
 }
 
@@ -183,6 +186,10 @@ export class RalphCore implements CoreBase<State> {
         this.state.worktrees[key] = next;
         changed = true;
       } else if (!this.state.worktrees[key]) {
+        // First time we see this worktree but sampleWorktree returned the
+        // blank state unchanged (e.g. getProjectPath was empty or the item
+        // has no tracker config yet). Register it so consumers get a
+        // well-formed entry on the next subscribe callback.
         this.state.worktrees[key] = cur;
         changed = true;
       }

--- a/src/cores/RalphCore.ts
+++ b/src/cores/RalphCore.ts
@@ -274,7 +274,11 @@ export class RalphCore implements CoreBase<State> {
 
     // ── nudge guards ─────────────────────────────────────────────────────────
     if (!config.enabled) return next;
-    if (!sessionName || !wt.session?.attached) return next;
+    // Need a tmux session to deliver the nudge into. Attachment (whether the
+    // user is viewing the pane) is *not* a "running agent" signal — a
+    // backgrounded tmux session is still running the agent, and ai_status
+    // handles the "is the agent alive and idle?" question below.
+    if (!sessionName) return next;
     if (aiStatus === 'working' || aiStatus === 'waiting') return next;
     if (aiStatus !== 'idle') return next;
     if (idleSince === null || nowMs - idleSince < config.idleThresholdMs) return next;

--- a/src/cores/RalphCore.ts
+++ b/src/cores/RalphCore.ts
@@ -89,9 +89,13 @@ export function saveRalphConfig(projectPath: string, config: RalphConfig): void 
   fs.writeFileSync(ralphConfigPath(projectPath), JSON.stringify(config, null, 2));
 }
 
-// Build the stage-specific nudge text. The agent pastes this back into its
-// own context, so it's written in the second person, names the stage guide
-// path, and references the status.json protocol it should be maintaining.
+// Build the stage-specific reminder text. The agent pastes this back into
+// its own context, so it's written in the second person and phrased as a
+// polite check-in rather than a system-labelled nudge — we want the agent
+// to read it as conversation, not metadata. It reminds the agent to report
+// its current stage and whether it needs user input via status.json; that
+// report is what suppresses future check-ins when the agent is legitimately
+// paused on a human.
 export function buildNudgeText(opts: {
   slug: string;
   stage: TrackerStage;
@@ -105,11 +109,14 @@ export function buildNudgeText(opts: {
     : opts.stage === 'cleanup' ? 'implementation.md'
     : '—';
   const stageFile = `tracker/stages/${stageFileNumber(opts.stage)}-${opts.stage}.md`;
+  const statusPath = `tracker/items/${opts.slug}/status.json`;
   return [
-    `[ralph] You're still in stage "${opts.stage}" for ${opts.slug} and appear idle.`,
-    `Re-read ${stageFile} (gate: ${opts.gateOnAdvance}; input_mode: ${opts.inputMode}).`,
-    `Expected output: ${outputFile}. When work is done, advance by updating tracker/items/${opts.slug}/status.json (canonical) then the index.`,
-    `If you're blocked, set is_waiting_for_user: true in status.json with a brief_description — or use ask_questions if that's your input_mode. Otherwise keep going.`,
+    `Quick check-in — this session has been idle for a while, so I wanted to make sure you're not stuck.`,
+    `Current stage is \`${opts.stage}\` (guide: ${stageFile}, gate: ${opts.gateOnAdvance}, input_mode: ${opts.inputMode}). The expected output for this stage is \`${outputFile}\`.`,
+    `Please update \`${statusPath}\` to reflect where you are right now:`,
+    `set \`stage\` to your current stage, then either set \`is_waiting_for_user: true\` with a short \`brief_description\` if you need my input before you can continue, or \`is_waiting_for_user: false\` with a note of what you're actively working on.`,
+    `If you're waiting on me, flipping that flag in status.json (or using ask_questions if that's your input_mode) will stop these check-ins from firing.`,
+    `Otherwise, please keep making progress on \`${outputFile}\` and advance the stage when ready.`,
   ].join(' ');
 }
 

--- a/src/cores/WorktreeCore.ts
+++ b/src/cores/WorktreeCore.ts
@@ -396,7 +396,7 @@ export class WorktreeCore implements CoreBase<State> {
       const flags = this.getAIToolFlags(worktree.project, selectedTool);
       const flagStr = flags.length > 0 ? ' ' + flags.map(shellQuote).join(' ') : '';
       if (selectedTool === 'claude') this.launchClaudeSessionWithFallback(sessionName, worktree.path, flagStr, `${worktree.feature} - ${worktree.project}`, initialPrompt);
-      else this.tmux.createSessionWithCommand(sessionName, worktree.path, aiLaunchCommand(selectedTool) + flagStr, true);
+      else this.launchAISessionWithFallback(sessionName, worktree.path, selectedTool, flagStr, initialPrompt);
       setLastTool(selectedTool, worktree.path);
     } else {
       this.tmux.createSession(sessionName, worktree.path, true);
@@ -593,6 +593,34 @@ export class WorktreeCore implements CoreBase<State> {
     const fallbackCmd = 'claude' + nameFlag + flagStr + promptArg;
     const continueCmd = aiLaunchCommand('claude') + nameFlag + flagStr + promptArg;
     this.tmux.createSessionWithCommand(sessionName, cwd, `${continueCmd} || ${fallbackCmd}`, true);
+  }
+
+  // codex / gemini: if we have an initial prompt, wire it into the launch via
+  // the tool's CLI args and add a fresh-session fallback (mirrors claude).
+  // Without a prompt, keep the plain resume launch — no fallback.
+  private launchAISessionWithFallback(sessionName: string, cwd: string, tool: AITool, flagStr: string = '', initialPrompt?: string): void {
+    if (!initialPrompt) {
+      this.tmux.createSessionWithCommand(sessionName, cwd, aiLaunchCommand(tool as Exclude<AITool, 'none'>) + flagStr, true);
+      return;
+    }
+    const promptQ = shellQuote(initialPrompt);
+    let resumeCmd: string;
+    let freshCmd: string;
+    if (tool === 'codex') {
+      // `codex resume [SESSION_ID] [PROMPT]`; with --last the SESSION_ID slot
+      // is filled, so a trailing positional maps to PROMPT.
+      resumeCmd = `codex resume --last${flagStr} ${promptQ}`;
+      freshCmd = `codex${flagStr} ${promptQ}`;
+    } else if (tool === 'gemini') {
+      // -i/--prompt-interactive runs the prompt then stays interactive.
+      resumeCmd = `gemini --resume latest${flagStr} -i ${promptQ}`;
+      freshCmd = `gemini${flagStr} -i ${promptQ}`;
+    } else {
+      const cmd = aiLaunchCommand(tool as Exclude<AITool, 'none'>) + flagStr;
+      resumeCmd = cmd;
+      freshCmd = cmd;
+    }
+    this.tmux.createSessionWithCommand(sessionName, cwd, `${resumeCmd} || ${freshCmd}`, true);
   }
 
   private setState(partial: Partial<State>): void {

--- a/src/models.ts
+++ b/src/models.ts
@@ -139,8 +139,11 @@ export class WorktreeInfo {
   // Ralph-sourced live state (optional — may be undefined for worktrees that
   // aren't tracker items). Populated by WorktreeContext from RalphCore +
   // TrackerService.getItemStatus so WorktreeRow can render a compact chip.
+  // `state` mirrors ItemStatus.state when the status file is fresh, or
+  // 'working' when there is no fresh waiting signal — consumers don't need
+  // to re-check staleness.
   ralph?: {
-    is_waiting_for_user: boolean;
+    state: 'working' | 'waiting_for_input' | 'waiting_for_approval';
     brief_description?: string;
     nudges_this_stage: number;
     max_nudges_per_stage: number;

--- a/src/models.ts
+++ b/src/models.ts
@@ -136,6 +136,16 @@ export class WorktreeInfo {
   children?: WorktreeInfo[];
   // Rendering helpers for workspace grouping
   is_last_workspace_child?: boolean;
+  // Ralph-sourced live state (optional — may be undefined for worktrees that
+  // aren't tracker items). Populated by WorktreeContext from RalphCore +
+  // TrackerService.getItemStatus so WorktreeRow can render a compact chip.
+  ralph?: {
+    is_waiting_for_user: boolean;
+    brief_description?: string;
+    nudges_this_stage: number;
+    max_nudges_per_stage: number;
+    capped: boolean;
+  };
   constructor(init: Partial<WorktreeInfo> = {}) {
     this.project = '';
     this.feature = '';

--- a/src/screens/TrackerBoardScreen.tsx
+++ b/src/screens/TrackerBoardScreen.tsx
@@ -627,18 +627,26 @@ export default function TrackerBoardScreen({
             const hasSession = !!sessWt;
 
             // Ralph waiting signal: the agent self-reported is_waiting_for_user
-            // in status.json. We treat that as equivalent to the tmux-level
-            // `waiting` state for rendering — it's the same "human needs to
-            // respond" UX — and surface the brief_description as secondary
-            // text so the user sees what the agent is waiting on.
+            // in status.json. `awaiting_advance_approval` is a distinct subset
+            // ("stage work complete, waiting for your go-ahead to advance") —
+            // we give it its own green "ready to advance" treatment because
+            // that's the moment the human most wants to spot at a glance.
             const itemStatus = service.getItemStatus(projectPath, item.slug);
-            const ralphWaiting = !!itemStatus
-              && itemStatus.is_waiting_for_user
-              && !service.isItemStatusStale(itemStatus);
+            const statusFresh = !!itemStatus && !service.isItemStatusStale(itemStatus);
+            const readyToAdvance = statusFresh && !!itemStatus!.awaiting_advance_approval;
+            const ralphWaiting = statusFresh && !!itemStatus!.is_waiting_for_user && !readyToAdvance;
             const isWaiting = aiWaiting || ralphWaiting;
 
-            const statusGlyph = isWaiting ? '!' : isWorking ? '⟳' : hasSession ? '◆' : ' ';
-            const statusColor = isWaiting ? 'yellow' : isWorking ? 'cyan' : hasSession ? 'gray' : undefined;
+            const statusGlyph =
+              readyToAdvance ? '✓' :
+              isWaiting ? '!' :
+              isWorking ? '⟳' :
+              hasSession ? '◆' : ' ';
+            const statusColor =
+              readyToAdvance ? 'green' :
+              isWaiting ? 'yellow' :
+              isWorking ? 'cyan' :
+              hasSession ? 'gray' : undefined;
 
             // Slug row eats: 2 (border) + 2 (paddingX) + 2 (cursor) + 2 (status glyph) = 8 chars
             const slug = truncateDisplay(item.slug, Math.max(4, colWidth - 8));
@@ -652,17 +660,22 @@ export default function TrackerBoardScreen({
             const waitingLabel = ralphWaiting && itemStatus?.brief_description
               ? itemStatus.brief_description
               : 'waiting for you';
+            const readyLabel = itemStatus?.brief_description
+              ? `READY TO ADVANCE — ${itemStatus.brief_description}`
+              : 'READY TO ADVANCE';
 
             return (
               <Box key={item.slug} flexDirection="column" marginBottom={1} flexShrink={0}>
                 {/* Slug row: cursor + status + name */}
                 <Box>
                   <Text color={accent} bold>{isSelected ? '▸ ' : '  '}</Text>
-                  <Text color={statusColor} bold={isWaiting}>{statusGlyph} </Text>
+                  <Text color={statusColor} bold={isWaiting || readyToAdvance}>{statusGlyph} </Text>
                   <Text
                     inverse={isSelected}
-                    color={!isSelected && isWaiting ? 'yellow' : undefined}
-                    bold={isWaiting || isSelected}
+                    color={!isSelected
+                      ? (readyToAdvance ? 'green' : isWaiting ? 'yellow' : undefined)
+                      : undefined}
+                    bold={isWaiting || readyToAdvance || isSelected}
                     wrap="truncate"
                   >
                     {slug}
@@ -672,19 +685,24 @@ export default function TrackerBoardScreen({
                     long brief_descriptions from the agent stay readable. */}
                 {(() => {
                   const text =
-                    isWaiting ? waitingLabel
+                    readyToAdvance ? readyLabel
+                    : isWaiting ? waitingLabel
                     : isWorking ? (itemStatus?.brief_description || 'running')
                     : hasSession ? (itemStatus?.brief_description || 'session idle')
                     : secondary || '';
                   if (!text) return null;
                   const lines = wrapToLines(text, secMax, SECONDARY_MAX_LINES);
-                  const color = isWaiting ? 'yellow' : isWorking ? 'cyan' : undefined;
-                  const dim = !isWaiting && !isWorking;
+                  const color =
+                    readyToAdvance ? 'green'
+                    : isWaiting ? 'yellow'
+                    : isWorking ? 'cyan'
+                    : undefined;
+                  const dim = !readyToAdvance && !isWaiting && !isWorking;
                   return lines.map((line, lineIdx) => (
                     <Text
                       key={lineIdx}
                       color={color}
-                      bold={isWaiting}
+                      bold={isWaiting || readyToAdvance}
                       dimColor={dim}
                       wrap="truncate"
                     >

--- a/src/screens/TrackerBoardScreen.tsx
+++ b/src/screens/TrackerBoardScreen.tsx
@@ -596,9 +596,20 @@ export default function TrackerBoardScreen({
             const isSelected = isActiveColumn && selectedRow === itemIndex;
             const sessWt = getSessionForItem(item);
             const aiStatus: AIStatus | undefined = sessWt?.session?.ai_status;
-            const isWaiting = aiStatus === 'waiting';
+            const aiWaiting = aiStatus === 'waiting';
             const isWorking = aiStatus === 'working' || aiStatus === 'active';
             const hasSession = !!sessWt;
+
+            // Ralph waiting signal: the agent self-reported is_waiting_for_user
+            // in status.json. We treat that as equivalent to the tmux-level
+            // `waiting` state for rendering — it's the same "human needs to
+            // respond" UX — and surface the brief_description as secondary
+            // text so the user sees what the agent is waiting on.
+            const itemStatus = service.getItemStatus(projectPath, item.slug);
+            const ralphWaiting = !!itemStatus
+              && itemStatus.is_waiting_for_user
+              && !service.isItemStatusStale(itemStatus);
+            const isWaiting = aiWaiting || ralphWaiting;
 
             const statusGlyph = isWaiting ? '!' : isWorking ? '⟳' : hasSession ? '◆' : ' ';
             const statusColor = isWaiting ? 'yellow' : isWorking ? 'cyan' : hasSession ? 'gray' : undefined;
@@ -608,6 +619,13 @@ export default function TrackerBoardScreen({
             // Secondary row eats: 2 (border) + 2 (paddingX) + 4 (indent) = 8 chars
             const secMax = Math.max(4, colWidth - 8);
             const secondary = !hasSession ? renderSecondary(item) : '';
+
+            // Prefer the agent's own brief_description over the generic
+            // "waiting for you" label when the ralph flag is set — it tells
+            // the human exactly what needs attention.
+            const waitingLabel = ralphWaiting && itemStatus?.brief_description
+              ? itemStatus.brief_description
+              : 'waiting for you';
 
             return (
               <Box key={item.slug} flexDirection="column" marginBottom={1} flexShrink={0}>
@@ -626,11 +644,11 @@ export default function TrackerBoardScreen({
                 </Box>
                 {/* Status / secondary text */}
                 {isWaiting ? (
-                  <Text color="yellow" bold wrap="truncate">{`    ${truncateDisplay('waiting for you', secMax)}`}</Text>
+                  <Text color="yellow" bold wrap="truncate">{`    ${truncateDisplay(waitingLabel, secMax)}`}</Text>
                 ) : isWorking ? (
-                  <Text color="cyan" wrap="truncate">{`    ${truncateDisplay('running', secMax)}`}</Text>
+                  <Text color="cyan" wrap="truncate">{`    ${truncateDisplay(itemStatus?.brief_description || 'running', secMax)}`}</Text>
                 ) : hasSession ? (
-                  <Text dimColor wrap="truncate">{`    ${truncateDisplay('session idle', secMax)}`}</Text>
+                  <Text dimColor wrap="truncate">{`    ${truncateDisplay(itemStatus?.brief_description || 'session idle', secMax)}`}</Text>
                 ) : secondary ? (
                   <Text dimColor wrap="truncate">{`    ${truncateDisplay(secondary, secMax)}`}</Text>
                 ) : null}

--- a/src/screens/TrackerBoardScreen.tsx
+++ b/src/screens/TrackerBoardScreen.tsx
@@ -36,9 +36,35 @@ const MIN_COLUMN_WIDTH = 20;
 const MAX_COLUMN_WIDTH = 50;
 const PLAN_COLOR = 'blue';
 const IMPL_COLOR = 'magenta';
-// Each item renders as 3 rows (slug + secondary + marginBottom). Used for per-column
-// scroll math so the column box stays within colHeight regardless of item count.
-const ROWS_PER_ITEM = 3;
+// Each item renders as up to 4 rows: slug + 2 secondary lines + marginBottom.
+// Reserved as a fixed slot so mixed short/long descriptions don't overlap
+// during scroll. Short descriptions just leave the second line blank.
+const ROWS_PER_ITEM = 4;
+const SECONDARY_MAX_LINES = 2;
+
+// Word-wrap `text` onto at most `maxLines` of width `width`. Breaks on spaces
+// when possible, falls back to character boundaries. Appends '…' to the last
+// line when content was truncated. Returns an array of 0–maxLines strings.
+function wrapToLines(text: string, width: number, maxLines: number): string[] {
+  if (!text || width <= 0 || maxLines <= 0) return [];
+  const out: string[] = [];
+  let remaining = text.trim();
+  while (remaining && out.length < maxLines) {
+    if (remaining.length <= width) { out.push(remaining); break; }
+    let breakAt = remaining.lastIndexOf(' ', width);
+    if (breakAt <= 0) breakAt = width;
+    out.push(remaining.slice(0, breakAt).trimEnd());
+    remaining = remaining.slice(breakAt).trimStart();
+  }
+  if (remaining && out.length > 0) {
+    const last = out[out.length - 1];
+    const fitsEllipsis = last.length + 1 <= width;
+    out[out.length - 1] = fitsEllipsis
+      ? last + '…'
+      : last.slice(0, Math.max(0, width - 1)) + '…';
+  }
+  return out;
+}
 // 2 borders + 1 header. Items area starts on the row directly below the title — no
 // inter-row gap so we get one extra item per column.
 const COLUMN_CHROME_ROWS = 3;
@@ -642,16 +668,30 @@ export default function TrackerBoardScreen({
                     {slug}
                   </Text>
                 </Box>
-                {/* Status / secondary text */}
-                {isWaiting ? (
-                  <Text color="yellow" bold wrap="truncate">{`    ${truncateDisplay(waitingLabel, secMax)}`}</Text>
-                ) : isWorking ? (
-                  <Text color="cyan" wrap="truncate">{`    ${truncateDisplay(itemStatus?.brief_description || 'running', secMax)}`}</Text>
-                ) : hasSession ? (
-                  <Text dimColor wrap="truncate">{`    ${truncateDisplay(itemStatus?.brief_description || 'session idle', secMax)}`}</Text>
-                ) : secondary ? (
-                  <Text dimColor wrap="truncate">{`    ${truncateDisplay(secondary, secMax)}`}</Text>
-                ) : null}
+                {/* Status / secondary text — wraps to SECONDARY_MAX_LINES so
+                    long brief_descriptions from the agent stay readable. */}
+                {(() => {
+                  const text =
+                    isWaiting ? waitingLabel
+                    : isWorking ? (itemStatus?.brief_description || 'running')
+                    : hasSession ? (itemStatus?.brief_description || 'session idle')
+                    : secondary || '';
+                  if (!text) return null;
+                  const lines = wrapToLines(text, secMax, SECONDARY_MAX_LINES);
+                  const color = isWaiting ? 'yellow' : isWorking ? 'cyan' : undefined;
+                  const dim = !isWaiting && !isWorking;
+                  return lines.map((line, lineIdx) => (
+                    <Text
+                      key={lineIdx}
+                      color={color}
+                      bold={isWaiting}
+                      dimColor={dim}
+                      wrap="truncate"
+                    >
+                      {`    ${line}`}
+                    </Text>
+                  ));
+                })()}
               </Box>
             );
           })}

--- a/src/screens/TrackerBoardScreen.tsx
+++ b/src/screens/TrackerBoardScreen.tsx
@@ -626,15 +626,14 @@ export default function TrackerBoardScreen({
             const isWorking = aiStatus === 'working' || aiStatus === 'active';
             const hasSession = !!sessWt;
 
-            // Ralph waiting signal: the agent self-reported is_waiting_for_user
-            // in status.json. `awaiting_advance_approval` is a distinct subset
-            // ("stage work complete, waiting for your go-ahead to advance") —
-            // we give it its own green "ready to advance" treatment because
-            // that's the moment the human most wants to spot at a glance.
+            // Ralph status signal: the agent self-reported a non-working
+            // state in status.json. `waiting_for_approval` gets its own green
+            // "ready to advance" treatment so it's spottable at a glance and
+            // can be acted on with the `m` shortcut from the board.
             const itemStatus = service.getItemStatus(projectPath, item.slug);
             const statusFresh = !!itemStatus && !service.isItemStatusStale(itemStatus);
-            const readyToAdvance = statusFresh && !!itemStatus!.awaiting_advance_approval;
-            const ralphWaiting = statusFresh && !!itemStatus!.is_waiting_for_user && !readyToAdvance;
+            const readyToAdvance = statusFresh && itemStatus!.state === 'waiting_for_approval';
+            const ralphWaiting = statusFresh && itemStatus!.state === 'waiting_for_input';
             const isWaiting = aiWaiting || ralphWaiting;
 
             const statusGlyph =
@@ -654,15 +653,16 @@ export default function TrackerBoardScreen({
             const secMax = Math.max(4, colWidth - 8);
             const secondary = !hasSession ? renderSecondary(item) : '';
 
-            // Prefer the agent's own brief_description over the generic
-            // "waiting for you" label when the ralph flag is set — it tells
-            // the human exactly what needs attention.
+            // Prefer the agent's own brief_description when available.
             const waitingLabel = ralphWaiting && itemStatus?.brief_description
               ? itemStatus.brief_description
               : 'waiting for you';
-            const readyLabel = itemStatus?.brief_description
-              ? `READY TO ADVANCE — ${itemStatus.brief_description}`
-              : 'READY TO ADVANCE';
+            const readyLabel = (() => {
+              const brief = itemStatus?.brief_description
+                ? `READY TO ADVANCE — ${itemStatus.brief_description}`
+                : 'READY TO ADVANCE';
+              return isSelected ? `${brief}  ·  [m] approve` : brief;
+            })();
 
             return (
               <Box key={item.slug} flexDirection="column" marginBottom={1} flexShrink={0}>

--- a/src/screens/TrackerBoardScreen.tsx
+++ b/src/screens/TrackerBoardScreen.tsx
@@ -631,9 +631,8 @@ export default function TrackerBoardScreen({
             // "ready to advance" treatment so it's spottable at a glance and
             // can be acted on with the `m` shortcut from the board.
             const itemStatus = service.getItemStatus(projectPath, item.slug);
-            const statusFresh = !!itemStatus && !service.isItemStatusStale(itemStatus);
-            const readyToAdvance = statusFresh && itemStatus!.state === 'waiting_for_approval';
-            const ralphWaiting = statusFresh && itemStatus!.state === 'waiting_for_input';
+            const readyToAdvance = service.isItemReadyToAdvance(itemStatus);
+            const ralphWaiting = !!itemStatus && !readyToAdvance && service.isItemWaiting(itemStatus);
             const isWaiting = aiWaiting || ralphWaiting;
 
             const statusGlyph =
@@ -653,16 +652,12 @@ export default function TrackerBoardScreen({
             const secMax = Math.max(4, colWidth - 8);
             const secondary = !hasSession ? renderSecondary(item) : '';
 
-            // Prefer the agent's own brief_description when available.
             const waitingLabel = ralphWaiting && itemStatus?.brief_description
               ? itemStatus.brief_description
               : 'waiting for you';
-            const readyLabel = (() => {
-              const brief = itemStatus?.brief_description
-                ? `READY TO ADVANCE — ${itemStatus.brief_description}`
-                : 'READY TO ADVANCE';
-              return isSelected ? `${brief}  ·  [m] approve` : brief;
-            })();
+            const readyLabel = itemStatus?.brief_description
+              ? `Ready — ${itemStatus.brief_description}`
+              : 'Ready';
 
             return (
               <Box key={item.slug} flexDirection="column" marginBottom={1} flexShrink={0}>
@@ -691,7 +686,10 @@ export default function TrackerBoardScreen({
                     : hasSession ? (itemStatus?.brief_description || 'session idle')
                     : secondary || '';
                   if (!text) return null;
-                  const lines = wrapToLines(text, secMax, SECONDARY_MAX_LINES);
+                  // Focused card gets more lines so the full (up to 200-char)
+                  // brief_description is readable; other cards stay compact.
+                  const maxLines = isSelected ? 4 : SECONDARY_MAX_LINES;
+                  const lines = wrapToLines(text, secMax, maxLines);
                   const color =
                     readyToAdvance ? 'green'
                     : isWaiting ? 'yellow'
@@ -710,6 +708,16 @@ export default function TrackerBoardScreen({
                     </Text>
                   ));
                 })()}
+                {/* Dedicated approve-hint row — only when this card is the
+                    selected one and ready for approval. Keeping it on its
+                    own line (rather than suffixing the brief_description)
+                    makes the shortcut visible even when the description
+                    wraps to two lines. */}
+                {readyToAdvance && isSelected && (
+                  <Text color="green" bold>
+                    {`    press [m] to approve and advance`}
+                  </Text>
+                )}
               </Box>
             );
           })}

--- a/src/screens/TrackerStagesScreen.tsx
+++ b/src/screens/TrackerStagesScreen.tsx
@@ -14,15 +14,11 @@ interface OptionDef {
   choices: {value: string; label: string}[];
 }
 
-// Options shared by every stage: input mode + gate. Kept in one place so all
-// four stages surface the same ralph-facing knobs with consistent labels.
+// Gate is per-stage (different stages want different approval semantics).
+// Input mode is project-global — it's a personal preference for how the
+// agent should ask questions, not something that changes per stage — and
+// lives on the Style tab (see STYLE_OPTIONS).
 const COMMON_STAGE_OPTIONS: OptionDef[] = [
-  {key: 'input_mode', label: 'Input mode', choices: [
-    {value: 'ask_questions', label: 'ask_questions tool'},
-    {value: 'inline', label: 'Inline chat'},
-    {value: 'batch', label: 'Batched'},
-    {value: 'doc_review', label: 'Doc review'},
-  ]},
   {key: 'gate_on_advance', label: 'Gate on advance', choices: [
     {value: 'none', label: 'None (auto-advance)'},
     {value: 'review_and_advance', label: 'Write review, then advance'},
@@ -182,6 +178,12 @@ const STYLE_OPTIONS: StyleOptionDef[] = [
     {value: 'try_first', label: 'Try alternatives first'},
     {value: 'continue', label: 'Note & continue'},
   ]},
+  {key: 'inputMode', label: 'Input mode', choices: [
+    {value: 'ask_questions', label: 'ask_questions tool'},
+    {value: 'inline', label: 'Inline chat'},
+    {value: 'batch', label: 'Batched'},
+    {value: 'doc_review', label: 'Doc review'},
+  ]},
 ];
 
 const STYLE_CUSTOM_ROW = STYLE_OPTIONS.length;
@@ -257,11 +259,12 @@ export default function TrackerStagesScreen({projectPath, onBack}: TrackerStages
   const stageOpts = currentStage ? (STAGE_OPTION_DEFS[currentStage] || []) : [];
   const stageSettings = currentStage ? (config[currentStage].settings || {}) : {};
 
-  // For stage tabs: generate preview in-memory from settings so it updates in real-time
+  // For stage tabs: generate preview in-memory from settings so it updates in real-time.
+  // inputMode is global (Style tab) — pass it so the protocol tail reflects live changes.
   const stageFileContent = React.useMemo(() => {
-    if (isStyleTab || !currentStage) return '';
-    return service.defaultStageFileContent(currentStage, stageSettings);
-  }, [isStyleTab, currentStage, stageSettings, service]);
+    if (isStyleTab || isRalphTab || !currentStage) return '';
+    return service.defaultStageFileContent(currentStage, stageSettings, workStyle);
+  }, [isStyleTab, isRalphTab, currentStage, stageSettings, workStyle, service]);
 
   const stageFileLines = React.useMemo(() => fileContentToLines(stageFileContent), [stageFileContent]);
 
@@ -291,11 +294,11 @@ export default function TrackerStagesScreen({projectPath, onBack}: TrackerStages
     const newSettings = {...stageSettings, [opt.key]: next};
     service.saveStageSettings(projectPath, currentStage, newSettings);
     // Write updated file to disk so the agent gets the new settings
-    const updatedContent = service.defaultStageFileContent(currentStage, newSettings);
+    const updatedContent = service.defaultStageFileContent(currentStage, newSettings, workStyle);
     const filePath = service.getStageFilePath(projectPath, currentStage);
     try { fs.writeFileSync(filePath, updatedContent, 'utf8'); } catch {}
     setConfig(service.loadStagesConfig(projectPath));
-  }, [currentStage, stageOpts, selectedRow, stageSettings, service, projectPath]);
+  }, [currentStage, stageOpts, selectedRow, stageSettings, workStyle, service, projectPath]);
 
   const cycleStyleOption = React.useCallback((delta: number) => {
     const opt = STYLE_OPTIONS[selectedRow];
@@ -306,7 +309,19 @@ export default function TrackerStagesScreen({projectPath, onBack}: TrackerStages
     const updated = {...workStyle, [opt.key]: next};
     setWorkStyle(updated);
     service.saveWorkStyle(projectPath, updated);
-  }, [selectedRow, workStyle, service, projectPath]);
+    // inputMode changes affect the protocol tail in every stage guide, so
+    // regenerate all four files on disk. Other style fields only drive
+    // working-style.md (saveWorkStyle already rewrites that).
+    if (opt.key === 'inputMode') {
+      for (const stage of ['discovery', 'requirements', 'implement', 'cleanup'] as const) {
+        const stageSettings = config[stage]?.settings || {};
+        const filePath = service.getStageFilePath(projectPath, stage);
+        try {
+          fs.writeFileSync(filePath, service.defaultStageFileContent(stage, stageSettings, updated), 'utf8');
+        } catch {}
+      }
+    }
+  }, [selectedRow, workStyle, config, service, projectPath]);
 
   const cycleRalphOption = React.useCallback((delta: number) => {
     const opt = RALPH_OPTIONS[selectedRow];

--- a/src/screens/TrackerStagesScreen.tsx
+++ b/src/screens/TrackerStagesScreen.tsx
@@ -13,6 +13,22 @@ interface OptionDef {
   choices: {value: string; label: string}[];
 }
 
+// Options shared by every stage: input mode + gate. Kept in one place so all
+// four stages surface the same ralph-facing knobs with consistent labels.
+const COMMON_STAGE_OPTIONS: OptionDef[] = [
+  {key: 'input_mode', label: 'Input mode', choices: [
+    {value: 'ask_questions', label: 'ask_questions tool'},
+    {value: 'inline', label: 'Inline chat'},
+    {value: 'batch', label: 'Batched'},
+    {value: 'doc_review', label: 'Doc review'},
+  ]},
+  {key: 'gate_on_advance', label: 'Gate on advance', choices: [
+    {value: 'none', label: 'None (auto-advance)'},
+    {value: 'review_and_advance', label: 'Write review, then advance'},
+    {value: 'wait_for_approval', label: 'Wait for approval'},
+  ]},
+];
+
 // Per-stage structured options (different per stage)
 const STAGE_OPTION_DEFS: Partial<Record<Exclude<TrackerStage, 'archive'>, OptionDef[]>> = {
   discovery: [
@@ -36,6 +52,7 @@ const STAGE_OPTION_DEFS: Partial<Record<Exclude<TrackerStage, 'archive'>, Option
       {value: 'minimal', label: 'Minimal (1)'},
       {value: 'standard', label: 'Standard (1–3)'},
     ]},
+    ...COMMON_STAGE_OPTIONS,
   ],
   requirements: [
     {key: 'style', label: 'Style', choices: [
@@ -58,6 +75,7 @@ const STAGE_OPTION_DEFS: Partial<Record<Exclude<TrackerStage, 'archive'>, Option
       {value: 'include', label: 'Include'},
       {value: 'lead', label: 'Lead with'},
     ]},
+    ...COMMON_STAGE_OPTIONS,
   ],
   implement: [
     {key: 'start_with', label: 'Start with', choices: [
@@ -80,6 +98,7 @@ const STAGE_OPTION_DEFS: Partial<Record<Exclude<TrackerStage, 'archive'>, Option
       {value: 'brief', label: 'Brief'},
       {value: 'detailed', label: 'Detailed'},
     ]},
+    ...COMMON_STAGE_OPTIONS,
   ],
   cleanup: [
     {key: 'scope', label: 'Scope', choices: [
@@ -101,6 +120,11 @@ const STAGE_OPTION_DEFS: Partial<Record<Exclude<TrackerStage, 'archive'>, Option
       {value: 'skip', label: 'Skip'},
       {value: 'notes', label: 'Key notes'},
       {value: 'full', label: 'Full description'},
+    ]},
+    ...COMMON_STAGE_OPTIONS,
+    {key: 'submit', label: 'Submit (PR)', choices: [
+      {value: 'approve', label: 'Wait for approval'},
+      {value: 'auto', label: 'Auto-submit'},
     ]},
   ],
 };

--- a/src/screens/TrackerStagesScreen.tsx
+++ b/src/screens/TrackerStagesScreen.tsx
@@ -2,10 +2,11 @@ import React from 'react';
 import fs from 'fs';
 import {Box, Text, useInput} from 'ink';
 import {TrackerService, StagesConfig, TrackerStage, WorkStyle, STAGE_LABELS} from '../services/TrackerService.js';
+import {RalphConfig, loadRalphConfig, saveRalphConfig} from '../cores/RalphCore.js';
 import {useTerminalDimensions} from '../hooks/useTerminalDimensions.js';
 
 const STAGE_KEYS: Exclude<TrackerStage, 'archive'>[] = ['discovery', 'requirements', 'implement', 'cleanup'];
-const ALL_TABS = [...STAGE_KEYS, 'style'] as const;
+const ALL_TABS = [...STAGE_KEYS, 'style', 'ralph'] as const;
 
 interface OptionDef {
   key: string;
@@ -185,6 +186,38 @@ const STYLE_OPTIONS: StyleOptionDef[] = [
 
 const STYLE_CUSTOM_ROW = STYLE_OPTIONS.length;
 
+// Discrete choices for the two numeric ralph fields. The set is deliberately
+// small — most users just want "aggressive / default / conservative" without
+// fiddling with exact millisecond values.
+const RALPH_IDLE_CHOICES: {value: string; label: string; ms: number}[] = [
+  {value: '60000', label: '1 min (aggressive)', ms: 60_000},
+  {value: '180000', label: '3 min (default)', ms: 180_000},
+  {value: '600000', label: '10 min (conservative)', ms: 600_000},
+  {value: '1800000', label: '30 min (rarely)', ms: 1_800_000},
+];
+
+const RALPH_CAP_CHOICES: {value: string; label: string; n: number}[] = [
+  {value: '1', label: '1', n: 1},
+  {value: '3', label: '3 (default)', n: 3},
+  {value: '5', label: '5', n: 5},
+  {value: '10', label: '10', n: 10},
+];
+
+interface RalphOptionDef {
+  key: keyof RalphConfig;
+  label: string;
+  choices: {value: string; label: string}[];
+}
+
+const RALPH_OPTIONS: RalphOptionDef[] = [
+  {key: 'enabled', label: 'Enabled', choices: [
+    {value: 'false', label: 'Off'},
+    {value: 'true', label: 'On'},
+  ]},
+  {key: 'idleThresholdMs', label: 'Idle threshold', choices: RALPH_IDLE_CHOICES.map(c => ({value: c.value, label: c.label}))},
+  {key: 'maxNudgesPerStage', label: 'Max nudges/stage', choices: RALPH_CAP_CHOICES.map(c => ({value: c.value, label: c.label}))},
+];
+
 interface ContentLine {
   key: string;
   text: string;
@@ -208,6 +241,7 @@ export default function TrackerStagesScreen({projectPath, onBack}: TrackerStages
   const service = React.useMemo(() => new TrackerService(), []);
   const [config, setConfig] = React.useState<Required<StagesConfig>>(() => service.loadStagesConfig(projectPath));
   const [workStyle, setWorkStyle] = React.useState<WorkStyle>(() => service.loadWorkStyle(projectPath));
+  const [ralphConfig, setRalphConfig] = React.useState<RalphConfig>(() => loadRalphConfig(projectPath));
   const [selectedTab, setSelectedTab] = React.useState<number>(0);
   const [scrollTop, setScrollTop] = React.useState(0);
   const [selectedRow, setSelectedRow] = React.useState(0);
@@ -218,7 +252,8 @@ export default function TrackerStagesScreen({projectPath, onBack}: TrackerStages
 
   const currentTab = ALL_TABS[selectedTab];
   const isStyleTab = currentTab === 'style';
-  const currentStage = isStyleTab ? null : currentTab as Exclude<TrackerStage, 'archive'>;
+  const isRalphTab = currentTab === 'ralph';
+  const currentStage = isStyleTab || isRalphTab ? null : currentTab as Exclude<TrackerStage, 'archive'>;
   const stageOpts = currentStage ? (STAGE_OPTION_DEFS[currentStage] || []) : [];
   const stageSettings = currentStage ? (config[currentStage].settings || {}) : {};
 
@@ -272,6 +307,26 @@ export default function TrackerStagesScreen({projectPath, onBack}: TrackerStages
     setWorkStyle(updated);
     service.saveWorkStyle(projectPath, updated);
   }, [selectedRow, workStyle, service, projectPath]);
+
+  const cycleRalphOption = React.useCallback((delta: number) => {
+    const opt = RALPH_OPTIONS[selectedRow];
+    if (!opt) return;
+    const curStr =
+      opt.key === 'enabled' ? String(ralphConfig.enabled)
+      : opt.key === 'idleThresholdMs' ? String(ralphConfig.idleThresholdMs)
+      : String(ralphConfig.maxNudgesPerStage);
+    const idx = opt.choices.findIndex(c => c.value === curStr);
+    const startIdx = idx < 0 ? 0 : idx;
+    const nextStr = opt.choices[(startIdx + delta + opt.choices.length) % opt.choices.length].value;
+    const updated: RalphConfig = {
+      ...ralphConfig,
+      [opt.key]:
+        opt.key === 'enabled' ? nextStr === 'true'
+        : Number(nextStr),
+    } as RalphConfig;
+    setRalphConfig(updated);
+    saveRalphConfig(projectPath, updated);
+  }, [selectedRow, ralphConfig, projectPath]);
 
   const handleEditSubmit = React.useCallback(() => {
     const prompt = editPrompt.trim();
@@ -330,6 +385,16 @@ export default function TrackerStagesScreen({projectPath, onBack}: TrackerStages
       else if (goRight) cycleStyleOption(1);
       else if (input === 'e') { setEditMode(true); setError(null); }
       else if (input === 'q' || key.escape) onBack();
+    } else if (isRalphTab) {
+      const maxRow = RALPH_OPTIONS.length - 1;
+      if (goDown) setSelectedRow(r => Math.min(maxRow, r + 1));
+      else if (goUp) {
+        if (selectedRow === 0) setSelectedRow(-1);
+        else setSelectedRow(r => r - 1);
+      }
+      else if (goLeft) cycleRalphOption(-1);
+      else if (goRight) cycleRalphOption(1);
+      else if (input === 'q' || key.escape) onBack();
     } else {
       // Stage tab content
       if (goDown) {
@@ -347,7 +412,10 @@ export default function TrackerStagesScreen({projectPath, onBack}: TrackerStages
   });
 
   const stageFilePath = currentStage ? service.getStageFilePath(projectPath, currentStage) : '';
-  const tabLabel = isStyleTab ? 'Style' : STAGE_LABELS[currentTab as Exclude<TrackerStage, 'archive'>];
+  const tabLabel =
+    isStyleTab ? 'Style'
+    : isRalphTab ? 'Ralph'
+    : STAGE_LABELS[currentTab as Exclude<TrackerStage, 'archive'>];
   const scrollIndicator = maxScroll > 0 ? ` ↑↓` : '';
 
   return (
@@ -357,7 +425,10 @@ export default function TrackerStagesScreen({projectPath, onBack}: TrackerStages
 
       <Box marginTop={1}>
         {ALL_TABS.map((tab, index) => {
-          const label = tab === 'style' ? 'Style' : STAGE_LABELS[tab as Exclude<TrackerStage, 'archive'>];
+          const label =
+            tab === 'style' ? 'Style'
+            : tab === 'ralph' ? 'Ralph'
+            : STAGE_LABELS[tab as Exclude<TrackerStage, 'archive'>];
           const active = index === selectedTab;
           const focusedHere = tabRowFocused && active;
           return (
@@ -378,7 +449,46 @@ export default function TrackerStagesScreen({projectPath, onBack}: TrackerStages
       <Box flexDirection="column" borderStyle="round" borderColor="green" paddingX={1} height={contentViewHeight + 2}>
         <Text bold color="green">{tabLabel}</Text>
 
-        {isStyleTab ? (
+        {isRalphTab ? (
+          <Box flexDirection="column">
+            <Text dimColor>
+              Ralph watches idle agents and nudges them to keep advancing
+              (unless they've flagged `is_waiting_for_user` in status.json).
+            </Text>
+            <Box marginTop={1} flexDirection="column">
+              {RALPH_OPTIONS.map((opt, rowIdx) => {
+                const curStr =
+                  opt.key === 'enabled' ? String(ralphConfig.enabled)
+                  : opt.key === 'idleThresholdMs' ? String(ralphConfig.idleThresholdMs)
+                  : String(ralphConfig.maxNudgesPerStage);
+                const isRowSelected = selectedRow === rowIdx;
+                return (
+                  <Box key={opt.key} flexDirection="row" marginBottom={0}>
+                    <Box width={20}>
+                      <Text bold={isRowSelected}>{opt.label}</Text>
+                    </Box>
+                    {opt.choices.map(choice => (
+                      <Box key={choice.value} marginRight={1}>
+                        <Text
+                          inverse={curStr === choice.value}
+                          color={isRowSelected && curStr === choice.value ? 'green' : undefined}
+                        >
+                          {` ${choice.label} `}
+                        </Text>
+                      </Box>
+                    ))}
+                  </Box>
+                );
+              })}
+            </Box>
+            <Box marginTop={1}>
+              <Text dimColor>
+                Config persists to tracker/ralph.json. Per-item status lives at
+                tracker/items/&lt;slug&gt;/status.json.
+              </Text>
+            </Box>
+          </Box>
+        ) : isStyleTab ? (
           <Box flexDirection="column">
             {STYLE_OPTIONS.map((opt, rowIdx) => {
               const cur = workStyle[opt.key] as string;

--- a/src/screens/TrackerStagesScreen.tsx
+++ b/src/screens/TrackerStagesScreen.tsx
@@ -15,14 +15,13 @@ interface OptionDef {
 }
 
 // Gate is per-stage (different stages want different approval semantics).
-// Input mode is project-global — it's a personal preference for how the
-// agent should ask questions, not something that changes per stage — and
-// lives on the Style tab (see STYLE_OPTIONS).
+// Two values: auto-advance (agent writes a review when appropriate then
+// advances without asking) or require approval (agent pauses for the user).
+// Input mode is project-global — lives on the Style tab (STYLE_OPTIONS).
 const COMMON_STAGE_OPTIONS: OptionDef[] = [
   {key: 'gate_on_advance', label: 'Gate on advance', choices: [
-    {value: 'none', label: 'None (auto-advance)'},
-    {value: 'review_and_advance', label: 'Write review, then advance'},
-    {value: 'wait_for_approval', label: 'Wait for approval'},
+    {value: 'auto_advance', label: 'Auto-advance'},
+    {value: 'require_approval', label: 'Require approval'},
   ]},
 ];
 

--- a/src/screens/TrackerStagesScreen.tsx
+++ b/src/screens/TrackerStagesScreen.tsx
@@ -5,7 +5,7 @@ import {TrackerService, StagesConfig, TrackerStage, WorkStyle, STAGE_LABELS} fro
 import {RalphConfig, loadRalphConfig, saveRalphConfig} from '../cores/RalphCore.js';
 import {useTerminalDimensions} from '../hooks/useTerminalDimensions.js';
 
-const STAGE_KEYS: Exclude<TrackerStage, 'archive'>[] = ['discovery', 'requirements', 'implement', 'cleanup'];
+const STAGE_KEYS: Exclude<TrackerStage, 'archive' | 'backlog'>[] = ['discovery', 'requirements', 'implement', 'cleanup'];
 const ALL_TABS = [...STAGE_KEYS, 'style', 'ralph'] as const;
 
 interface OptionDef {
@@ -17,13 +17,22 @@ interface OptionDef {
 // Gate is per-stage (different stages want different approval semantics).
 // Two values: auto-advance (agent writes a review when appropriate then
 // advances without asking) or require approval (agent pauses for the user).
+// Label carries the stage context so options stay terse and generic — no
+// redundant "…before cleanup / …before implementing" repetition.
 // Input mode is project-global — lives on the Style tab (STYLE_OPTIONS).
-const COMMON_STAGE_OPTIONS: OptionDef[] = [
-  {key: 'gate_on_advance', label: 'Gate on advance', choices: [
-    {value: 'auto_advance', label: 'Auto-advance'},
-    {value: 'require_approval', label: 'Require approval'},
-  ]},
-];
+function gateOptionFor(stage: 'requirements' | 'implement' | 'cleanup'): OptionDef {
+  const label = stage === 'requirements' ? 'After requirements'
+    : stage === 'implement' ? 'After implementation'
+    : 'After cleanup and submit';
+  return {
+    key: 'gate_on_advance',
+    label,
+    choices: [
+      {value: 'auto_advance', label: 'Move on'},
+      {value: 'require_approval', label: 'Ask me first'},
+    ],
+  };
+}
 
 // Per-stage structured options (different per stage)
 const STAGE_OPTION_DEFS: Partial<Record<Exclude<TrackerStage, 'archive'>, OptionDef[]>> = {
@@ -60,7 +69,7 @@ const STAGE_OPTION_DEFS: Partial<Record<Exclude<TrackerStage, 'archive'>, Option
       {value: 'standard', label: 'Standard'},
       {value: 'thorough', label: 'Thorough'},
     ]},
-    ...COMMON_STAGE_OPTIONS,
+    gateOptionFor('requirements'),
   ],
   implement: [
     {key: 'start_with', label: 'Start with', choices: [
@@ -83,7 +92,7 @@ const STAGE_OPTION_DEFS: Partial<Record<Exclude<TrackerStage, 'archive'>, Option
       {value: 'brief', label: 'Brief'},
       {value: 'detailed', label: 'Detailed'},
     ]},
-    ...COMMON_STAGE_OPTIONS,
+    gateOptionFor('implement'),
   ],
   cleanup: [
     {key: 'scope', label: 'Scope', choices: [
@@ -106,7 +115,7 @@ const STAGE_OPTION_DEFS: Partial<Record<Exclude<TrackerStage, 'archive'>, Option
       {value: 'notes', label: 'Key notes'},
       {value: 'full', label: 'Full description'},
     ]},
-    ...COMMON_STAGE_OPTIONS,
+    gateOptionFor('cleanup'),
     {key: 'submit', label: 'Submit (PR)', choices: [
       {value: 'approve', label: 'Wait for approval'},
       {value: 'auto', label: 'Auto-submit'},
@@ -243,7 +252,7 @@ export default function TrackerStagesScreen({projectPath, onBack}: TrackerStages
   const currentTab = ALL_TABS[selectedTab];
   const isStyleTab = currentTab === 'style';
   const isRalphTab = currentTab === 'ralph';
-  const currentStage = isStyleTab || isRalphTab ? null : currentTab as Exclude<TrackerStage, 'archive'>;
+  const currentStage = isStyleTab || isRalphTab ? null : currentTab as Exclude<TrackerStage, 'archive' | 'backlog'>;
   const stageOpts = currentStage ? (STAGE_OPTION_DEFS[currentStage] || []) : [];
   const stageSettings = currentStage ? (config[currentStage].settings || {}) : {};
 

--- a/src/screens/TrackerStagesScreen.tsx
+++ b/src/screens/TrackerStagesScreen.tsx
@@ -28,27 +28,23 @@ const COMMON_STAGE_OPTIONS: OptionDef[] = [
 // Per-stage structured options (different per stage)
 const STAGE_OPTION_DEFS: Partial<Record<Exclude<TrackerStage, 'archive'>, OptionDef[]>> = {
   discovery: [
-    {key: 'skip', label: 'When to run', choices: [
-      {value: 'always_run', label: 'Always'},
-      {value: 'if_obvious', label: 'Skip if obvious'},
-      {value: 'always_skip', label: 'Always skip'},
+    // Research scope only — code + web. Not about asking the user; those
+    // questions belong to requirements. Clarifying questions in discovery
+    // are a baked-in behaviour (only when the problem statement itself is
+    // incomprehensible), not a tunable.
+    {key: 'effort', label: 'Effort', choices: [
+      {value: 'skim', label: 'Skim'},
+      {value: 'standard', label: 'Standard'},
+      {value: 'deep', label: 'Deep'},
     ]},
-    {key: 'depth', label: 'Depth', choices: [
-      {value: 'quick', label: 'Quick'},
-      {value: 'normal', label: 'Normal'},
-      {value: 'thorough', label: 'Thorough'},
+    // How discovery closes out. Replaces the common gate_on_advance for
+    // this stage — `confirm_if_notable` (the middle value) is what the
+    // two-value gate can't express.
+    {key: 'report', label: 'Report', choices: [
+      {value: 'just_advance', label: 'Just advance'},
+      {value: 'confirm_if_notable', label: 'Confirm if notable'},
+      {value: 'always_confirm', label: 'Always confirm'},
     ]},
-    {key: 'web_search', label: 'Web search', choices: [
-      {value: 'never', label: 'Never'},
-      {value: 'if_needed', label: 'If needed'},
-      {value: 'always', label: 'Always'},
-    ]},
-    {key: 'questions', label: 'Questions', choices: [
-      {value: 'none', label: 'None'},
-      {value: 'minimal', label: 'Minimal (1)'},
-      {value: 'standard', label: 'Standard (1–3)'},
-    ]},
-    ...COMMON_STAGE_OPTIONS,
   ],
   requirements: [
     {key: 'style', label: 'Style', choices: [

--- a/src/screens/TrackerStagesScreen.tsx
+++ b/src/screens/TrackerStagesScreen.tsx
@@ -47,25 +47,18 @@ const STAGE_OPTION_DEFS: Partial<Record<Exclude<TrackerStage, 'archive'>, Option
     ]},
   ],
   requirements: [
+    // Collaboration shape. `freeform` was fuzzy; check-in cadence is
+    // covered by the project-global inputMode (Style tab).
     {key: 'style', label: 'Style', choices: [
       {value: 'interview', label: 'Interview first'},
       {value: 'draft_first', label: 'Draft then refine'},
-      {value: 'freeform', label: 'Free-form'},
     ]},
+    // Scope dial for the spec itself. Controls which output sections are
+    // required and the min-word floor.
     {key: 'detail', label: 'Detail', choices: [
       {value: 'minimal', label: 'Minimal'},
       {value: 'standard', label: 'Standard'},
       {value: 'thorough', label: 'Thorough'},
-    ]},
-    {key: 'approval', label: 'Check-ins', choices: [
-      {value: 'per_section', label: 'Per section'},
-      {value: 'end_only', label: 'End only'},
-      {value: 'none', label: 'None'},
-    ]},
-    {key: 'user_stories', label: 'User stories', choices: [
-      {value: 'skip', label: 'Skip'},
-      {value: 'include', label: 'Include'},
-      {value: 'lead', label: 'Lead with'},
     ]},
     ...COMMON_STAGE_OPTIONS,
   ],

--- a/src/screens/TrackerStagesScreen.tsx
+++ b/src/screens/TrackerStagesScreen.tsx
@@ -465,7 +465,8 @@ export default function TrackerStagesScreen({projectPath, onBack}: TrackerStages
           <Box flexDirection="column">
             <Text dimColor>
               Ralph watches idle agents and nudges them to keep advancing
-              (unless they've flagged `is_waiting_for_user` in status.json).
+              (unless they've set `state` to `waiting_for_input` or
+              `waiting_for_approval` in status.json).
             </Text>
             <Box marginTop={1} flexDirection="column">
               {RALPH_OPTIONS.map((opt, rowIdx) => {

--- a/src/services/TrackerService.ts
+++ b/src/services/TrackerService.ts
@@ -141,7 +141,7 @@ Write your findings to tracker/items/<slug>/notes.md. Keep it short: user proble
     exitCriteria: [
       {id: 'has-notes', description: 'Discovery notes written to notes.md', check: 'has_notes'},
     ],
-    settings: {skip: 'always_run', depth: 'normal'},
+    settings: {effort: 'standard', report: 'confirm_if_notable'},
   },
   requirements: {
     actionLabel: 'Start implement',
@@ -1295,11 +1295,9 @@ Update \`status.json\` at every meaningful transition:
 ### Input mode: \`${inputMode}\`
 
 ${inputInstruction}
-
-### Gate on advance: \`${gate}\`
-
-${gateInstruction}
-${submitBlock}`;
+${stage === 'discovery'
+  ? '\n(Advance behaviour for discovery is governed by the `Report` setting in the stage body above — the generic gate_on_advance does not apply here.)\n'
+  : `\n### Gate on advance: \`${gate}\`\n\n${gateInstruction}\n`}${submitBlock}`;
   }
 
   // Original per-stage content generator — the body that the user edits via
@@ -1354,91 +1352,53 @@ When the user confirms pursuit: update the `+"`"+`tracker/index.json`+"`"+` (pat
       }
 
       case 'discovery': {
-        const depth = s['depth'] ?? 'normal';
-        const skip = s['skip'] ?? 'if_obvious';
-        const webSearch = s['web_search'] ?? 'if_needed';
-        const questions = s['questions'] ?? 'standard';
+        // Effort = research scope (code + web). Asking the user is a
+        // narrow, baked-in behaviour — not a tunable — because most
+        // clarification belongs in requirements.
+        const effort = s['effort'] ?? 'standard';
+        const report = s['report'] ?? 'confirm_if_notable';
 
-        if (skip === 'always_skip') {
-          return `# Stage ${n}: Discovery
+        const researchStep =
+          effort === 'skim'
+            ? 'Skim codebase for duplicates. No web search.'
+            : effort === 'deep'
+            ? 'Thorough codebase scan: patterns, conflicts, tests. Web research: domain, external APIs, prior art, alternatives.'
+            : 'Scan codebase for related patterns. Web search if the domain is unfamiliar.';
 
-**Mode: always skip** — Write a minimal `+"`"+`notes.md`+"`"+` and advance immediately. No investigation needed.
-
-## Steps
-
-${numbered([
-  'Infer the user problem from the item title and `requirements.md`.',
-  'Write a brief `notes.md` (3–5 sentences: problem, assumption, recommendation).',
-  'Advance: update the `tracker/index.json` (path is in the prompt, relative to cwd) slug to `backlog.requirements`. Read `tracker/stages/3-requirements.md` and continue.',
-])}
-`;
-        }
-
-        const skipClause = skip === 'if_obvious'
-          ? '\n> **If obvious**: if the problem and approach are already clear from the title and context, write a minimal `notes.md` and advance without full investigation.\n'
-          : '';
-
-        const steps: (string | null)[] = [];
-        steps.push('Read the item title and `requirements.md` stub. What is the actual user problem?');
-
-        if (depth === 'quick') {
-          if (webSearch === 'always') steps.push('Do a quick web search for relevant context or prior art.');
-          if (questions === 'standard') steps.push('Use the ask_questions tool to ask **1 focused question** if anything is ambiguous.');
-          else if (questions === 'minimal') steps.push('Use the ask_questions tool if anything critical is unclear — one question max.');
-          steps.push('Write findings to `notes.md` (user problem + recommendation). Keep it brief.');
-        } else if (depth === 'thorough') {
-          steps.push('Scan the codebase: relevant patterns, existing solutions, potential conflicts, test coverage.');
-          if (webSearch !== 'never') steps.push('Do a web search: domain knowledge, external APIs/libraries, prior art, competing approaches.');
-          if (questions === 'none') {
-            steps.push('Write comprehensive findings to `notes.md` based on research alone — no Q&A.');
-          } else {
-            const qCount = questions === 'minimal' ? '2–3' : '3–5';
-            steps.push(`Use the ask_questions tool to ask **${qCount} focused questions** about the problem and approach before concluding.`);
-            steps.push('Write comprehensive findings to `notes.md`.');
+        const reportStep = (() => {
+          switch (report) {
+            case 'just_advance':
+              return 'Advance silently.';
+            case 'always_confirm':
+              return 'Summarise findings and wait for approval (set `is_waiting_for_user: true` + `awaiting_advance_approval: true`).';
+            case 'confirm_if_notable':
+            default:
+              return 'If findings are notable (surprise, risk, pivot, conflict, viable alternative), summarise and wait for approval (`is_waiting_for_user: true` + `awaiting_advance_approval: true`). Otherwise advance silently.';
           }
-        } else { // normal
-          steps.push('Quick codebase scan: existing patterns, related code, similar solutions.');
-          if (webSearch === 'never') {
-            // no web search step
-          } else if (webSearch === 'always') {
-            steps.push('Do a web search to understand the domain and any relevant tools or APIs.');
-          } else {
-            steps.push('If the domain is unfamiliar or involves external APIs, do a brief web search.');
-          }
-          if (questions === 'none') {
-            steps.push('Write findings to `notes.md` based on research — no Q&A.');
-          } else {
-            const qCount = questions === 'minimal' ? '1 focused question' : '1–3 focused questions';
-            steps.push(`Use the ask_questions tool to ask **${qCount}** — focus on "why" and "what to build", not "how".`);
-            steps.push('Write findings to `notes.md`.');
-          }
-        }
+        })();
 
         const outputFields =
-          depth === 'quick'
-            ? '- **User problem**: who has this problem and what is the pain\n- **Recommendation**: proposed approach'
-            : depth === 'thorough'
-            ? '- **User problem**: who has this problem and what is the pain\n- **Context**: codebase findings and research\n- **Options considered**: 2+ approaches with tradeoffs\n- **Recommendation**: proposed approach with reasoning and known risks'
-            : '- **User problem**: who has this problem and what is the pain\n- **Findings**: relevant codebase or research findings\n- **Recommendation**: proposed approach with brief reasoning';
+          effort === 'skim'
+            ? '- Problem\n- Recommendation'
+            : effort === 'deep'
+            ? '- Problem\n- Context (code findings + research)\n- Options (2+ with tradeoffs)\n- Recommendation (reasoning + risks)'
+            : '- Problem\n- Findings\n- Recommendation';
 
         return `# Stage ${n}: Discovery
-${skipClause}
-**Goal**: Clarify what user problem this item solves and whether the approach makes sense.
 
-## Steps
+Understand the user problem. Research the code and domain — don't interrogate the user.
 
-${numbered(steps)}
+**Skip rules.** Trivial items (typo, rename, doc tweak): write one-line \`notes.md\` and advance. Clarifying questions: only if the problem statement itself is too vague to interpret. "X or Y?" questions belong in requirements.
 
-## Output
+## Do
 
-Write to `+"`"+`notes.md`+"`"+`:
-${outputFields}
+${numbered([
+  researchStep,
+  `Write \`notes.md\`:\n${outputFields}`,
+  reportStep,
+])}
 
-Keep the body of `+"`"+`requirements.md`+"`"+` untouched during discovery — that belongs to stage 3.
-
-## Advancing
-
-When `+"`"+`notes.md`+"`"+` is written, append a single line like \`## Requirements (stub)\` to `+"`"+`requirements.md`+"`"+` as the "discovery done" signal. The board auto-detects this heading and advances the item to the requirements stage. Then read `+"`"+`tracker/stages/3-requirements.md`+"`"+` and continue.
+Advance by setting \`status.json.stage\` to \`requirements\`.
 `;
       }
 

--- a/src/services/TrackerService.ts
+++ b/src/services/TrackerService.ts
@@ -33,19 +33,36 @@ export interface ExitCriterionResult {
 // to decide whether an idle pane is truly stuck or legitimately waiting.
 export interface ItemStatus {
   stage: Exclude<TrackerStage, 'archive'>;
-  is_waiting_for_user: boolean;
-  // Short human-readable note: current activity when not waiting, or what's
-  // being waited on when waiting. ≤ 120 chars.
+  // One tri-state instead of overlapping booleans:
+  //   - 'working': actively progressing, no human needed.
+  //   - 'waiting_for_input': mid-stage — blocked on a clarification.
+  //   - 'waiting_for_approval': stage work is done, wants sign-off to advance.
+  // Ralph treats the two waiting states the same (suppress nudges); the UI
+  // renders them differently so "ready to advance" is visually distinct.
+  state: ItemStatusState;
+  // Short human-readable note: what the agent is currently doing, or the
+  // concrete thing it's waiting on. ≤ 120 chars.
   brief_description: string;
   // ISO-8601 timestamp of last update. Used for the staleness check.
   timestamp: string;
-  // True when the stage's work is complete and the agent is specifically
-  // waiting for the user to approve the advance to the next stage. Distinct
-  // from `is_waiting_for_user` (which covers any mid-stage waiting) because
-  // "done, waiting for go-ahead" is a very different UX signal from "stuck
-  // on a clarifying question" — the kanban wants to call it out visibly,
-  // and ralph suppresses nudges for it regardless of is_waiting_for_user.
-  awaiting_advance_approval?: boolean;
+}
+
+export type ItemStatusState = 'working' | 'waiting_for_input' | 'waiting_for_approval';
+
+// Coerce a freshly-parsed status.json payload to a valid state. Accepts the
+// new `state` enum and the legacy `is_waiting_for_user` / `awaiting_advance_approval`
+// booleans so existing files on disk keep working. Returns null when the
+// payload isn't recognisable as a status record.
+function normaliseItemState(parsed: Record<string, unknown>): ItemStatusState | null {
+  const raw = parsed.state;
+  if (raw === 'working' || raw === 'waiting_for_input' || raw === 'waiting_for_approval') return raw;
+  if (typeof raw === 'string') return null; // unknown value — treat as malformed
+  const approval = parsed.awaiting_advance_approval === true;
+  const input = parsed.is_waiting_for_user === true;
+  if (approval) return 'waiting_for_approval';
+  if (input) return 'waiting_for_input';
+  if (parsed.is_waiting_for_user === false) return 'working';
+  return null; // no legacy boolean either — schema doesn't match
 }
 
 // Treat a waiting flag as stale (and ignore it) after this many ms. Guards
@@ -159,7 +176,7 @@ Write your findings to tracker/items/<slug>/notes.md. Keep it short: user proble
     settings: {style: 'interview', detail: 'standard'},
   },
   implement: {
-    actionLabel: 'Move to cleanup',
+    actionLabel: 'Move to cleanup and submit',
     description: 'Build the feature. Follow TDD, commit incrementally.',
     checklist: [
       'Review requirements before starting',
@@ -260,14 +277,13 @@ export const STAGE_LABELS: Record<TrackerStage, string> = {
   discovery: 'Discovery',
   requirements: 'Requirements',
   implement: 'Implement',
-  cleanup: 'Cleanup',
+  cleanup: 'Cleanup and submit',
   archive: 'Archive',
 };
 
 // Wider title used for the board column header (where space allows a longer label).
 const COLUMN_TITLES: Record<TrackerStage, string> = {
   ...STAGE_LABELS,
-  cleanup: 'Cleanup and Submit',
 };
 
 export class TrackerService {
@@ -440,20 +456,17 @@ export class TrackerService {
     const raw = readFileOrNull(statusPath);
     if (!raw) return null;
     try {
-      const parsed = JSON.parse(raw) as Partial<ItemStatus>;
-      if (
-        !parsed ||
-        typeof parsed.stage !== 'string' ||
-        typeof parsed.is_waiting_for_user !== 'boolean' ||
-        typeof parsed.timestamp !== 'string'
-      ) return null;
+      const parsed = JSON.parse(raw) as Record<string, unknown>;
+      if (!parsed || typeof parsed.stage !== 'string' || typeof parsed.timestamp !== 'string') return null;
+      // Accept both the new `state` enum and the legacy boolean schema so
+      // existing status.json files on disk keep working.
+      const state = normaliseItemState(parsed);
+      if (!state) return null;
       return {
         stage: parsed.stage as Exclude<TrackerStage, 'archive'>,
-        is_waiting_for_user: parsed.is_waiting_for_user,
+        state,
         brief_description: typeof parsed.brief_description === 'string' ? parsed.brief_description : '',
         timestamp: parsed.timestamp,
-        awaiting_advance_approval:
-          typeof parsed.awaiting_advance_approval === 'boolean' ? parsed.awaiting_advance_approval : false,
       };
     } catch {
       return null;
@@ -472,10 +485,9 @@ export class TrackerService {
     }
     const payload: ItemStatus = {
       stage: status.stage,
-      is_waiting_for_user: status.is_waiting_for_user,
+      state: status.state,
       brief_description: (status.brief_description || '').slice(0, 120),
       timestamp: status.timestamp || new Date().toISOString(),
-      awaiting_advance_approval: !!status.awaiting_advance_approval,
     };
     writeJSONAtomic(path.join(itemDir, 'status.json'), payload);
   }
@@ -559,11 +571,13 @@ export class TrackerService {
     // Archive moves don't get a status.json — archived items live outside
     // the live-state protocol.
     if (toStage !== 'archive') {
-      const prev = this.getItemStatus(projectPath, slug);
+      // Advancing is a clean slate — the previous brief_description describes
+      // finished work, and waiting flags from the old stage don't apply to
+      // the new one. Reset to working so ralph can resume normal cadence.
       this.writeItemStatus(projectPath, slug, {
         stage: toStage,
-        is_waiting_for_user: prev?.is_waiting_for_user ?? false,
-        brief_description: prev?.brief_description ?? '',
+        state: 'working',
+        brief_description: '',
         timestamp: new Date().toISOString(),
       });
     }
@@ -1111,21 +1125,16 @@ Use ask_questions tool when you need to ask the user. Read the stage guide and g
 
   // ── Stage instruction files ──────────────────────────────────────────────
 
-  private readonly STAGE_FILE_NUMBERS: Record<Exclude<TrackerStage, 'archive'>, number> = {
-    backlog: 1, discovery: 2, requirements: 3, implement: 4, cleanup: 5,
-  };
-
   getStagesDir(projectPath: string): string {
     return path.join(this.getTrackerPath(projectPath), 'stages');
   }
 
   getStageFilePath(projectPath: string, stage: Exclude<TrackerStage, 'archive'>): string {
-    const n = this.STAGE_FILE_NUMBERS[stage];
-    return path.join(this.getStagesDir(projectPath), `${n}-${stage}.md`);
+    return path.join(this.getStagesDir(projectPath), `${stage}.md`);
   }
 
   getOverviewFilePath(projectPath: string): string {
-    return path.join(this.getStagesDir(projectPath), '0-overview.md');
+    return path.join(this.getStagesDir(projectPath), 'overview.md');
   }
 
   readStageFile(projectPath: string, stage: Exclude<TrackerStage, 'archive'>): string {
@@ -1145,13 +1154,13 @@ This project uses devteam's tracker to manage work items through a structured wo
 
 ## Stages
 
-Items progress through these numbered stages:
+Items progress through these stages in order:
 
-1. **Backlog** (\`1-backlog.md\`) — Item created, not yet being worked on. Triage and describe.
-2. **Discovery** (\`2-discovery.md\`) — Clarify the user problem and approach. Output: \`notes.md\`.
-3. **Requirements** (\`3-requirements.md\`) — Document what to build. Output: \`requirements.md\`.
-4. **Implement** (\`4-implement.md\`) — Build the feature. Output: code + \`implementation.md\`.
-5. **Cleanup** (\`5-cleanup.md\`) — Polish, review, and ship.
+1. **Backlog** (\`backlog.md\`) — Item created, not yet being worked on. Triage and describe.
+2. **Discovery** (\`discovery.md\`) — Clarify the user problem and approach. Output: \`notes.md\`.
+3. **Requirements** (\`requirements.md\`) — Document what to build. Output: \`requirements.md\`.
+4. **Implement** (\`implement.md\`) — Build the feature. Output: code + \`implementation.md\`.
+5. **Cleanup and submit** (\`cleanup.md\`) — Polish, review, and ship.
 
 ## Item Files
 
@@ -1193,7 +1202,7 @@ Read \`tracker/stages/working-style.md\` for the project's preferred working sty
   }
 
   defaultStageFileContent(
-    stage: Exclude<TrackerStage, 'archive'>,
+    stage: Exclude<TrackerStage, 'archive' | 'backlog'>,
     settings?: Record<string, string>,
     workStyle?: WorkStyle,
   ): string {
@@ -1235,14 +1244,14 @@ Read \`tracker/stages/working-style.md\` for the project's preferred working sty
     const inputInstruction = (() => {
       switch (inputMode) {
         case 'inline':
-          return 'Ask questions inline in the conversation when you need input. Before sending each question, set `is_waiting_for_user: true` in `status.json` with a `brief_description` of what you need. Clear it (set back to false) the moment you receive the user\'s response and resume work.';
+          return 'Ask questions inline in the conversation when you need input. Before sending each question, set `state: "waiting_for_input"` in `status.json` with a `brief_description` of what you need. Set it back to `"working"` the moment you receive the user\'s response and resume work.';
         case 'batch':
-          return 'Batch every question you have into a single message — do not ask one at a time. Before sending the batched message, set `is_waiting_for_user: true` in `status.json` with a `brief_description` summarising the batch. Clear it when the user replies.';
+          return 'Batch every question you have into a single message — do not ask one at a time. Before sending the batched message, set `state: "waiting_for_input"` in `status.json` with a `brief_description` summarising the batch. Clear it to `"working"` when the user replies.';
         case 'doc_review':
-          return `Write the stage's output file (\`${outputFile}\`) first. Then ask the user to review it. Before asking for review, set \`is_waiting_for_user: true\` in \`status.json\` with a \`brief_description\` of what you need reviewed. Clear it when the user responds.`;
+          return `Write the stage's output file (\`${outputFile}\`) first. Then ask the user to review it. Before asking for review, set \`state: "waiting_for_input"\` in \`status.json\` with a \`brief_description\` of what you need reviewed. Clear it to \`"working"\` when the user responds.`;
         case 'ask_questions':
         default:
-          return 'Use the `ask_questions` tool when you need input from the user. Keep `status.json` up to date — set `is_waiting_for_user: true` with a `brief_description` when you\'re waiting, and clear it when the user responds.';
+          return 'Use the `ask_questions` tool when you need input from the user. Keep `status.json` up to date — set `state: "waiting_for_input"` with a `brief_description` when you\'re waiting, and set it back to `"working"` when the user responds.';
       }
     })();
 
@@ -1251,7 +1260,7 @@ Read \`tracker/stages/working-style.md\` for the project's preferred working sty
         case 'auto_advance':
           return `Advance without asking. Before you do, if this stage produced meaningful findings, decisions, or changes, append a short "## Stage review" section (1–3 sentences) to \`${outputFile}\` summarising what you did — skip the review for trivial no-op stages. Then update \`status.json.stage\` to the next stage and continue.`;
         case 'require_approval':
-          return 'When the stage\'s work is complete, pause and ask for the user\'s approval to advance. At that point, update `status.json` to set BOTH `is_waiting_for_user: true` AND `awaiting_advance_approval: true`, with a `brief_description` summarising what\'s ready for review (the kanban surfaces this specifically). Do not update `status.json.stage` until the user explicitly approves. When the user approves, flip both flags back to false and update `stage`.';
+          return 'When the stage\'s work is complete, pause and ask for the user\'s approval to advance. Set `state: "waiting_for_approval"` in `status.json` with a `brief_description` that summarises what the user should review (e.g., "caching layer complete"). Do not update `status.json.stage` until the user explicitly approves. When they do, set `state: "working"` and update `stage`.';
         default:
           return '';
       }
@@ -1272,25 +1281,31 @@ Schema:
 \`\`\`json
 {
   "stage": "${stage}",
-  "is_waiting_for_user": false,
-  "awaiting_advance_approval": false,
+  "state": "working",
   "brief_description": "the concrete thing you're doing or need (≤ 120 chars)",
   "timestamp": "ISO-8601 now"
 }
 \`\`\`
 
+\`state\` is one of:
+
+- \`"working"\` — actively progressing. No human needed.
+- \`"waiting_for_input"\` — mid-stage, blocked on a clarification from the user. \`brief_description\` should name the specific question.
+- \`"waiting_for_approval"\` — stage work is done; asking the user to sign off before advancing. Set this only when the gate is \`require_approval\`. \`brief_description\` should summarise what's ready for review.
+
+Ralph suppresses check-ins whenever \`state\` isn't \`"working"\`. The kanban renders approval-state cards with a distinct "ready to advance" treatment, so use it specifically — not as a generic waiting catch-all.
+
 \`brief_description\` guidance — the stage is already visible from the kanban column. Write about the *work*:
 
-- Good: \`drafting acceptance criteria for the caching layer\`, \`blocked: do we want retry-on-429?\`, \`ran the suite, 3 failing in auth spec\`, \`needs your sign-off on the schema I wrote\`.
+- Good: \`drafting acceptance criteria for the caching layer\`, \`blocked: do we want retry-on-429?\`, \`ran the suite, 3 failing in auth spec\`, \`caching layer complete\`.
 - Not useful: \`in requirements stage\`, \`doing discovery\`, \`working on implement\`.
 
 Update \`status.json\` at every meaningful transition:
 
-- **Stage start**: write the file with the current stage and \`is_waiting_for_user: false\`.
-- **Pausing for input**: set \`is_waiting_for_user: true\` and put the specific thing you're blocked on in \`brief_description\`.
-- **Resuming**: set \`is_waiting_for_user: false\` and update \`brief_description\` to the specific thing you're now doing.
-- **Stage done, waiting for approval to advance** (when gate is \`require_approval\`): set \`is_waiting_for_user: true\` AND \`awaiting_advance_approval: true\`, and put a concrete summary of what the user should review/approve in \`brief_description\`.
-- **Advancing**: flip both flags back to false and set \`stage\` to the next stage.
+- **Stage start**: write the file with the current stage and \`state: "working"\`.
+- **Blocked on a clarification**: set \`state: "waiting_for_input"\`; put the concrete ask in \`brief_description\`.
+- **Stage work complete, awaiting approval**: set \`state: "waiting_for_approval"\`; summarise what's ready.
+- **Resuming or advancing**: set \`state: "working"\` and update \`brief_description\` to what you're now doing; update \`stage\` if you're moving to the next one.
 
 ### Input mode: \`${inputMode}\`
 
@@ -1303,54 +1318,14 @@ ${stage === 'discovery'
   // Original per-stage content generator — the body that the user edits via
   // the stages screen. Kept private and wrapped by defaultStageFileContent()
   // so the status/gate protocol is always appended.
-  private defaultStageFileBody(stage: Exclude<TrackerStage, 'archive'>, settings?: Record<string, string>): string {
-    const n = this.STAGE_FILE_NUMBERS[stage];
+  private defaultStageFileBody(stage: Exclude<TrackerStage, 'archive' | 'backlog'>, settings?: Record<string, string>): string {
     const s = settings || {};
     const numbered = (items: (string | null)[]): string =>
       items.filter((x): x is string => !!x).map((x, i) => `${i + 1}. ${x}`).join('\n');
 
     switch (stage) {
-      case 'backlog': {
-        const effortEstimate = s['effort_estimate'] ?? 'rough';
-        const autoDiscover = s['auto_discover'] ?? 'prompt';
-
-        const effortStep =
-          effortEstimate === 'skip' ? null
-          : effortEstimate === 'detailed'
-            ? 'Assess effort: estimate story points or days, identify blockers and risks. Note this in `requirements.md`.'
-            : 'Assess rough effort and value — a t-shirt size (S/M/L/XL) is enough. Note it in `requirements.md`.';
-
-        const afterStep =
-          autoDiscover === 'auto'
-            ? 'Advance to discovery automatically — no need to prompt the user.'
-            : autoDiscover === 'manual'
-            ? 'Stop here. The user will manually trigger the next stage.'
-            : 'Use the ask_questions tool to ask: is this worth pursuing now, or should it stay in backlog?';
-
-        return `# Stage ${n}: Backlog
-
-**Goal**: Triage this item — clarify what it is, assess scope, decide whether to pursue.
-
-## Steps
-
-${numbered([
-  'Read the item title. Is it clear and actionable? Rewrite it if not.',
-  'Check the tracker for similar or duplicate items.',
-  effortStep,
-  'Write a short description of the item in `requirements.md` — what it is and why it matters. Not full requirements yet, just enough context to revisit later.',
-  afterStep,
-])}
-
-## Output
-
-`+"`"+`requirements.md`+"`"+` with a short description${effortEstimate !== 'skip' ? ' and effort estimate' : ''}.
-
-## Advancing
-
-When the user confirms pursuit: update the `+"`"+`tracker/index.json`+"`"+` (path is in the prompt, relative to cwd) to move the slug from `+"`"+`backlog.backlog`+"`"+` to `+"`"+`backlog.discovery`+"`"+`. Then read `+"`"+`tracker/stages/2-discovery.md`+"`"+` and continue.
-`;
-      }
-
+      // No 'backlog' case — the stage is deprecated (merged into discovery
+      // for display purposes) and `ensureStageFiles` doesn't emit backlog.md.
       case 'discovery': {
         // Effort = research scope (code + web). Asking the user is a
         // narrow, baked-in behaviour — not a tunable — because most
@@ -1370,10 +1345,10 @@ When the user confirms pursuit: update the `+"`"+`tracker/index.json`+"`"+` (pat
             case 'just_advance':
               return 'Advance silently.';
             case 'always_confirm':
-              return 'Summarise findings, wait for approval — set `is_waiting_for_user` + `awaiting_advance_approval` to true.';
+              return 'Summarise findings, set `state: "waiting_for_approval"` with a `brief_description` summarising what was found, and wait for approval.';
             case 'confirm_if_notable':
             default:
-              return 'If findings are notable (surprise, risk, pivot, conflict, alternative), summarise and wait for approval (set `is_waiting_for_user` + `awaiting_advance_approval` to true). Otherwise advance silently.';
+              return 'If findings are notable (surprise, risk, pivot, conflict, alternative), summarise and set `state: "waiting_for_approval"` with a `brief_description` summarising what was found. Otherwise advance silently.';
           }
         })();
 
@@ -1384,7 +1359,7 @@ When the user confirms pursuit: update the `+"`"+`tracker/index.json`+"`"+` (pat
             ? 'Problem; Context (code + research); Options (2+ with tradeoffs); Recommendation (reasoning + risks).'
             : 'Problem, Findings, Recommendation.';
 
-        return `# Stage ${n}: Discovery
+        return `# Discovery
 
 Research the problem — code and domain. Trivial items (typo, rename, doc): one-line \`notes.md\`, advance. Clarifying questions: only if the request itself is unreadable; "X or Y?" trade-offs belong in requirements.
 
@@ -1421,7 +1396,7 @@ Advance: set \`status.json.stage\` to \`requirements\`.
         }
         const minWords = detail === 'minimal' ? 30 : detail === 'thorough' ? 100 : 50;
 
-        return `# Stage ${n}: Requirements
+        return `# Requirements
 
 Document what to build. Always preserve the **Problem** and **Why** from \`notes.md\` — copy them verbatim; never paraphrase them away.
 
@@ -1476,7 +1451,7 @@ Minimum ${minWords} words of real content.
         if (implNotes === 'brief') outputLines.push('- `implementation.md`: what was built, key decisions, notes for cleanup');
         else if (implNotes === 'detailed') outputLines.push('- `implementation.md`: full implementation journal — decisions, rationale, architecture, known issues');
 
-        return `# Stage ${n}: Implement
+        return `# Implement
 
 **Goal**: Build the feature according to the requirements.
 
@@ -1490,7 +1465,7 @@ ${outputLines.join('\n')}
 
 ## Advancing
 
-When implementation is complete${tdd !== 'skip' ? ' and tests pass' : ''}: update the `+"`"+`tracker/index.json`+"`"+` (path is in the prompt, relative to cwd) slug to `+"`"+`implementation.cleanup`+"`"+`. Read `+"`"+`tracker/stages/5-cleanup.md`+"`"+` and continue.
+When implementation is complete${tdd !== 'skip' ? ' and tests pass' : ''}: update the `+"`"+`tracker/index.json`+"`"+` (path is in the prompt, relative to cwd) slug to `+"`"+`implementation.cleanup`+"`"+`. Read `+"`"+`tracker/stages/cleanup.md`+"`"+` and continue.
 `;
       }
 
@@ -1527,7 +1502,7 @@ When implementation is complete${tdd !== 'skip' ? ' and tests pass' : ''}: updat
         if (prPrep === 'notes') steps.push('Jot down key changes and decisions for the PR description.');
         else if (prPrep === 'full') steps.push('Write a full PR description: summary, changes made, how to test, screenshots or logs if applicable.');
 
-        return `# Stage ${n}: Cleanup
+        return `# Cleanup and submit
 
 **Goal**: Polish and ship. Review what was built, catch issues, get it across the finish line.
 

--- a/src/services/TrackerService.ts
+++ b/src/services/TrackerService.ts
@@ -539,7 +539,49 @@ export class TrackerService {
     this.removeSlugFromIndexObj(index, slug);
     this.addSlugToIndexObj(index, slug, toStage);
     writeJSONAtomic(this.getIndexPath(projectPath), index);
+    // Mirror the canonical stage into the per-item status.json so ralph (and
+    // anything that reads status.json first) sees the new stage immediately.
+    // Archive moves don't get a status.json — archived items live outside
+    // the live-state protocol.
+    if (toStage !== 'archive') {
+      const prev = this.getItemStatus(projectPath, slug);
+      this.writeItemStatus(projectPath, slug, {
+        stage: toStage,
+        is_waiting_for_user: prev?.is_waiting_for_user ?? false,
+        brief_description: prev?.brief_description ?? '',
+        timestamp: new Date().toISOString(),
+      });
+    }
     return true;
+  }
+
+  // Canonical current stage for an item. Prefers the agent's status.json
+  // (which is the live self-report), then falls back to index.json bucket
+  // membership, then to 'backlog' if the slug is unknown. Never returns null
+  // for a known slug — an item always has a stage somewhere.
+  getItemStage(projectPath: string, slug: string): TrackerStage {
+    const status = this.getItemStatus(projectPath, slug);
+    if (status) return status.stage;
+    const legacy = this.createStageBySlug(this.readIndex(projectPath)).get(slug);
+    return legacy ?? 'backlog';
+  }
+
+  // Enumerate every known active item grouped by stage. Stage for each slug
+  // comes from status.json first; unmigrated items fall back to the index
+  // buckets. Archived items are listed verbatim from index.archive.
+  listItemsByStage(projectPath: string): Map<string, TrackerStage> {
+    const index = this.readIndex(projectPath);
+    const out = this.createStageBySlug(index);
+    // Override with status.json where present, so the agent's live self-report
+    // wins over the index buckets.
+    const knownSlugs = new Set(out.keys());
+    // Also surface slugs that have a status.json but aren't in the index yet
+    // (e.g., an agent wrote status.json before the index was updated).
+    for (const slug of knownSlugs) {
+      const status = this.getItemStatus(projectPath, slug);
+      if (status) out.set(slug, status.stage);
+    }
+    return out;
   }
 
   // Auto-advance items based on signals in their files:
@@ -1130,6 +1172,99 @@ Read \`tracker/stages/working-style.md\` for the project's preferred working sty
   }
 
   defaultStageFileContent(stage: Exclude<TrackerStage, 'archive'>, settings?: Record<string, string>): string {
+    return this.defaultStageFileBody(stage, settings) + this.renderStageProtocol(stage, settings);
+  }
+
+  // Common tail appended to every generated stage guide. Surfaces three new
+  // settings (input_mode, gate_on_advance, submit) and the status.json
+  // self-report protocol that ralph relies on. Kept separate from the
+  // per-stage body generator so adding a setting doesn't require touching
+  // every stage's case block.
+  private renderStageProtocol(stage: Exclude<TrackerStage, 'archive'>, settings?: Record<string, string>): string {
+    if (stage === 'backlog') return ''; // status.json + gates don't apply pre-discovery
+    const s = settings || {};
+    const inputMode = s['input_mode'] ?? 'ask_questions';
+    const gate = s['gate_on_advance'] ?? (stage === 'requirements' || stage === 'cleanup'
+      ? 'wait_for_approval'
+      : stage === 'implement'
+      ? 'review_and_advance'
+      : 'none');
+    const submit = s['submit'] ?? 'approve';
+    const outputFile =
+      stage === 'discovery' ? 'notes.md'
+      : stage === 'requirements' ? 'requirements.md'
+      : stage === 'implement' ? 'implementation.md'
+      : 'implementation.md';
+
+    const inputInstruction = (() => {
+      switch (inputMode) {
+        case 'inline':
+          return 'Ask questions inline in the conversation when you need input. Before sending each question, set `is_waiting_for_user: true` in `status.json` with a `brief_description` of what you need. Clear it (set back to false) the moment you receive the user\'s response and resume work.';
+        case 'batch':
+          return 'Batch every question you have into a single message — do not ask one at a time. Before sending the batched message, set `is_waiting_for_user: true` in `status.json` with a `brief_description` summarising the batch. Clear it when the user replies.';
+        case 'doc_review':
+          return `Write the stage's output file (\`${outputFile}\`) first. Then ask the user to review it. Before asking for review, set \`is_waiting_for_user: true\` in \`status.json\` with a \`brief_description\` of what you need reviewed. Clear it when the user responds.`;
+        case 'ask_questions':
+        default:
+          return 'Use the `ask_questions` tool when you need input from the user. Keep `status.json` up to date — set `is_waiting_for_user: true` with a `brief_description` when you\'re waiting, and clear it when the user responds.';
+      }
+    })();
+
+    const gateInstruction = (() => {
+      switch (gate) {
+        case 'none':
+          return 'Advance silently: update `status.json.stage` to the next stage and continue.';
+        case 'review_and_advance':
+          return `Before advancing, append a short "## Stage review" section (1–3 sentences) to \`${outputFile}\` summarising what you did this stage. Then update \`status.json.stage\` to the next stage and continue.`;
+        case 'wait_for_approval':
+          return 'Before advancing, pause and ask for the user\'s approval using this stage\'s input mode (above). Do not update `status.json.stage` until the user explicitly approves the advance.';
+        default:
+          return '';
+      }
+    })();
+
+    const submitBlock = stage === 'cleanup'
+      ? (submit === 'auto'
+          ? '\n### Submit (PR creation)\n\nAfter cleanup passes, open the PR automatically — no extra approval step.\n'
+          : '\n### Submit (PR creation)\n\nAfter cleanup passes, pause and ask the user for explicit approval using this stage\'s input mode before opening the PR. Do not create the PR until approved.\n')
+      : '';
+
+    return `
+## Agent status protocol
+
+You must keep \`tracker/items/<slug>/status.json\` current. It's the canonical live state for this item and ralph reads it to decide whether you're stuck or legitimately waiting.
+
+Schema:
+\`\`\`json
+{
+  "stage": "${stage}",
+  "is_waiting_for_user": false,
+  "brief_description": "short description of current activity (≤ 120 chars)",
+  "timestamp": "ISO-8601 now"
+}
+\`\`\`
+
+Update \`status.json\` at every meaningful transition:
+
+- **Stage start**: write the file with the current stage and \`is_waiting_for_user: false\`.
+- **Pausing for input**: set \`is_waiting_for_user: true\` and put what you're waiting on in \`brief_description\`.
+- **Resuming**: set \`is_waiting_for_user: false\` and update \`brief_description\` to reflect what you're now doing.
+- **Advancing**: set \`stage\` to the next stage before you move on.
+
+### Input mode: \`${inputMode}\`
+
+${inputInstruction}
+
+### Gate on advance: \`${gate}\`
+
+${gateInstruction}
+${submitBlock}`;
+  }
+
+  // Original per-stage content generator — the body that the user edits via
+  // the stages screen. Kept private and wrapped by defaultStageFileContent()
+  // so the status/gate protocol is always appended.
+  private defaultStageFileBody(stage: Exclude<TrackerStage, 'archive'>, settings?: Record<string, string>): string {
     const n = this.STAGE_FILE_NUMBERS[stage];
     const s = settings || {};
     const numbered = (items: (string | null)[]): string =>

--- a/src/services/TrackerService.ts
+++ b/src/services/TrackerService.ts
@@ -595,6 +595,10 @@ export class TrackerService {
   // (which is the live self-report), then falls back to index.json bucket
   // membership, then to 'backlog' if the slug is unknown. Never returns null
   // for a known slug — an item always has a stage somewhere.
+  // The staleness guard used by ralph (`isItemWaiting`) deliberately doesn't
+  // apply here: the last stage the agent wrote is still the correct stage
+  // even if the agent crashed 48h ago — nothing would auto-revert it — so
+  // stage reads trust status.json unconditionally.
   getItemStage(projectPath: string, slug: string): TrackerStage {
     const status = this.getItemStatus(projectPath, slug);
     if (status) return status.stage;
@@ -605,15 +609,14 @@ export class TrackerService {
   // Enumerate every known active item grouped by stage. Stage for each slug
   // comes from status.json first; unmigrated items fall back to the index
   // buckets. Archived items are listed verbatim from index.archive.
+  // Maps each index-known slug to its canonical stage, with any fresh
+  // status.json stage overriding the index bucket. Slugs that exist only in
+  // tracker/items/<slug>/ but aren't yet in the index aren't surfaced —
+  // callers that need orphan-detection should scan the directory themselves.
   listItemsByStage(projectPath: string): Map<string, TrackerStage> {
     const index = this.readIndex(projectPath);
     const out = this.createStageBySlug(index);
-    // Override with status.json where present, so the agent's live self-report
-    // wins over the index buckets.
-    const knownSlugs = new Set(out.keys());
-    // Also surface slugs that have a status.json but aren't in the index yet
-    // (e.g., an agent wrote status.json before the index was updated).
-    for (const slug of knownSlugs) {
+    for (const slug of out.keys()) {
       const status = this.getItemStatus(projectPath, slug);
       if (status) out.set(slug, status.stage);
     }

--- a/src/services/TrackerService.ts
+++ b/src/services/TrackerService.ts
@@ -450,6 +450,10 @@ export class TrackerService {
     try {
       const parsed = JSON.parse(raw) as Record<string, unknown>;
       if (!parsed || typeof parsed.stage !== 'string' || typeof parsed.timestamp !== 'string') return null;
+      // Whitelist the stage string before using it anywhere that constructs
+      // file paths (getStageFilePath) — otherwise a malicious or corrupted
+      // status.json with `stage: "../../.ssh/id_rsa"` would flow through.
+      if (!STAGE_ORDER.includes(parsed.stage as TrackerStage) || parsed.stage === 'archive') return null;
       // Accept both the new `state` enum and the legacy boolean schema so
       // existing status.json files on disk keep working.
       const state = normaliseItemState(parsed);

--- a/src/services/TrackerService.ts
+++ b/src/services/TrackerService.ts
@@ -28,6 +28,23 @@ export interface ExitCriterionResult {
   met: boolean;
 }
 
+// Agent-reported live state for an item. Written by the agent at every
+// meaningful transition (stage start/advance, pause, resume). Ralph reads this
+// to decide whether an idle pane is truly stuck or legitimately waiting.
+export interface ItemStatus {
+  stage: Exclude<TrackerStage, 'archive'>;
+  is_waiting_for_user: boolean;
+  // Short human-readable note: current activity when not waiting, or what's
+  // being waited on when waiting. ≤ 120 chars.
+  brief_description: string;
+  // ISO-8601 timestamp of last update. Used for the staleness check.
+  timestamp: string;
+}
+
+// Treat a waiting flag as stale (and ignore it) after this many ms. Guards
+// against crashed agents that never cleared is_waiting_for_user.
+export const ITEM_STATUS_STALE_MS = 24 * 60 * 60 * 1000;
+
 export interface StageConfig {
   actionLabel: string;
   description: string;
@@ -392,6 +409,69 @@ export class TrackerService {
     const idx = STAGE_ORDER.indexOf(stage);
     if (idx <= 0) return null;
     return STAGE_ORDER[idx - 1];
+  }
+
+  // Path to the agent's self-reported status file for an item. Lives alongside
+  // the stage output files (notes.md, requirements.md, implementation.md).
+  getItemStatusPath(projectPath: string, slug: string): string | null {
+    const itemDir = this.resolveItemDir(projectPath, slug);
+    if (!itemDir) return null;
+    return path.join(itemDir, 'status.json');
+  }
+
+  // Read the agent's current status. Returns null when the file is absent or
+  // malformed. Validates the schema loosely so a partial write doesn't explode
+  // ralph's sampling loop.
+  getItemStatus(projectPath: string, slug: string): ItemStatus | null {
+    const statusPath = this.getItemStatusPath(projectPath, slug);
+    if (!statusPath || !fs.existsSync(statusPath)) return null;
+    const raw = readFileOrNull(statusPath);
+    if (!raw) return null;
+    try {
+      const parsed = JSON.parse(raw) as Partial<ItemStatus>;
+      if (
+        !parsed ||
+        typeof parsed.stage !== 'string' ||
+        typeof parsed.is_waiting_for_user !== 'boolean' ||
+        typeof parsed.timestamp !== 'string'
+      ) return null;
+      return {
+        stage: parsed.stage as Exclude<TrackerStage, 'archive'>,
+        is_waiting_for_user: parsed.is_waiting_for_user,
+        brief_description: typeof parsed.brief_description === 'string' ? parsed.brief_description : '',
+        timestamp: parsed.timestamp,
+      };
+    } catch {
+      return null;
+    }
+  }
+
+  // Overwrite the status file. Writes to the resolved item dir, or (as a
+  // fallback for items with no worktree yet) to the main-project stub dir so
+  // the file still has a home. Truncates brief_description to 120 chars to
+  // keep the UI row tidy.
+  writeItemStatus(projectPath: string, slug: string, status: ItemStatus): void {
+    let itemDir = this.resolveItemDir(projectPath, slug);
+    if (!itemDir) {
+      itemDir = path.join(projectPath, 'tracker', 'items', slug);
+      ensureDirectory(itemDir);
+    }
+    const payload: ItemStatus = {
+      stage: status.stage,
+      is_waiting_for_user: status.is_waiting_for_user,
+      brief_description: (status.brief_description || '').slice(0, 120),
+      timestamp: status.timestamp || new Date().toISOString(),
+    };
+    writeJSONAtomic(path.join(itemDir, 'status.json'), payload);
+  }
+
+  // A status is "stale" if its timestamp is older than ITEM_STATUS_STALE_MS.
+  // Ralph ignores `is_waiting_for_user: true` on stale records so a crashed
+  // agent doesn't suppress nudges indefinitely.
+  isItemStatusStale(status: ItemStatus, now: Date = new Date()): boolean {
+    const ts = Date.parse(status.timestamp);
+    if (Number.isNaN(ts)) return true;
+    return now.getTime() - ts > ITEM_STATUS_STALE_MS;
   }
 
   createItem(projectPath: string, title: string, stage: TrackerStage = 'discovery', explicitSlug?: string, body?: string): void {

--- a/src/services/TrackerService.ts
+++ b/src/services/TrackerService.ts
@@ -63,6 +63,9 @@ export type TestingStyle = 'always' | 'suggest' | 'skip';
 export type CommitStyle = 'never' | 'milestones' | 'often';
 export type BlockerStyle = 'ask' | 'try_first' | 'continue';
 export type ContextDepthStyle = 'light' | 'moderate' | 'deep';
+// How the agent should deliver questions/requests for review. Project-wide
+// preference; drives the "Input mode" block in every generated stage guide.
+export type InputModeStyle = 'ask_questions' | 'inline' | 'batch' | 'doc_review';
 
 export interface WorkStyle {
   decisionStyle: DecisionStyle;
@@ -74,6 +77,7 @@ export interface WorkStyle {
   commits: CommitStyle;
   onBlockers: BlockerStyle;
   contextDepth: ContextDepthStyle;
+  inputMode: InputModeStyle;
   customInstructions: string;
 }
 
@@ -87,6 +91,7 @@ export const DEFAULT_WORK_STYLE: WorkStyle = {
   commits: 'never',
   onBlockers: 'ask',
   contextDepth: 'moderate',
+  inputMode: 'ask_questions',
   customInstructions: '',
 };
 
@@ -877,6 +882,12 @@ export class TrackerService {
       try_first: ['Try alternatives first', 'Try reasonable alternatives before asking. Ask only if exhausted.'],
       continue: ['Note & continue', 'Note the issue clearly and continue with the rest of the work.'],
     };
+    const INPUT_MODE_LABELS: Record<string, [string, string]> = {
+      ask_questions: ['ask_questions tool', 'Use the ask_questions tool whenever you need input. Produces a detectable numbered prompt in the terminal.'],
+      inline: ['Inline chat', 'Ask questions inline in the conversation. Before pausing, set is_waiting_for_user: true in status.json with a brief_description; clear it on resume.'],
+      batch: ['Batched', 'Batch every question into a single message — do not ask one at a time. Set is_waiting_for_user: true in status.json before sending; clear on resume.'],
+      doc_review: ['Doc review', 'Write the stage\'s output file first, then ask the user to review it. Set is_waiting_for_user: true in status.json before asking for review; clear on resume.'],
+    };
 
     const row = (label: string, map: Record<string, [string, string]>, val: string) => {
       const [name, desc] = map[val] ?? [val, ''];
@@ -909,7 +920,7 @@ ${row('Commits', COMMITS_LABELS, workStyle.commits)}
 
 ${row('On blockers', BLOCKERS_LABELS, workStyle.onBlockers)}
 
-Use the ask_questions tool (or equivalent) when you need to ask the user questions, rather than asking inline.
+${row('Input mode', INPUT_MODE_LABELS, workStyle.inputMode)}
 ${custom}`;
   }
 
@@ -1171,19 +1182,30 @@ Read \`tracker/stages/working-style.md\` for the project's preferred working sty
 `;
   }
 
-  defaultStageFileContent(stage: Exclude<TrackerStage, 'archive'>, settings?: Record<string, string>): string {
-    return this.defaultStageFileBody(stage, settings) + this.renderStageProtocol(stage, settings);
+  defaultStageFileContent(
+    stage: Exclude<TrackerStage, 'archive'>,
+    settings?: Record<string, string>,
+    workStyle?: WorkStyle,
+  ): string {
+    return this.defaultStageFileBody(stage, settings) + this.renderStageProtocol(stage, settings, workStyle);
   }
 
-  // Common tail appended to every generated stage guide. Surfaces three new
-  // settings (input_mode, gate_on_advance, submit) and the status.json
-  // self-report protocol that ralph relies on. Kept separate from the
-  // per-stage body generator so adding a setting doesn't require touching
-  // every stage's case block.
-  private renderStageProtocol(stage: Exclude<TrackerStage, 'archive'>, settings?: Record<string, string>): string {
+  // Common tail appended to every generated stage guide. Surfaces the
+  // gate_on_advance / submit per-stage settings plus the project-global
+  // inputMode from WorkStyle, and the status.json self-report protocol
+  // that ralph relies on. Kept separate from the per-stage body generator
+  // so adding a setting doesn't require touching every stage's case block.
+  private renderStageProtocol(
+    stage: Exclude<TrackerStage, 'archive'>,
+    settings?: Record<string, string>,
+    workStyle?: WorkStyle,
+  ): string {
     if (stage === 'backlog') return ''; // status.json + gates don't apply pre-discovery
     const s = settings || {};
-    const inputMode = s['input_mode'] ?? 'ask_questions';
+    // inputMode is a project-global preference, not per-stage. It lives on
+    // WorkStyle and falls back to the default when absent (e.g., tests that
+    // don't pass a workStyle).
+    const inputMode: InputModeStyle = workStyle?.inputMode ?? DEFAULT_WORK_STYLE.inputMode;
     const gate = s['gate_on_advance'] ?? (stage === 'requirements' || stage === 'cleanup'
       ? 'wait_for_approval'
       : stage === 'implement'

--- a/src/services/TrackerService.ts
+++ b/src/services/TrackerService.ts
@@ -39,6 +39,13 @@ export interface ItemStatus {
   brief_description: string;
   // ISO-8601 timestamp of last update. Used for the staleness check.
   timestamp: string;
+  // True when the stage's work is complete and the agent is specifically
+  // waiting for the user to approve the advance to the next stage. Distinct
+  // from `is_waiting_for_user` (which covers any mid-stage waiting) because
+  // "done, waiting for go-ahead" is a very different UX signal from "stuck
+  // on a clarifying question" — the kanban wants to call it out visibly,
+  // and ralph suppresses nudges for it regardless of is_waiting_for_user.
+  awaiting_advance_approval?: boolean;
 }
 
 // Treat a waiting flag as stale (and ignore it) after this many ms. Guards
@@ -445,6 +452,8 @@ export class TrackerService {
         is_waiting_for_user: parsed.is_waiting_for_user,
         brief_description: typeof parsed.brief_description === 'string' ? parsed.brief_description : '',
         timestamp: parsed.timestamp,
+        awaiting_advance_approval:
+          typeof parsed.awaiting_advance_approval === 'boolean' ? parsed.awaiting_advance_approval : false,
       };
     } catch {
       return null;
@@ -466,6 +475,7 @@ export class TrackerService {
       is_waiting_for_user: status.is_waiting_for_user,
       brief_description: (status.brief_description || '').slice(0, 120),
       timestamp: status.timestamp || new Date().toISOString(),
+      awaiting_advance_approval: !!status.awaiting_advance_approval,
     };
     writeJSONAtomic(path.join(itemDir, 'status.json'), payload);
   }
@@ -1241,7 +1251,7 @@ Read \`tracker/stages/working-style.md\` for the project's preferred working sty
         case 'auto_advance':
           return `Advance without asking. Before you do, if this stage produced meaningful findings, decisions, or changes, append a short "## Stage review" section (1–3 sentences) to \`${outputFile}\` summarising what you did — skip the review for trivial no-op stages. Then update \`status.json.stage\` to the next stage and continue.`;
         case 'require_approval':
-          return 'Before advancing, pause and ask for the user\'s approval using this stage\'s input mode (above). Do not update `status.json.stage` until the user explicitly approves the advance.';
+          return 'When the stage\'s work is complete, pause and ask for the user\'s approval to advance. At that point, update `status.json` to set BOTH `is_waiting_for_user: true` AND `awaiting_advance_approval: true`, with a `brief_description` summarising what\'s ready for review (the kanban surfaces this specifically). Do not update `status.json.stage` until the user explicitly approves. When the user approves, flip both flags back to false and update `stage`.';
         default:
           return '';
       }
@@ -1256,24 +1266,31 @@ Read \`tracker/stages/working-style.md\` for the project's preferred working sty
     return `
 ## Agent status protocol
 
-You must keep \`tracker/items/<slug>/status.json\` current. It's the canonical live state for this item and ralph reads it to decide whether you're stuck or legitimately waiting.
+You must keep \`tracker/items/<slug>/status.json\` current. It's the canonical live state for this item and ralph reads it to decide whether you're stuck or legitimately waiting. The kanban renders \`brief_description\` directly on the card, so write about *substance*, not stage identity.
 
 Schema:
 \`\`\`json
 {
   "stage": "${stage}",
   "is_waiting_for_user": false,
-  "brief_description": "short description of current activity (≤ 120 chars)",
+  "awaiting_advance_approval": false,
+  "brief_description": "the concrete thing you're doing or need (≤ 120 chars)",
   "timestamp": "ISO-8601 now"
 }
 \`\`\`
 
+\`brief_description\` guidance — the stage is already visible from the kanban column. Write about the *work*:
+
+- Good: \`drafting acceptance criteria for the caching layer\`, \`blocked: do we want retry-on-429?\`, \`ran the suite, 3 failing in auth spec\`, \`needs your sign-off on the schema I wrote\`.
+- Not useful: \`in requirements stage\`, \`doing discovery\`, \`working on implement\`.
+
 Update \`status.json\` at every meaningful transition:
 
 - **Stage start**: write the file with the current stage and \`is_waiting_for_user: false\`.
-- **Pausing for input**: set \`is_waiting_for_user: true\` and put what you're waiting on in \`brief_description\`.
-- **Resuming**: set \`is_waiting_for_user: false\` and update \`brief_description\` to reflect what you're now doing.
-- **Advancing**: set \`stage\` to the next stage before you move on.
+- **Pausing for input**: set \`is_waiting_for_user: true\` and put the specific thing you're blocked on in \`brief_description\`.
+- **Resuming**: set \`is_waiting_for_user: false\` and update \`brief_description\` to the specific thing you're now doing.
+- **Stage done, waiting for approval to advance** (when gate is \`require_approval\`): set \`is_waiting_for_user: true\` AND \`awaiting_advance_approval: true\`, and put a concrete summary of what the user should review/approve in \`brief_description\`.
+- **Advancing**: flip both flags back to false and set \`stage\` to the next stage.
 
 ### Input mode: \`${inputMode}\`
 

--- a/src/services/TrackerService.ts
+++ b/src/services/TrackerService.ts
@@ -1399,69 +1399,39 @@ Advance: set \`status.json.stage\` to \`requirements\`.
       }
 
       case 'requirements': {
+        // Two knobs: collaboration shape (style) + spec depth (detail).
+        // Check-in cadence is governed by the project inputMode, not here.
         const style = s['style'] ?? 'interview';
         const detail = s['detail'] ?? 'standard';
-        const approval = s['approval'] ?? 'per_section';
-        const userStories = s['user_stories'] ?? 'skip';
 
-        const steps: (string | null)[] = [];
-        steps.push('Read `notes.md` (discovery output) and the existing `requirements.md` — note the discovery stub heading and anything already written.');
-        steps.push('**Preserve the what / why from discovery.** The "Problem" and "Why" sections come straight from `notes.md` — copy them into `requirements.md` verbatim or lightly edited. Do not delete, paraphrase away, or weaken that context when adding new sections.');
+        const collabStep = style === 'draft_first'
+          ? 'Draft a strawman `requirements.md` from `notes.md` before asking anything. Share the draft; collect corrections per the project inputMode.'
+          : 'Ask targeted questions about acceptance criteria, edge cases, and constraints — batch them, follow the project inputMode. Then draft.';
 
-        if (style === 'interview') {
-          steps.push(`Use the ask_questions tool to ask targeted questions about acceptance criteria, edge cases, and constraints.${approval !== 'none' ? ' Batch questions — don\'t ask one at a time.' : ''}`);
-          steps.push('Draft the remaining requirements sections based on the answers, **appending** to the preserved discovery context rather than replacing it.');
-          if (approval === 'per_section') steps.push('Walk through each new section with the user for approval before moving to the next.');
-          else if (approval === 'end_only') steps.push('Draft all new sections, then present the complete document for user review.');
-          steps.push('Write the final `requirements.md` — it must still open with the discovery "Problem" and "Why" content, followed by the new sections.');
-        } else if (style === 'draft_first') {
-          steps.push('Draft a strawman `requirements.md` based on `notes.md` and your understanding — write it before asking anything. **Start with "Problem" and "Why" copied from `notes.md`**, then append your draft of the remaining sections.');
-          if (approval === 'per_section') steps.push('Walk through each section with the user. Use the ask_questions tool for feedback and corrections.');
-          else if (approval === 'end_only') steps.push('Share the complete draft. Use the ask_questions tool to collect corrections and open questions.');
-          else steps.push('Share the draft and incorporate any feedback the user volunteers.');
-          steps.push('Revise and write the final `requirements.md` — the "Problem" and "Why" from discovery must remain intact at the top.');
-        } else { // freeform
-          steps.push('Ask the user how they want to proceed — let them guide the format and depth.');
-          steps.push('Use the ask_questions tool as needed throughout the conversation.');
-          steps.push('Write `requirements.md` in whatever format fits the item — but always retain the "Problem" / "Why" context surfaced by discovery.');
-        }
-
-        const outputSections: string[] = [];
-        outputSections.push('- **Problem** (from discovery): the user problem this solves — preserved from `notes.md`');
-        outputSections.push('- **Why** (from discovery): context / motivation / findings — preserved from `notes.md`');
-        if (userStories === 'lead') outputSections.push('- **User stories** (lead): as a [user], I want [feature] so that [benefit]');
-        outputSections.push('- **Summary**: one-paragraph summary of what is being built');
-        if (userStories === 'include') outputSections.push('- **User stories**: as a [user], I want [feature] so that [benefit]');
-        outputSections.push('- **Acceptance criteria**: numbered list of testable conditions');
-        if (detail !== 'minimal') outputSections.push('- **Edge cases**: important boundary conditions');
+        const sections: string[] = [
+          '- **Problem** + **Why** — copied from `notes.md` (do not drop or rewrite).',
+          '- **Summary** — one paragraph of what will be built.',
+          '- **Acceptance criteria** — numbered testable conditions.',
+        ];
+        if (detail !== 'minimal') sections.push('- **Edge cases** — boundary conditions.');
         if (detail === 'thorough') {
-          outputSections.push('- **Constraints**: technical, performance, security, or UX constraints');
-          outputSections.push('- **Dependencies**: other items or systems this depends on');
-          outputSections.push('- **Out of scope**: explicitly what is NOT being built');
+          sections.push('- **Constraints** — technical / performance / security / UX.');
+          sections.push('- **Dependencies** — other items or systems.');
+          sections.push('- **Out of scope** — what is NOT being built.');
         }
-
         const minWords = detail === 'minimal' ? 30 : detail === 'thorough' ? 100 : 50;
 
         return `# Stage ${n}: Requirements
 
-**Goal**: Document what needs to be built — acceptance criteria, edge cases, constraints — **while preserving the what / why surfaced during discovery**.
+Document what to build. Always preserve the **Problem** and **Why** from \`notes.md\` — copy them verbatim; never paraphrase them away.
 
-## Steps
-
-${numbered(steps)}
-
-## Output
-
-`+"`"+`requirements.md`+"`"+` must contain, in this order:
-${outputSections.join('\n')}
-
-The **Problem** and **Why** sections are copied forward from `+"`"+`notes.md`+"`"+` — do not drop or substantially rewrite them. Reviewers should be able to see the original motivation without going back to `+"`"+`notes.md`+"`"+`.
+${numbered([
+  'Read `notes.md` and the existing `requirements.md` stub.',
+  collabStep,
+  `Write \`requirements.md\` in order:\n${sections.join('\n')}`,
+])}
 
 Minimum ${minWords} words of real content.
-
-## Advancing
-
-When `+"`"+`requirements.md`+"`"+` has sufficient detail: update the `+"`"+`tracker/index.json`+"`"+` (path is in the prompt, relative to cwd) slug to `+"`"+`implementation.implement`+"`"+`. Read `+"`"+`tracker/stages/4-implement.md`+"`"+` and continue.
 `;
       }
 

--- a/src/services/TrackerService.ts
+++ b/src/services/TrackerService.ts
@@ -1206,11 +1206,15 @@ Read \`tracker/stages/working-style.md\` for the project's preferred working sty
     // WorkStyle and falls back to the default when absent (e.g., tests that
     // don't pass a workStyle).
     const inputMode: InputModeStyle = workStyle?.inputMode ?? DEFAULT_WORK_STYLE.inputMode;
-    const gate = s['gate_on_advance'] ?? (stage === 'requirements' || stage === 'cleanup'
-      ? 'wait_for_approval'
-      : stage === 'implement'
-      ? 'review_and_advance'
-      : 'none');
+    // Back-compat: old configs might still have 'none' / 'review_and_advance' /
+    // 'wait_for_approval'. Map them onto the current two-value shape.
+    const rawGate = s['gate_on_advance'] ?? (stage === 'requirements' || stage === 'cleanup'
+      ? 'require_approval'
+      : 'auto_advance');
+    const gate =
+      rawGate === 'wait_for_approval' ? 'require_approval'
+      : rawGate === 'none' || rawGate === 'review_and_advance' ? 'auto_advance'
+      : rawGate;
     const submit = s['submit'] ?? 'approve';
     const outputFile =
       stage === 'discovery' ? 'notes.md'
@@ -1234,11 +1238,9 @@ Read \`tracker/stages/working-style.md\` for the project's preferred working sty
 
     const gateInstruction = (() => {
       switch (gate) {
-        case 'none':
-          return 'Advance silently: update `status.json.stage` to the next stage and continue.';
-        case 'review_and_advance':
-          return `Before advancing, append a short "## Stage review" section (1–3 sentences) to \`${outputFile}\` summarising what you did this stage. Then update \`status.json.stage\` to the next stage and continue.`;
-        case 'wait_for_approval':
+        case 'auto_advance':
+          return `Advance without asking. Before you do, if this stage produced meaningful findings, decisions, or changes, append a short "## Stage review" section (1–3 sentences) to \`${outputFile}\` summarising what you did — skip the review for trivial no-op stages. Then update \`status.json.stage\` to the next stage and continue.`;
+        case 'require_approval':
           return 'Before advancing, pause and ask for the user\'s approval using this stage\'s input mode (above). Do not update `status.json.stage` until the user explicitly approves the advance.';
         default:
           return '';

--- a/src/services/TrackerService.ts
+++ b/src/services/TrackerService.ts
@@ -1360,9 +1360,9 @@ When the user confirms pursuit: update the `+"`"+`tracker/index.json`+"`"+` (pat
 
         const researchStep =
           effort === 'skim'
-            ? 'Skim codebase for duplicates. No web search.'
+            ? 'Skim codebase for duplicates.'
             : effort === 'deep'
-            ? 'Thorough codebase scan: patterns, conflicts, tests. Web research: domain, external APIs, prior art, alternatives.'
+            ? 'Thorough codebase scan: patterns, conflicts, tests. Web research: domain, APIs, prior art, alternatives.'
             : 'Scan codebase for related patterns. Web search if the domain is unfamiliar.';
 
         const reportStep = (() => {
@@ -1370,35 +1370,31 @@ When the user confirms pursuit: update the `+"`"+`tracker/index.json`+"`"+` (pat
             case 'just_advance':
               return 'Advance silently.';
             case 'always_confirm':
-              return 'Summarise findings and wait for approval (set `is_waiting_for_user: true` + `awaiting_advance_approval: true`).';
+              return 'Summarise findings, wait for approval — set `is_waiting_for_user` + `awaiting_advance_approval` to true.';
             case 'confirm_if_notable':
             default:
-              return 'If findings are notable (surprise, risk, pivot, conflict, viable alternative), summarise and wait for approval (`is_waiting_for_user: true` + `awaiting_advance_approval: true`). Otherwise advance silently.';
+              return 'If findings are notable (surprise, risk, pivot, conflict, alternative), summarise and wait for approval (set `is_waiting_for_user` + `awaiting_advance_approval` to true). Otherwise advance silently.';
           }
         })();
 
         const outputFields =
           effort === 'skim'
-            ? '- Problem\n- Recommendation'
+            ? 'Problem, Recommendation.'
             : effort === 'deep'
-            ? '- Problem\n- Context (code findings + research)\n- Options (2+ with tradeoffs)\n- Recommendation (reasoning + risks)'
-            : '- Problem\n- Findings\n- Recommendation';
+            ? 'Problem; Context (code + research); Options (2+ with tradeoffs); Recommendation (reasoning + risks).'
+            : 'Problem, Findings, Recommendation.';
 
         return `# Stage ${n}: Discovery
 
-Understand the user problem. Research the code and domain — don't interrogate the user.
-
-**Skip rules.** Trivial items (typo, rename, doc tweak): write one-line \`notes.md\` and advance. Clarifying questions: only if the problem statement itself is too vague to interpret. "X or Y?" questions belong in requirements.
-
-## Do
+Research the problem — code and domain. Trivial items (typo, rename, doc): one-line \`notes.md\`, advance. Clarifying questions: only if the request itself is unreadable; "X or Y?" trade-offs belong in requirements.
 
 ${numbered([
   researchStep,
-  `Write \`notes.md\`:\n${outputFields}`,
+  `Write \`notes.md\`: ${outputFields}`,
   reportStep,
 ])}
 
-Advance by setting \`status.json.stage\` to \`requirements\`.
+Advance: set \`status.json.stage\` to \`requirements\`.
 `;
       }
 

--- a/src/services/TrackerService.ts
+++ b/src/services/TrackerService.ts
@@ -33,15 +33,12 @@ export interface ExitCriterionResult {
 // to decide whether an idle pane is truly stuck or legitimately waiting.
 export interface ItemStatus {
   stage: Exclude<TrackerStage, 'archive'>;
-  // One tri-state instead of overlapping booleans:
-  //   - 'working': actively progressing, no human needed.
-  //   - 'waiting_for_input': mid-stage — blocked on a clarification.
-  //   - 'waiting_for_approval': stage work is done, wants sign-off to advance.
-  // Ralph treats the two waiting states the same (suppress nudges); the UI
-  // renders them differently so "ready to advance" is visually distinct.
+  // Ralph treats both waiting states the same (suppress nudges); the kanban
+  // renders waiting_for_approval distinctly so "ready to advance" is
+  // spottable at a glance.
   state: ItemStatusState;
   // Short human-readable note: what the agent is currently doing, or the
-  // concrete thing it's waiting on. ≤ 120 chars.
+  // concrete thing it's waiting on. ≤ 200 chars.
   brief_description: string;
   // ISO-8601 timestamp of last update. Used for the staleness check.
   timestamp: string;
@@ -281,11 +278,6 @@ export const STAGE_LABELS: Record<TrackerStage, string> = {
   archive: 'Archive',
 };
 
-// Wider title used for the board column header (where space allows a longer label).
-const COLUMN_TITLES: Record<TrackerStage, string> = {
-  ...STAGE_LABELS,
-};
-
 export class TrackerService {
   getTrackerPath(projectPath: string): string {
     return path.join(projectPath, 'tracker');
@@ -383,7 +375,7 @@ export class TrackerService {
         .sort((a, b) => a.slug.localeCompare(b.slug));
       return {
         id,
-        title: COLUMN_TITLES[id],
+        title: STAGE_LABELS[id],
         bucket,
         items: [...ordered, ...extras],
       };
@@ -475,8 +467,8 @@ export class TrackerService {
 
   // Overwrite the status file. Writes to the resolved item dir, or (as a
   // fallback for items with no worktree yet) to the main-project stub dir so
-  // the file still has a home. Truncates brief_description to 120 chars to
-  // keep the UI row tidy.
+  // the file still has a home. Truncates brief_description to 200 chars to
+  // keep the UI row from growing without bound.
   writeItemStatus(projectPath: string, slug: string, status: ItemStatus): void {
     let itemDir = this.resolveItemDir(projectPath, slug);
     if (!itemDir) {
@@ -486,19 +478,30 @@ export class TrackerService {
     const payload: ItemStatus = {
       stage: status.stage,
       state: status.state,
-      brief_description: (status.brief_description || '').slice(0, 120),
+      brief_description: (status.brief_description || '').slice(0, 200),
       timestamp: status.timestamp || new Date().toISOString(),
     };
     writeJSONAtomic(path.join(itemDir, 'status.json'), payload);
   }
 
   // A status is "stale" if its timestamp is older than ITEM_STATUS_STALE_MS.
-  // Ralph ignores `is_waiting_for_user: true` on stale records so a crashed
-  // agent doesn't suppress nudges indefinitely.
+  // Ralph ignores non-working state on stale records so a crashed agent
+  // doesn't suppress nudges indefinitely.
   isItemStatusStale(status: ItemStatus, now: Date = new Date()): boolean {
     const ts = Date.parse(status.timestamp);
     if (Number.isNaN(ts)) return true;
     return now.getTime() - ts > ITEM_STATUS_STALE_MS;
+  }
+
+  // Fresh + non-working. Covers both waiting_for_input and waiting_for_approval.
+  isItemWaiting(status: ItemStatus | null | undefined, now?: Date): boolean {
+    return !!status && status.state !== 'working' && !this.isItemStatusStale(status, now);
+  }
+
+  // Fresh + specifically waiting_for_approval. The kanban uses this to render
+  // the green "ready to advance" treatment and expose the [m] approve shortcut.
+  isItemReadyToAdvance(status: ItemStatus | null | undefined, now?: Date): boolean {
+    return !!status && status.state === 'waiting_for_approval' && !this.isItemStatusStale(status, now);
   }
 
   createItem(projectPath: string, title: string, stage: TrackerStage = 'discovery', explicitSlug?: string, body?: string): void {
@@ -908,9 +911,9 @@ export class TrackerService {
     };
     const INPUT_MODE_LABELS: Record<string, [string, string]> = {
       ask_questions: ['ask_questions tool', 'Use the ask_questions tool whenever you need input. Produces a detectable numbered prompt in the terminal.'],
-      inline: ['Inline chat', 'Ask questions inline in the conversation. Before pausing, set is_waiting_for_user: true in status.json with a brief_description; clear it on resume.'],
-      batch: ['Batched', 'Batch every question into a single message — do not ask one at a time. Set is_waiting_for_user: true in status.json before sending; clear on resume.'],
-      doc_review: ['Doc review', 'Write the stage\'s output file first, then ask the user to review it. Set is_waiting_for_user: true in status.json before asking for review; clear on resume.'],
+      inline: ['Inline chat', 'Ask questions inline in the conversation. Before pausing, set state: "waiting_for_input" in status.json with a brief_description; set it back to "working" on resume.'],
+      batch: ['Batched', 'Batch every question into a single message — do not ask one at a time. Set state: "waiting_for_input" in status.json before sending; set it back to "working" on resume.'],
+      doc_review: ['Doc review', 'Write the stage\'s output file first, then ask the user to review it. Set state: "waiting_for_input" in status.json before asking for review; set it back to "working" on resume.'],
     };
 
     const row = (label: string, map: Record<string, [string, string]>, val: string) => {
@@ -1282,7 +1285,7 @@ Schema:
 {
   "stage": "${stage}",
   "state": "working",
-  "brief_description": "the concrete thing you're doing or need (≤ 120 chars)",
+  "brief_description": "the concrete thing you're doing or need (≤ 200 chars)",
   "timestamp": "ISO-8601 now"
 }
 \`\`\`

--- a/tests/unit/ralph.test.ts
+++ b/tests/unit/ralph.test.ts
@@ -147,8 +147,29 @@ describe('buildNudgeText', () => {
   });
 
   test('points the agent at status.json for advancement', () => {
-    const text = buildNudgeText({slug: 'abc', stage: 'implement', inputMode: 'ask_questions', gateOnAdvance: 'review_and_advance'});
+    const text = buildNudgeText({slug: 'abc', stage: 'implement', inputMode: 'ask_questions', gateOnAdvance: 'auto_advance'});
     expect(text).toContain('status.json');
+  });
+
+  test('does not use the word "ralph" in the message to the agent', () => {
+    // We want the reminder to read like a polite human check-in, not a
+    // system notification. The agent should not be told about the machinery.
+    const text = buildNudgeText({slug: 'abc', stage: 'discovery', inputMode: 'inline', gateOnAdvance: 'auto_advance'});
+    expect(text.toLowerCase()).not.toContain('ralph');
+  });
+
+  test('reminds the agent to flip is_waiting_for_user when they need input', () => {
+    const text = buildNudgeText({slug: 'abc', stage: 'requirements', inputMode: 'inline', gateOnAdvance: 'require_approval'});
+    expect(text).toContain('is_waiting_for_user');
+    expect(text).toMatch(/brief_description/);
+  });
+
+  test('reads as a polite check-in, not a directive', () => {
+    const text = buildNudgeText({slug: 'abc', stage: 'discovery', inputMode: 'ask_questions', gateOnAdvance: 'auto_advance'});
+    // Soft signals: contains "please" or "check-in" phrasing and doesn't
+    // open with a system-labelled bracket like "[ralph]".
+    expect(text).not.toMatch(/^\[/);
+    expect(text.toLowerCase()).toMatch(/please|check-in/);
   });
 });
 

--- a/tests/unit/ralph.test.ts
+++ b/tests/unit/ralph.test.ts
@@ -213,6 +213,26 @@ describe('RalphCore safety invariants', () => {
     expect(tmux.sent.length).toBe(0);
   });
 
+  test('never sends a nudge when awaiting_advance_approval is set (even without is_waiting_for_user)', () => {
+    // The agent may end up with only awaiting_advance_approval true (work is
+    // done, just waiting for user sign-off). That's still a legitimate
+    // human-pause — ralph must treat it the same as is_waiting_for_user.
+    enableRalph();
+    writeStatus('my-slug', {
+      is_waiting_for_user: false,
+      awaiting_advance_approval: true,
+      brief_description: 'ready to advance from requirements',
+    });
+    const t0 = Date.now();
+    let now = t0;
+    const wt = makeWorktree({ai_status: 'idle'});
+    const {core, tmux} = buildCore({worktrees: [wt], now: () => now});
+    core.sampleOnce();
+    now = t0 + 10 * 60 * 1000;
+    core.sampleOnce();
+    expect(tmux.sent.length).toBe(0);
+  });
+
   test('never sends a nudge when ralph is disabled for the project', () => {
     saveRalphConfig(projectPath, {enabled: false, idleThresholdMs: 60_000, maxNudgesPerStage: 3});
     writeStatus('my-slug', {});

--- a/tests/unit/ralph.test.ts
+++ b/tests/unit/ralph.test.ts
@@ -350,3 +350,75 @@ describe('RalphCore detection + cap + resets', () => {
     expect(entry.slug).toBe('my-slug');
   });
 });
+
+// ─── full end-to-end flow (ac §38) ──────────────────────────────────────────
+
+describe('RalphCore full fake-agent flow', () => {
+  test('waiting → clear → nudge → cap → advance → reset', () => {
+    enableRalph({idleThresholdMs: 60_000, maxNudgesPerStage: 2});
+
+    // Fake agent begins the stage and marks itself waiting on the user.
+    writeStatus('my-slug', {
+      stage: 'requirements',
+      is_waiting_for_user: true,
+      brief_description: 'awaiting approval',
+    });
+
+    const t0 = Date.now();
+    let now = t0;
+    const wt = makeWorktree({ai_status: 'idle'});
+    const {core, tmux} = buildCore({worktrees: [wt], now: () => now});
+
+    // Sample while fresh-waiting — no nudge regardless of how long we wait.
+    core.sampleOnce();
+    now = t0 + 10 * 60_000;
+    core.sampleOnce();
+    expect(tmux.sent.length).toBe(0);
+
+    // User responds; agent clears the waiting flag and keeps working.
+    writeStatus('my-slug', {
+      stage: 'requirements',
+      is_waiting_for_user: false,
+      brief_description: 'drafting section 2',
+    });
+
+    // Idle clock starts now. Advance just past the threshold; nudge fires.
+    now = t0 + 11 * 60_000;
+    core.sampleOnce(); // starts the idle window
+    now = t0 + 13 * 60_000;
+    core.sampleOnce();
+    expect(tmux.sent.length).toBe(1);
+
+    // Another idle window elapses; second nudge fires and hits the cap.
+    now = t0 + 15 * 60_000;
+    core.sampleOnce();
+    now = t0 + 17 * 60_000;
+    core.sampleOnce();
+    expect(tmux.sent.length).toBe(2);
+    let state = core.get().worktrees['proj::my-slug'];
+    expect(state.capped).toBe(true);
+
+    // Further idle time while capped produces no more nudges.
+    now = t0 + 30 * 60_000;
+    core.sampleOnce();
+    expect(tmux.sent.length).toBe(2);
+
+    // Agent advances the stage (or a human does via moveItem, same effect).
+    writeStatus('my-slug', {
+      stage: 'implement',
+      is_waiting_for_user: false,
+      brief_description: 'writing RalphCore',
+    });
+    now = t0 + 31 * 60_000;
+    core.sampleOnce(); // observes stage change, resets cap + counter
+    state = core.get().worktrees['proj::my-slug'];
+    expect(state.capped).toBe(false);
+    expect(state.nudgesThisStage).toBe(0);
+
+    // New idle window; nudge fires cleanly on the new stage.
+    now = t0 + 34 * 60_000;
+    core.sampleOnce();
+    expect(tmux.sent.length).toBe(3);
+    expect(tmux.sent[2].text).toContain('implement');
+  });
+});

--- a/tests/unit/ralph.test.ts
+++ b/tests/unit/ralph.test.ts
@@ -246,7 +246,10 @@ describe('RalphCore safety invariants', () => {
     expect(tmux.sent.length).toBe(0);
   });
 
-  test('never sends a nudge when the tmux session is not attached', () => {
+  test('nudges a backgrounded session when the agent is running + idle', () => {
+    // Attachment just means the user is viewing the pane; it's orthogonal
+    // to whether the agent itself is running. ai_status === 'idle' is the
+    // authoritative "running and ready" signal.
     enableRalph();
     writeStatus('my-slug', {});
     const t0 = Date.now();
@@ -256,7 +259,7 @@ describe('RalphCore safety invariants', () => {
     core.sampleOnce();
     now = t0 + 10 * 60 * 1000;
     core.sampleOnce();
-    expect(tmux.sent.length).toBe(0);
+    expect(tmux.sent.length).toBe(1);
   });
 });
 

--- a/tests/unit/ralph.test.ts
+++ b/tests/unit/ralph.test.ts
@@ -1,0 +1,352 @@
+import {describe, test, expect, beforeEach, afterEach} from '@jest/globals';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import {
+  RalphCore,
+  DEFAULT_RALPH_CONFIG,
+  loadRalphConfig,
+  saveRalphConfig,
+  buildNudgeText,
+  RalphConfig,
+} from '../../src/cores/RalphCore.js';
+import {TrackerService, ItemStatus} from '../../src/services/TrackerService.js';
+import {WorktreeInfo, SessionInfo} from '../../src/models.js';
+
+// Minimal sendText-capturing fake. We don't need the full FakeTmuxService
+// surface here — the ralph loop only ever calls sendText().
+class CapturingTmuxService {
+  public sent: Array<{session: string; text: string; executeCommand?: boolean}> = [];
+  sendText(session: string, text: string, options: {executeCommand?: boolean} = {}) {
+    this.sent.push({session, text, executeCommand: options.executeCommand});
+  }
+}
+
+function makeWorktree(opts: {
+  project?: string;
+  feature?: string;
+  ai_status?: SessionInfo['ai_status'];
+  attached?: boolean;
+} = {}): WorktreeInfo {
+  return new WorktreeInfo({
+    project: opts.project ?? 'proj',
+    feature: opts.feature ?? 'my-slug',
+    path: '/tmp/ignored',
+    branch: 'feature',
+    session: new SessionInfo({
+      session_name: `dev-${opts.project ?? 'proj'}-${opts.feature ?? 'my-slug'}`,
+      attached: opts.attached ?? true,
+      ai_status: opts.ai_status ?? 'idle',
+      ai_tool: 'claude',
+    }),
+  });
+}
+
+let tmpDir: string;
+let projectPath: string;
+let tracker: TrackerService;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ralph-test-'));
+  projectPath = path.join(tmpDir, 'proj');
+  fs.mkdirSync(path.join(projectPath, 'tracker', 'items', 'my-slug'), {recursive: true});
+  tracker = new TrackerService();
+  tracker.ensureTracker(projectPath);
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, {recursive: true, force: true});
+});
+
+function writeStatus(slug: string, status: Partial<ItemStatus>): void {
+  tracker.writeItemStatus(projectPath, slug, {
+    stage: 'discovery',
+    is_waiting_for_user: false,
+    brief_description: '',
+    timestamp: new Date().toISOString(),
+    ...status,
+  });
+}
+
+function enableRalph(overrides: Partial<RalphConfig> = {}): void {
+  saveRalphConfig(projectPath, {
+    enabled: true,
+    idleThresholdMs: 60_000,
+    maxNudgesPerStage: 3,
+    ...overrides,
+  });
+}
+
+function buildCore(opts: {
+  worktrees: readonly WorktreeInfo[];
+  now: () => number;
+  tmux?: CapturingTmuxService;
+}): {core: RalphCore; tmux: CapturingTmuxService; logs: string[]} {
+  const tmux = opts.tmux ?? new CapturingTmuxService();
+  const logs: string[] = [];
+  const core = new RalphCore({
+    tracker,
+    // The fake's surface is a subset of TmuxService but typesafe where the
+    // core calls into it. Cast is safe — only sendText is invoked.
+    tmux: tmux as any,
+    getWorktrees: () => opts.worktrees,
+    getProjectPath: (p) => (p === 'proj' ? projectPath : ''),
+    now: opts.now,
+    logger: (line) => logs.push(line),
+  });
+  return {core, tmux, logs};
+}
+
+// ─── ralph.json load/save ───────────────────────────────────────────────────
+
+describe('ralph config load/save', () => {
+  test('loadRalphConfig returns defaults when file is missing', () => {
+    const cfg = loadRalphConfig(projectPath);
+    expect(cfg).toEqual(DEFAULT_RALPH_CONFIG);
+  });
+
+  test('round-trips through saveRalphConfig', () => {
+    saveRalphConfig(projectPath, {
+      enabled: true,
+      idleThresholdMs: 10_000,
+      maxNudgesPerStage: 5,
+    });
+    expect(loadRalphConfig(projectPath)).toEqual({
+      enabled: true,
+      idleThresholdMs: 10_000,
+      maxNudgesPerStage: 5,
+    });
+  });
+
+  test('rejects garbage fields and falls back to defaults', () => {
+    fs.writeFileSync(
+      path.join(projectPath, 'tracker', 'ralph.json'),
+      JSON.stringify({enabled: 'yes', idleThresholdMs: -5, maxNudgesPerStage: 'infinity'}),
+    );
+    const cfg = loadRalphConfig(projectPath);
+    expect(cfg.enabled).toBe(DEFAULT_RALPH_CONFIG.enabled);
+    expect(cfg.idleThresholdMs).toBe(DEFAULT_RALPH_CONFIG.idleThresholdMs);
+    expect(cfg.maxNudgesPerStage).toBe(DEFAULT_RALPH_CONFIG.maxNudgesPerStage);
+  });
+});
+
+// ─── buildNudgeText ─────────────────────────────────────────────────────────
+
+describe('buildNudgeText', () => {
+  test('references stage guide path and output file', () => {
+    const text = buildNudgeText({slug: 'abc', stage: 'discovery', inputMode: 'ask_questions', gateOnAdvance: 'none'});
+    expect(text).toContain('discovery');
+    expect(text).toContain('2-discovery.md');
+    expect(text).toContain('notes.md');
+  });
+
+  test('includes the current gate and input_mode', () => {
+    const text = buildNudgeText({slug: 'abc', stage: 'requirements', inputMode: 'inline', gateOnAdvance: 'wait_for_approval'});
+    expect(text).toContain('wait_for_approval');
+    expect(text).toContain('inline');
+  });
+
+  test('points the agent at status.json for advancement', () => {
+    const text = buildNudgeText({slug: 'abc', stage: 'implement', inputMode: 'ask_questions', gateOnAdvance: 'review_and_advance'});
+    expect(text).toContain('status.json');
+  });
+});
+
+// ─── safety invariants ──────────────────────────────────────────────────────
+
+describe('RalphCore safety invariants', () => {
+  test('never sends a nudge when ai_status is "waiting"', () => {
+    enableRalph();
+    writeStatus('my-slug', {});
+    const t0 = Date.now();
+    const wt = makeWorktree({ai_status: 'waiting'});
+    const {core, tmux} = buildCore({worktrees: [wt], now: () => t0});
+    core.sampleOnce();
+    // fast-forward way past the idle threshold
+    (core as any).now = () => t0 + 10 * 60 * 1000;
+    core.sampleOnce();
+    expect(tmux.sent.length).toBe(0);
+  });
+
+  test('never sends a nudge when ai_status is "working"', () => {
+    enableRalph();
+    writeStatus('my-slug', {});
+    const t0 = Date.now();
+    const wt = makeWorktree({ai_status: 'working'});
+    const {core, tmux} = buildCore({worktrees: [wt], now: () => t0 + 10 * 60 * 1000});
+    core.sampleOnce();
+    expect(tmux.sent.length).toBe(0);
+  });
+
+  test('never sends a nudge when status.json has a fresh is_waiting_for_user=true', () => {
+    enableRalph();
+    writeStatus('my-slug', {is_waiting_for_user: true, brief_description: 'waiting on user'});
+    const t0 = Date.now();
+    const wt = makeWorktree({ai_status: 'idle'});
+    // First sample seeds the stall window; second advances past the threshold.
+    let now = t0;
+    const {core, tmux} = buildCore({worktrees: [wt], now: () => now});
+    core.sampleOnce();
+    now = t0 + 10 * 60 * 1000;
+    core.sampleOnce();
+    expect(tmux.sent.length).toBe(0);
+  });
+
+  test('never sends a nudge when ralph is disabled for the project', () => {
+    saveRalphConfig(projectPath, {enabled: false, idleThresholdMs: 60_000, maxNudgesPerStage: 3});
+    writeStatus('my-slug', {});
+    const t0 = Date.now();
+    let now = t0;
+    const wt = makeWorktree({ai_status: 'idle'});
+    const {core, tmux} = buildCore({worktrees: [wt], now: () => now});
+    core.sampleOnce();
+    now = t0 + 10 * 60 * 1000;
+    core.sampleOnce();
+    expect(tmux.sent.length).toBe(0);
+  });
+
+  test('never sends a nudge when the tmux session is not attached', () => {
+    enableRalph();
+    writeStatus('my-slug', {});
+    const t0 = Date.now();
+    let now = t0;
+    const wt = makeWorktree({ai_status: 'idle', attached: false});
+    const {core, tmux} = buildCore({worktrees: [wt], now: () => now});
+    core.sampleOnce();
+    now = t0 + 10 * 60 * 1000;
+    core.sampleOnce();
+    expect(tmux.sent.length).toBe(0);
+  });
+});
+
+// ─── detection + cap + resets ───────────────────────────────────────────────
+
+describe('RalphCore detection + cap + resets', () => {
+  test('fires a nudge after sustained idle + unchanged stage', () => {
+    enableRalph({idleThresholdMs: 60_000});
+    writeStatus('my-slug', {});
+    const t0 = Date.now();
+    let now = t0;
+    const wt = makeWorktree({ai_status: 'idle'});
+    const {core, tmux} = buildCore({worktrees: [wt], now: () => now});
+    core.sampleOnce();
+    expect(tmux.sent.length).toBe(0); // not yet past threshold
+    now = t0 + 90_000; // past threshold
+    core.sampleOnce();
+    expect(tmux.sent.length).toBe(1);
+    expect(tmux.sent[0].session).toBe('dev-proj-my-slug');
+    expect(tmux.sent[0].executeCommand).toBe(true);
+  });
+
+  test('increments the counter then caps at maxNudgesPerStage', () => {
+    enableRalph({idleThresholdMs: 60_000, maxNudgesPerStage: 3});
+    writeStatus('my-slug', {});
+    const t0 = Date.now();
+    let now = t0;
+    const wt = makeWorktree({ai_status: 'idle'});
+    const {core, tmux} = buildCore({worktrees: [wt], now: () => now});
+    core.sampleOnce(); // seed
+    for (let i = 1; i <= 5; i++) {
+      now = t0 + i * 120_000;
+      core.sampleOnce();
+    }
+    expect(tmux.sent.length).toBe(3);
+    const state = core.get().worktrees['proj::my-slug'];
+    expect(state.nudgesThisStage).toBe(3);
+    expect(state.capped).toBe(true);
+  });
+
+  test('stage change resets the cap and nudge counter', () => {
+    // Use cap=2 so the second nudge (post stage change) doesn't immediately
+    // re-cap us — that would confuse the "was the counter actually reset?"
+    // assertion.
+    enableRalph({idleThresholdMs: 60_000, maxNudgesPerStage: 2});
+    writeStatus('my-slug', {stage: 'discovery'});
+    const t0 = Date.now();
+    let now = t0;
+    const wt = makeWorktree({ai_status: 'idle'});
+    const {core, tmux} = buildCore({worktrees: [wt], now: () => now});
+    core.sampleOnce();
+    now = t0 + 120_000;
+    core.sampleOnce();
+    expect(tmux.sent.length).toBe(1);
+    // Agent advances the stage
+    writeStatus('my-slug', {stage: 'requirements'});
+    now = t0 + 240_000;
+    core.sampleOnce(); // observes the stage change and resets
+    now = t0 + 360_000;
+    core.sampleOnce(); // idle window re-accrues and fires
+    expect(tmux.sent.length).toBe(2);
+    const state = core.get().worktrees['proj::my-slug'];
+    expect(state.nudgesThisStage).toBe(1); // counter reset then incremented
+    expect(state.capped).toBe(false);
+  });
+
+  test('fresh is_waiting_for_user flip resets the cap mid-stage', () => {
+    enableRalph({idleThresholdMs: 60_000, maxNudgesPerStage: 1});
+    writeStatus('my-slug', {});
+    const t0 = Date.now();
+    let now = t0;
+    const wt = makeWorktree({ai_status: 'idle'});
+    const {core, tmux} = buildCore({worktrees: [wt], now: () => now});
+    core.sampleOnce();
+    now = t0 + 120_000;
+    core.sampleOnce();
+    expect(tmux.sent.length).toBe(1);
+    // Agent sets is_waiting_for_user: true
+    writeStatus('my-slug', {is_waiting_for_user: true, brief_description: 'reviewing'});
+    now = t0 + 240_000;
+    core.sampleOnce();
+    const state = core.get().worktrees['proj::my-slug'];
+    expect(state.capped).toBe(false);
+    expect(state.nudgesThisStage).toBe(0);
+  });
+
+  test('ignores stale waiting flags (> 24h old)', () => {
+    enableRalph({idleThresholdMs: 60_000});
+    const oldTimestamp = new Date(Date.now() - 25 * 60 * 60 * 1000).toISOString();
+    writeStatus('my-slug', {is_waiting_for_user: true, brief_description: 'stale', timestamp: oldTimestamp});
+    const t0 = Date.now();
+    let now = t0;
+    const wt = makeWorktree({ai_status: 'idle'});
+    const {core, tmux} = buildCore({worktrees: [wt], now: () => now});
+    core.sampleOnce();
+    now = t0 + 120_000;
+    core.sampleOnce();
+    // Stale flag does NOT suppress the nudge
+    expect(tmux.sent.length).toBe(1);
+  });
+
+  test('nudge text names the current stage and references status.json', () => {
+    enableRalph({idleThresholdMs: 60_000});
+    writeStatus('my-slug', {stage: 'requirements'});
+    const t0 = Date.now();
+    let now = t0;
+    const wt = makeWorktree({ai_status: 'idle'});
+    const {core, tmux} = buildCore({worktrees: [wt], now: () => now});
+    core.sampleOnce();
+    now = t0 + 120_000;
+    core.sampleOnce();
+    expect(tmux.sent.length).toBe(1);
+    expect(tmux.sent[0].text).toContain('requirements');
+    expect(tmux.sent[0].text).toContain('status.json');
+    expect(tmux.sent[0].text).toContain('my-slug');
+  });
+
+  test('logs an entry for each nudge', () => {
+    enableRalph({idleThresholdMs: 60_000});
+    writeStatus('my-slug', {stage: 'implement'});
+    const t0 = Date.now();
+    let now = t0;
+    const wt = makeWorktree({ai_status: 'idle'});
+    const {core, logs} = buildCore({worktrees: [wt], now: () => now});
+    core.sampleOnce();
+    now = t0 + 120_000;
+    core.sampleOnce();
+    expect(logs.length).toBe(1);
+    const entry = JSON.parse(logs[0]);
+    expect(entry.stage).toBe('implement');
+    expect(entry.nudgeNumber).toBe(1);
+    expect(entry.slug).toBe('my-slug');
+  });
+});

--- a/tests/unit/ralph.test.ts
+++ b/tests/unit/ralph.test.ts
@@ -61,7 +61,7 @@ afterEach(() => {
 function writeStatus(slug: string, status: Partial<ItemStatus>): void {
   tracker.writeItemStatus(projectPath, slug, {
     stage: 'discovery',
-    is_waiting_for_user: false,
+    state: 'working',
     brief_description: '',
     timestamp: new Date().toISOString(),
     ...status,
@@ -136,7 +136,7 @@ describe('buildNudgeText', () => {
   test('references stage guide path and output file', () => {
     const text = buildNudgeText({slug: 'abc', stage: 'discovery', inputMode: 'ask_questions', gateOnAdvance: 'none'});
     expect(text).toContain('discovery');
-    expect(text).toContain('2-discovery.md');
+    expect(text).toContain('stages/discovery.md');
     expect(text).toContain('notes.md');
   });
 
@@ -158,9 +158,10 @@ describe('buildNudgeText', () => {
     expect(text.toLowerCase()).not.toContain('ralph');
   });
 
-  test('reminds the agent to flip is_waiting_for_user when they need input', () => {
+  test('reminds the agent to set the right state when waiting', () => {
     const text = buildNudgeText({slug: 'abc', stage: 'requirements', inputMode: 'inline', gateOnAdvance: 'require_approval'});
-    expect(text).toContain('is_waiting_for_user');
+    expect(text).toContain('waiting_for_input');
+    expect(text).toContain('waiting_for_approval');
     expect(text).toMatch(/brief_description/);
   });
 
@@ -199,9 +200,9 @@ describe('RalphCore safety invariants', () => {
     expect(tmux.sent.length).toBe(0);
   });
 
-  test('never sends a nudge when status.json has a fresh is_waiting_for_user=true', () => {
+  test('never sends a nudge when status.json has a fresh waiting_for_input state', () => {
     enableRalph();
-    writeStatus('my-slug', {is_waiting_for_user: true, brief_description: 'waiting on user'});
+    writeStatus('my-slug', {state: 'waiting_for_input', brief_description: 'waiting on user'});
     const t0 = Date.now();
     const wt = makeWorktree({ai_status: 'idle'});
     // First sample seeds the stall window; second advances past the threshold.
@@ -213,19 +214,14 @@ describe('RalphCore safety invariants', () => {
     expect(tmux.sent.length).toBe(0);
   });
 
-  test('never sends a nudge when awaiting_advance_approval is set (even without is_waiting_for_user)', () => {
-    // The agent may end up with only awaiting_advance_approval true (work is
-    // done, just waiting for user sign-off). That's still a legitimate
-    // human-pause — ralph must treat it the same as is_waiting_for_user.
+  test('never sends a nudge when status.json has a fresh waiting_for_approval state', () => {
+    // waiting_for_approval is a legitimate pause — the agent finished the
+    // stage and is waiting for human sign-off. Ralph must leave it alone.
     enableRalph();
-    writeStatus('my-slug', {
-      is_waiting_for_user: false,
-      awaiting_advance_approval: true,
-      brief_description: 'ready to advance from requirements',
-    });
+    writeStatus('my-slug', {state: 'waiting_for_approval', brief_description: 'caching layer complete'});
     const t0 = Date.now();
-    let now = t0;
     const wt = makeWorktree({ai_status: 'idle'});
+    let now = t0;
     const {core, tmux} = buildCore({worktrees: [wt], now: () => now});
     core.sampleOnce();
     now = t0 + 10 * 60 * 1000;
@@ -338,7 +334,7 @@ describe('RalphCore detection + cap + resets', () => {
     core.sampleOnce();
     expect(tmux.sent.length).toBe(1);
     // Agent sets is_waiting_for_user: true
-    writeStatus('my-slug', {is_waiting_for_user: true, brief_description: 'reviewing'});
+    writeStatus('my-slug', {state: 'waiting_for_input', brief_description: 'reviewing'});
     now = t0 + 240_000;
     core.sampleOnce();
     const state = core.get().worktrees['proj::my-slug'];
@@ -349,7 +345,7 @@ describe('RalphCore detection + cap + resets', () => {
   test('ignores stale waiting flags (> 24h old)', () => {
     enableRalph({idleThresholdMs: 60_000});
     const oldTimestamp = new Date(Date.now() - 25 * 60 * 60 * 1000).toISOString();
-    writeStatus('my-slug', {is_waiting_for_user: true, brief_description: 'stale', timestamp: oldTimestamp});
+    writeStatus('my-slug', {state: 'waiting_for_input', brief_description: 'stale', timestamp: oldTimestamp});
     const t0 = Date.now();
     let now = t0;
     const wt = makeWorktree({ai_status: 'idle'});
@@ -404,7 +400,7 @@ describe('RalphCore full fake-agent flow', () => {
     // Fake agent begins the stage and marks itself waiting on the user.
     writeStatus('my-slug', {
       stage: 'requirements',
-      is_waiting_for_user: true,
+      state: 'waiting_for_input',
       brief_description: 'awaiting approval',
     });
 
@@ -422,7 +418,7 @@ describe('RalphCore full fake-agent flow', () => {
     // User responds; agent clears the waiting flag and keeps working.
     writeStatus('my-slug', {
       stage: 'requirements',
-      is_waiting_for_user: false,
+      state: 'working',
       brief_description: 'drafting section 2',
     });
 
@@ -450,7 +446,7 @@ describe('RalphCore full fake-agent flow', () => {
     // Agent advances the stage (or a human does via moveItem, same effect).
     writeStatus('my-slug', {
       stage: 'implement',
-      is_waiting_for_user: false,
+      state: 'working',
       brief_description: 'writing RalphCore',
     });
     now = t0 + 31 * 60_000;

--- a/tests/unit/tracker.test.ts
+++ b/tests/unit/tracker.test.ts
@@ -2,7 +2,7 @@ import {describe, test, expect, beforeEach, afterEach} from '@jest/globals';
 import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
-import {TrackerService, parseFrontmatter, DEFAULT_WORK_STYLE, TrackerItem, StageConfig, WorkStyle} from '../../src/services/TrackerService.js';
+import {TrackerService, parseFrontmatter, DEFAULT_WORK_STYLE, TrackerItem, StageConfig, WorkStyle, ItemStatus, ITEM_STATUS_STALE_MS} from '../../src/services/TrackerService.js';
 
 let tmpDir: string;
 let service: TrackerService;
@@ -112,6 +112,102 @@ describe('nextStage / previousStage', () => {
 
   test('previousStage returns null at start', () => {
     expect(service.previousStage('backlog')).toBeNull();
+  });
+});
+
+// ─── item status.json helpers ───────────────────────────────────────────────
+
+describe('item status.json helpers', () => {
+  const SLUG = 'test-item';
+
+  function seedItemDir(): string {
+    const dir = path.join(tmpDir, 'tracker', 'items', SLUG);
+    fs.mkdirSync(dir, {recursive: true});
+    return dir;
+  }
+
+  test('getItemStatus returns null when file is absent', () => {
+    seedItemDir();
+    expect(service.getItemStatus(tmpDir, SLUG)).toBeNull();
+  });
+
+  test('writeItemStatus round-trips through getItemStatus', () => {
+    seedItemDir();
+    const now = new Date().toISOString();
+    const status: ItemStatus = {
+      stage: 'discovery',
+      is_waiting_for_user: true,
+      brief_description: 'need approval on notes.md',
+      timestamp: now,
+    };
+    service.writeItemStatus(tmpDir, SLUG, status);
+    const roundTripped = service.getItemStatus(tmpDir, SLUG);
+    expect(roundTripped).toEqual(status);
+  });
+
+  test('writeItemStatus creates the item dir when missing and writes there', () => {
+    const status: ItemStatus = {
+      stage: 'backlog',
+      is_waiting_for_user: false,
+      brief_description: 'working',
+      timestamp: new Date().toISOString(),
+    };
+    service.writeItemStatus(tmpDir, SLUG, status);
+    const written = path.join(tmpDir, 'tracker', 'items', SLUG, 'status.json');
+    expect(fs.existsSync(written)).toBe(true);
+  });
+
+  test('writeItemStatus truncates brief_description to 120 chars', () => {
+    seedItemDir();
+    const longReason = 'x'.repeat(500);
+    service.writeItemStatus(tmpDir, SLUG, {
+      stage: 'requirements',
+      is_waiting_for_user: true,
+      brief_description: longReason,
+      timestamp: new Date().toISOString(),
+    });
+    const read = service.getItemStatus(tmpDir, SLUG);
+    expect(read?.brief_description.length).toBe(120);
+  });
+
+  test('getItemStatus returns null on malformed JSON', () => {
+    const dir = seedItemDir();
+    fs.writeFileSync(path.join(dir, 'status.json'), 'not json {{{');
+    expect(service.getItemStatus(tmpDir, SLUG)).toBeNull();
+  });
+
+  test('getItemStatus returns null when required fields are missing', () => {
+    const dir = seedItemDir();
+    fs.writeFileSync(path.join(dir, 'status.json'), JSON.stringify({stage: 'discovery'}));
+    expect(service.getItemStatus(tmpDir, SLUG)).toBeNull();
+  });
+
+  test('isItemStatusStale is true when timestamp is older than 24h', () => {
+    const old = new Date(Date.now() - ITEM_STATUS_STALE_MS - 1000).toISOString();
+    expect(service.isItemStatusStale({
+      stage: 'implement',
+      is_waiting_for_user: true,
+      brief_description: '',
+      timestamp: old,
+    })).toBe(true);
+  });
+
+  test('isItemStatusStale is false for a fresh timestamp', () => {
+    expect(service.isItemStatusStale({
+      stage: 'implement',
+      is_waiting_for_user: true,
+      brief_description: '',
+      timestamp: new Date().toISOString(),
+    })).toBe(false);
+  });
+
+  test('isItemStatusStale is true when timestamp is unparseable', () => {
+    expect(service.isItemStatusStale({
+      stage: 'implement',
+      is_waiting_for_user: true,
+      brief_description: '',
+      timestamp: 'not-a-date',
+    })).toBe(true);
   });
 });
 

--- a/tests/unit/tracker.test.ts
+++ b/tests/unit/tracker.test.ts
@@ -747,7 +747,7 @@ describe('defaultStageFileContent', () => {
 
   test('requirements: style=interview asks questions before drafting', () => {
     const content = service.defaultStageFileContent('requirements', {style: 'interview'});
-    expect(content).toContain('ask targeted questions');
+    expect(content).toMatch(/ask targeted questions/i);
   });
 
   test('requirements: style=draft_first drafts before asking', () => {
@@ -761,19 +761,6 @@ describe('defaultStageFileContent', () => {
     expect(thorough).toContain('Constraints');
     expect(thorough).toContain('Dependencies');
     expect(minimal).not.toContain('Constraints');
-  });
-
-  test('requirements: user_stories=lead puts user stories first in output', () => {
-    const content = service.defaultStageFileContent('requirements', {user_stories: 'lead'});
-    const storiesIdx = content.indexOf('User stories');
-    const summaryIdx = content.indexOf('Summary');
-    expect(storiesIdx).toBeGreaterThan(-1);
-    expect(storiesIdx).toBeLessThan(summaryIdx);
-  });
-
-  test('requirements: approval=per_section mentions section approval', () => {
-    const content = service.defaultStageFileContent('requirements', {approval: 'per_section'});
-    expect(content).toContain('approval');
   });
 
   test('requirements: min words varies by detail level', () => {
@@ -859,17 +846,17 @@ describe('defaultStageFileContent', () => {
     expect(content).toContain('Write new docs');
   });
 
-  test('non-discovery stages include advancing instructions referencing index.json', () => {
-    // Discovery now signals advancement via a heading in requirements.md (auto-detected),
-    // so it doesn't need to mention index.json itself.
-    for (const stage of ['requirements', 'implement', 'cleanup'] as const) {
+  test('implement + cleanup include advancing instructions referencing index.json', () => {
+    // Discovery and requirements now rely on status.json (set via the
+    // protocol tail) to advance — they don't repeat index.json guidance.
+    for (const stage of ['implement', 'cleanup'] as const) {
       const content = service.defaultStageFileContent(stage);
       expect(content).toContain('index.json');
     }
   });
 
   test('advancing instructions describe paths as relative / from prompt', () => {
-    for (const stage of ['requirements', 'implement', 'cleanup'] as const) {
+    for (const stage of ['implement', 'cleanup'] as const) {
       const content = service.defaultStageFileContent(stage);
       expect(content).toMatch(/path in (the )?prompt|relative path|path.*prompt/i);
     }

--- a/tests/unit/tracker.test.ts
+++ b/tests/unit/tracker.test.ts
@@ -2,7 +2,7 @@ import {describe, test, expect, beforeEach, afterEach} from '@jest/globals';
 import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
-import {TrackerService, parseFrontmatter, DEFAULT_WORK_STYLE, TrackerItem, StageConfig, WorkStyle, ItemStatus, ITEM_STATUS_STALE_MS} from '../../src/services/TrackerService.js';
+import {TrackerService, parseFrontmatter, DEFAULT_WORK_STYLE, TrackerItem, StageConfig, WorkStyle, InputModeStyle, ItemStatus, ITEM_STATUS_STALE_MS} from '../../src/services/TrackerService.js';
 
 let tmpDir: string;
 let service: TrackerService;
@@ -303,7 +303,7 @@ describe('defaultStageFileContent renders status + gate protocol', () => {
   });
 
   test.each(STAGES)('every stage renders Input mode + Gate on advance sections', (stage) => {
-    const content = service.defaultStageFileContent(stage, {});
+    const content = service.defaultStageFileContent(stage, {}, DEFAULT_WORK_STYLE);
     expect(content).toContain('Input mode:');
     expect(content).toContain('Gate on advance:');
   });
@@ -313,8 +313,9 @@ describe('defaultStageFileContent renders status + gate protocol', () => {
     ['inline', 'Inline'],
     ['batch', 'Batch'],
     ['doc_review', 'review'],
-  ] as const)('input_mode=%s renders mode-specific guidance', (mode, needle) => {
-    const content = service.defaultStageFileContent('discovery', {input_mode: mode});
+  ] as const)('inputMode (global style) = %s renders mode-specific guidance', (mode, needle) => {
+    const ws: WorkStyle = {...DEFAULT_WORK_STYLE, inputMode: mode as InputModeStyle};
+    const content = service.defaultStageFileContent('discovery', {}, ws);
     expect(content).toMatch(new RegExp(needle, 'i'));
   });
 

--- a/tests/unit/tracker.test.ts
+++ b/tests/unit/tracker.test.ts
@@ -182,6 +182,17 @@ describe('item status.json helpers', () => {
     expect(service.getItemStatus(tmpDir, SLUG)).toBeNull();
   });
 
+  test('getItemStatus rejects a stage value outside the known enum (path-traversal safety)', () => {
+    const dir = seedItemDir();
+    const ts = new Date().toISOString();
+    for (const badStage of ['../../evil', 'archive', 'unknown_stage', '']) {
+      fs.writeFileSync(path.join(dir, 'status.json'), JSON.stringify({
+        stage: badStage, state: 'working', brief_description: '', timestamp: ts,
+      }));
+      expect(service.getItemStatus(tmpDir, SLUG)).toBeNull();
+    }
+  });
+
   test('getItemStatus accepts the three state values', () => {
     const dir = seedItemDir();
     const ts = new Date().toISOString();

--- a/tests/unit/tracker.test.ts
+++ b/tests/unit/tracker.test.ts
@@ -157,7 +157,7 @@ describe('item status.json helpers', () => {
     expect(fs.existsSync(written)).toBe(true);
   });
 
-  test('writeItemStatus truncates brief_description to 120 chars', () => {
+  test('writeItemStatus truncates brief_description to 200 chars', () => {
     seedItemDir();
     const longReason = 'x'.repeat(500);
     service.writeItemStatus(tmpDir, SLUG, {
@@ -167,7 +167,7 @@ describe('item status.json helpers', () => {
       timestamp: new Date().toISOString(),
     });
     const read = service.getItemStatus(tmpDir, SLUG);
-    expect(read?.brief_description.length).toBe(120);
+    expect(read?.brief_description.length).toBe(200);
   });
 
   test('getItemStatus returns null on malformed JSON', () => {

--- a/tests/unit/tracker.test.ts
+++ b/tests/unit/tracker.test.ts
@@ -324,10 +324,42 @@ describe('defaultStageFileContent renders status + gate protocol', () => {
     expect(content).toContain('is_waiting_for_user');
   });
 
-  test.each(STAGES)('every stage renders Input mode + Gate on advance sections', (stage) => {
+  test.each(STAGES)('every stage renders the Input mode section', (stage) => {
     const content = service.defaultStageFileContent(stage, {}, DEFAULT_WORK_STYLE);
     expect(content).toContain('Input mode:');
-    expect(content).toContain('Gate on advance:');
+  });
+
+  test('non-discovery stages render the generic Gate on advance section', () => {
+    for (const stage of ['requirements', 'implement', 'cleanup'] as const) {
+      const content = service.defaultStageFileContent(stage, {}, DEFAULT_WORK_STYLE);
+      expect(content).toContain('Gate on advance:');
+    }
+  });
+
+  test('discovery does NOT render the generic Gate on advance section (report supersedes)', () => {
+    const content = service.defaultStageFileContent('discovery', {}, DEFAULT_WORK_STYLE);
+    expect(content).not.toContain('Gate on advance:');
+    // Points the reader at the Report setting instead.
+    expect(content).toMatch(/Report/);
+  });
+
+  test('discovery effort + report render the matching body', () => {
+    const skim = service.defaultStageFileContent('discovery', {effort: 'skim'});
+    expect(skim).toMatch(/Skim/);
+    const deep = service.defaultStageFileContent('discovery', {effort: 'deep'});
+    expect(deep).toMatch(/thorough/i);
+    const silent = service.defaultStageFileContent('discovery', {report: 'just_advance'});
+    expect(silent).toMatch(/advance silently/i);
+    const notable = service.defaultStageFileContent('discovery', {report: 'confirm_if_notable'});
+    expect(notable).toMatch(/notable/i);
+    const always = service.defaultStageFileContent('discovery', {report: 'always_confirm'});
+    expect(always).toMatch(/wait for approval/i);
+  });
+
+  test('discovery guide bakes in the trivial-skip + narrow-questions defaults', () => {
+    const content = service.defaultStageFileContent('discovery', {}, DEFAULT_WORK_STYLE);
+    expect(content).toMatch(/Trivial items/i);
+    expect(content).toMatch(/Clarifying questions/i);
   });
 
   test.each([
@@ -350,15 +382,17 @@ describe('defaultStageFileContent renders status + gate protocol', () => {
   });
 
   test('auto_advance also tells the agent to skip review for trivial stages', () => {
-    const content = service.defaultStageFileContent('discovery', {gate_on_advance: 'auto_advance'});
+    // implement (not discovery) — discovery has its own Report setting that
+    // supersedes the common gate_on_advance.
+    const content = service.defaultStageFileContent('implement', {gate_on_advance: 'auto_advance'});
     expect(content).toMatch(/skip the review/i);
   });
 
-  test('legacy gate values are mapped to the new shape', () => {
+  test('legacy gate values are mapped to the new shape (non-discovery stages)', () => {
     // Old configs saying 'none' or 'review_and_advance' both mean auto_advance.
-    const fromNone = service.defaultStageFileContent('discovery', {gate_on_advance: 'none'});
-    const fromReview = service.defaultStageFileContent('discovery', {gate_on_advance: 'review_and_advance'});
-    const fromWait = service.defaultStageFileContent('discovery', {gate_on_advance: 'wait_for_approval'});
+    const fromNone = service.defaultStageFileContent('implement', {gate_on_advance: 'none'});
+    const fromReview = service.defaultStageFileContent('implement', {gate_on_advance: 'review_and_advance'});
+    const fromWait = service.defaultStageFileContent('implement', {gate_on_advance: 'wait_for_approval'});
     expect(fromNone).toMatch(/auto_advance/);
     expect(fromReview).toMatch(/auto_advance/);
     expect(fromWait).toMatch(/require_approval/);
@@ -376,18 +410,15 @@ describe('defaultStageFileContent renders status + gate protocol', () => {
     expect(content).toMatch(/automatically/i);
   });
 
-  test('auto_advance gate references the stage\'s output file for the review', () => {
-    const disc = service.defaultStageFileContent('discovery', {gate_on_advance: 'auto_advance'});
-    expect(disc).toContain('notes.md');
+  test('auto_advance gate references the stage\'s output file for the review (non-discovery)', () => {
     const req = service.defaultStageFileContent('requirements', {gate_on_advance: 'auto_advance'});
     expect(req).toContain('requirements.md');
     const impl = service.defaultStageFileContent('implement', {gate_on_advance: 'auto_advance'});
     expect(impl).toContain('implementation.md');
   });
 
-  test('gate defaults: requirements and cleanup require approval, discovery and implement auto-advance', () => {
-    const disc = service.defaultStageFileContent('discovery', {});
-    expect(disc).toMatch(/Gate on advance: `auto_advance`/);
+  test('gate defaults: requirements + cleanup require approval, implement auto-advances', () => {
+    // Discovery has its own Report setting (no common gate), so not asserted here.
     const req = service.defaultStageFileContent('requirements', {});
     expect(req).toMatch(/Gate on advance: `require_approval`/);
     const impl = service.defaultStageFileContent('implement', {});
@@ -637,25 +668,25 @@ describe('loadStagesConfig / saveStageSettings', () => {
   });
 
   test('saveStageSettings persists and merges', () => {
-    service.saveStageSettings(tmpDir, 'discovery', {depth: 'thorough', skip: 'always_run'});
+    service.saveStageSettings(tmpDir, 'discovery', {effort: 'deep', report: 'always_confirm'});
     const config = service.loadStagesConfig(tmpDir);
-    expect(config.discovery.settings?.depth).toBe('thorough');
-    expect(config.discovery.settings?.skip).toBe('always_run');
+    expect(config.discovery.settings?.effort).toBe('deep');
+    expect(config.discovery.settings?.report).toBe('always_confirm');
   });
 
   test('saveStageSettings merges without overwriting other keys', () => {
-    service.saveStageSettings(tmpDir, 'discovery', {depth: 'quick'});
-    service.saveStageSettings(tmpDir, 'discovery', {skip: 'if_obvious'});
+    service.saveStageSettings(tmpDir, 'discovery', {effort: 'skim'});
+    service.saveStageSettings(tmpDir, 'discovery', {report: 'just_advance'});
     const config = service.loadStagesConfig(tmpDir);
-    expect(config.discovery.settings?.depth).toBe('quick');
-    expect(config.discovery.settings?.skip).toBe('if_obvious');
+    expect(config.discovery.settings?.effort).toBe('skim');
+    expect(config.discovery.settings?.report).toBe('just_advance');
   });
 
   test('settings for different stages are independent', () => {
-    service.saveStageSettings(tmpDir, 'discovery', {depth: 'quick'});
+    service.saveStageSettings(tmpDir, 'discovery', {effort: 'skim'});
     service.saveStageSettings(tmpDir, 'implement', {tdd: 'required'});
     const config = service.loadStagesConfig(tmpDir);
-    expect(config.discovery.settings?.depth).toBe('quick');
+    expect(config.discovery.settings?.effort).toBe('skim');
     expect(config.implement.settings?.tdd).toBe('required');
     expect(config.discovery.settings?.tdd).toBeUndefined();
   });
@@ -689,46 +720,29 @@ describe('defaultStageFileContent', () => {
     expect(content).toContain('Stop here');
   });
 
-  test('discovery: always_skip produces minimal short instructions', () => {
-    // The protocol suffix intentionally mentions ask_questions as the default
-    // input mode; scope the "must not appear" assertions to the body only.
-    const body = service.defaultStageFileContent('discovery', {skip: 'always_skip'}).split('## Agent status protocol')[0];
-    expect(body).toContain('always skip');
-    expect(body).not.toContain('codebase scan');
-    expect(body).not.toContain('ask_questions');
+  test('discovery: effort=skim stays minimal (no codebase-scan or web-search prose)', () => {
+    const body = service.defaultStageFileContent('discovery', {effort: 'skim'}).split('## Agent status protocol')[0];
+    expect(body).toContain('Skim codebase');
+    expect(body).not.toContain('Thorough codebase scan');
+    expect(body).not.toContain('Web research');
   });
 
-  test('discovery: depth=quick omits codebase scan', () => {
-    const content = service.defaultStageFileContent('discovery', {depth: 'quick', skip: 'always_run'});
-    expect(content).not.toContain('codebase scan');
+  test('discovery: effort=deep includes thorough codebase + web research prose', () => {
+    const content = service.defaultStageFileContent('discovery', {effort: 'deep'});
+    expect(content).toContain('Thorough codebase scan');
+    expect(content).toContain('Web research');
   });
 
-  test('discovery: depth=thorough includes codebase scan and web search', () => {
-    const content = service.defaultStageFileContent('discovery', {depth: 'thorough', skip: 'always_run', web_search: 'if_needed'});
-    expect(content).toContain('Scan the codebase');
-    expect(content).toContain('web search');
+  test('discovery: output fields vary by effort', () => {
+    const skim = service.defaultStageFileContent('discovery', {effort: 'skim'});
+    const deep = service.defaultStageFileContent('discovery', {effort: 'deep'});
+    expect(skim).not.toContain('Options');
+    expect(deep).toContain('Options');
   });
 
-  test('discovery: questions=none skips ask_questions step', () => {
-    const body = service.defaultStageFileContent('discovery', {depth: 'normal', skip: 'always_run', questions: 'none'}).split('## Agent status protocol')[0];
-    expect(body).not.toContain('ask_questions');
-  });
-
-  test('discovery: questions=standard includes ask_questions step', () => {
-    const content = service.defaultStageFileContent('discovery', {depth: 'normal', skip: 'always_run', questions: 'standard'});
-    expect(content).toContain('ask_questions');
-  });
-
-  test('discovery: output fields vary by depth', () => {
-    const quick = service.defaultStageFileContent('discovery', {depth: 'quick', skip: 'always_run'});
-    const thorough = service.defaultStageFileContent('discovery', {depth: 'thorough', skip: 'always_run'});
-    expect(quick).not.toContain('Options considered');
-    expect(thorough).toContain('Options considered');
-  });
-
-  test('discovery: skip=if_obvious adds a skip notice', () => {
-    const content = service.defaultStageFileContent('discovery', {skip: 'if_obvious'});
-    expect(content).toContain('obvious');
+  test('discovery: the trivial-item skip rule is always surfaced', () => {
+    const content = service.defaultStageFileContent('discovery', {});
+    expect(content).toMatch(/Trivial items/i);
   });
 
   test('requirements: style=interview asks questions before drafting', () => {

--- a/tests/unit/tracker.test.ts
+++ b/tests/unit/tracker.test.ts
@@ -139,10 +139,32 @@ describe('item status.json helpers', () => {
       is_waiting_for_user: true,
       brief_description: 'need approval on notes.md',
       timestamp: now,
+      awaiting_advance_approval: false,
     };
     service.writeItemStatus(tmpDir, SLUG, status);
     const roundTripped = service.getItemStatus(tmpDir, SLUG);
     expect(roundTripped).toEqual(status);
+  });
+
+  test('awaiting_advance_approval round-trips and defaults to false when absent', () => {
+    seedItemDir();
+    service.writeItemStatus(tmpDir, SLUG, {
+      stage: 'requirements',
+      is_waiting_for_user: true,
+      awaiting_advance_approval: true,
+      brief_description: 'ready to review requirements.md',
+      timestamp: new Date().toISOString(),
+    });
+    const read = service.getItemStatus(tmpDir, SLUG);
+    expect(read?.awaiting_advance_approval).toBe(true);
+    // Writing one without the flag stores false.
+    service.writeItemStatus(tmpDir, SLUG, {
+      stage: 'requirements',
+      is_waiting_for_user: false,
+      brief_description: 'drafting',
+      timestamp: new Date().toISOString(),
+    });
+    expect(service.getItemStatus(tmpDir, SLUG)?.awaiting_advance_approval).toBe(false);
   });
 
   test('writeItemStatus creates the item dir when missing and writes there', () => {
@@ -372,6 +394,20 @@ describe('defaultStageFileContent renders status + gate protocol', () => {
     expect(impl).toMatch(/Gate on advance: `auto_advance`/);
     const clean = service.defaultStageFileContent('cleanup', {});
     expect(clean).toMatch(/Gate on advance: `require_approval`/);
+  });
+
+  test('require_approval gate instructs the agent to set awaiting_advance_approval', () => {
+    const content = service.defaultStageFileContent('requirements', {gate_on_advance: 'require_approval'});
+    expect(content).toContain('awaiting_advance_approval');
+  });
+
+  test('protocol tells the agent brief_description is about substance, not the stage', () => {
+    const content = service.defaultStageFileContent('requirements', {});
+    expect(content).toMatch(/substance/i);
+    // The good/bad examples must both be present so the message can't be
+    // misread as "describe the stage".
+    expect(content).toMatch(/Good:/);
+    expect(content).toMatch(/Not useful:/);
   });
 });
 

--- a/tests/unit/tracker.test.ts
+++ b/tests/unit/tracker.test.ts
@@ -320,12 +320,26 @@ describe('defaultStageFileContent renders status + gate protocol', () => {
   });
 
   test.each([
-    ['none', 'silently'],
-    ['review_and_advance', 'Stage review'],
-    ['wait_for_approval', 'approval'],
+    ['auto_advance', 'Stage review'],
+    ['require_approval', 'approval'],
   ] as const)('gate_on_advance=%s renders the right gate text', (gate, needle) => {
     const content = service.defaultStageFileContent('requirements', {gate_on_advance: gate});
     expect(content).toMatch(new RegExp(needle, 'i'));
+  });
+
+  test('auto_advance also tells the agent to skip review for trivial stages', () => {
+    const content = service.defaultStageFileContent('discovery', {gate_on_advance: 'auto_advance'});
+    expect(content).toMatch(/skip the review/i);
+  });
+
+  test('legacy gate values are mapped to the new shape', () => {
+    // Old configs saying 'none' or 'review_and_advance' both mean auto_advance.
+    const fromNone = service.defaultStageFileContent('discovery', {gate_on_advance: 'none'});
+    const fromReview = service.defaultStageFileContent('discovery', {gate_on_advance: 'review_and_advance'});
+    const fromWait = service.defaultStageFileContent('discovery', {gate_on_advance: 'wait_for_approval'});
+    expect(fromNone).toMatch(/auto_advance/);
+    expect(fromReview).toMatch(/auto_advance/);
+    expect(fromWait).toMatch(/require_approval/);
   });
 
   test('submit=approve adds a submit gate to cleanup', () => {
@@ -340,22 +354,24 @@ describe('defaultStageFileContent renders status + gate protocol', () => {
     expect(content).toMatch(/automatically/i);
   });
 
-  test('review_and_advance gate references the stage\'s output file', () => {
-    const disc = service.defaultStageFileContent('discovery', {gate_on_advance: 'review_and_advance'});
+  test('auto_advance gate references the stage\'s output file for the review', () => {
+    const disc = service.defaultStageFileContent('discovery', {gate_on_advance: 'auto_advance'});
     expect(disc).toContain('notes.md');
-    const req = service.defaultStageFileContent('requirements', {gate_on_advance: 'review_and_advance'});
+    const req = service.defaultStageFileContent('requirements', {gate_on_advance: 'auto_advance'});
     expect(req).toContain('requirements.md');
-    const impl = service.defaultStageFileContent('implement', {gate_on_advance: 'review_and_advance'});
+    const impl = service.defaultStageFileContent('implement', {gate_on_advance: 'auto_advance'});
     expect(impl).toContain('implementation.md');
   });
 
-  test('gate defaults: requirements and cleanup default to wait_for_approval, implement to review_and_advance', () => {
+  test('gate defaults: requirements and cleanup require approval, discovery and implement auto-advance', () => {
+    const disc = service.defaultStageFileContent('discovery', {});
+    expect(disc).toMatch(/Gate on advance: `auto_advance`/);
     const req = service.defaultStageFileContent('requirements', {});
-    expect(req).toMatch(/Gate on advance: `wait_for_approval`/);
-    const clean = service.defaultStageFileContent('cleanup', {});
-    expect(clean).toMatch(/Gate on advance: `wait_for_approval`/);
+    expect(req).toMatch(/Gate on advance: `require_approval`/);
     const impl = service.defaultStageFileContent('implement', {});
-    expect(impl).toMatch(/Gate on advance: `review_and_advance`/);
+    expect(impl).toMatch(/Gate on advance: `auto_advance`/);
+    const clean = service.defaultStageFileContent('cleanup', {});
+    expect(clean).toMatch(/Gate on advance: `require_approval`/);
   });
 });
 

--- a/tests/unit/tracker.test.ts
+++ b/tests/unit/tracker.test.ts
@@ -136,41 +136,19 @@ describe('item status.json helpers', () => {
     const now = new Date().toISOString();
     const status: ItemStatus = {
       stage: 'discovery',
-      is_waiting_for_user: true,
+      state: 'waiting_for_input',
       brief_description: 'need approval on notes.md',
       timestamp: now,
-      awaiting_advance_approval: false,
     };
     service.writeItemStatus(tmpDir, SLUG, status);
     const roundTripped = service.getItemStatus(tmpDir, SLUG);
     expect(roundTripped).toEqual(status);
   });
 
-  test('awaiting_advance_approval round-trips and defaults to false when absent', () => {
-    seedItemDir();
-    service.writeItemStatus(tmpDir, SLUG, {
-      stage: 'requirements',
-      is_waiting_for_user: true,
-      awaiting_advance_approval: true,
-      brief_description: 'ready to review requirements.md',
-      timestamp: new Date().toISOString(),
-    });
-    const read = service.getItemStatus(tmpDir, SLUG);
-    expect(read?.awaiting_advance_approval).toBe(true);
-    // Writing one without the flag stores false.
-    service.writeItemStatus(tmpDir, SLUG, {
-      stage: 'requirements',
-      is_waiting_for_user: false,
-      brief_description: 'drafting',
-      timestamp: new Date().toISOString(),
-    });
-    expect(service.getItemStatus(tmpDir, SLUG)?.awaiting_advance_approval).toBe(false);
-  });
-
   test('writeItemStatus creates the item dir when missing and writes there', () => {
     const status: ItemStatus = {
       stage: 'backlog',
-      is_waiting_for_user: false,
+      state: 'working',
       brief_description: 'working',
       timestamp: new Date().toISOString(),
     };
@@ -184,7 +162,7 @@ describe('item status.json helpers', () => {
     const longReason = 'x'.repeat(500);
     service.writeItemStatus(tmpDir, SLUG, {
       stage: 'requirements',
-      is_waiting_for_user: true,
+      state: 'waiting_for_input',
       brief_description: longReason,
       timestamp: new Date().toISOString(),
     });
@@ -204,11 +182,45 @@ describe('item status.json helpers', () => {
     expect(service.getItemStatus(tmpDir, SLUG)).toBeNull();
   });
 
+  test('getItemStatus accepts the three state values', () => {
+    const dir = seedItemDir();
+    const ts = new Date().toISOString();
+    for (const state of ['working', 'waiting_for_input', 'waiting_for_approval'] as const) {
+      fs.writeFileSync(path.join(dir, 'status.json'), JSON.stringify({
+        stage: 'implement', state, brief_description: '', timestamp: ts,
+      }));
+      expect(service.getItemStatus(tmpDir, SLUG)?.state).toBe(state);
+    }
+  });
+
+  test('getItemStatus maps legacy boolean schema to the new state enum', () => {
+    const dir = seedItemDir();
+    const ts = new Date().toISOString();
+    // Old single-bool schema: waiting → waiting_for_input.
+    fs.writeFileSync(path.join(dir, 'status.json'), JSON.stringify({
+      stage: 'implement', is_waiting_for_user: true, brief_description: '', timestamp: ts,
+    }));
+    expect(service.getItemStatus(tmpDir, SLUG)?.state).toBe('waiting_for_input');
+
+    // Old dual-bool schema: awaiting_advance_approval wins → waiting_for_approval.
+    fs.writeFileSync(path.join(dir, 'status.json'), JSON.stringify({
+      stage: 'implement', is_waiting_for_user: true, awaiting_advance_approval: true,
+      brief_description: '', timestamp: ts,
+    }));
+    expect(service.getItemStatus(tmpDir, SLUG)?.state).toBe('waiting_for_approval');
+
+    // Not waiting at all → working.
+    fs.writeFileSync(path.join(dir, 'status.json'), JSON.stringify({
+      stage: 'implement', is_waiting_for_user: false, brief_description: '', timestamp: ts,
+    }));
+    expect(service.getItemStatus(tmpDir, SLUG)?.state).toBe('working');
+  });
+
   test('isItemStatusStale is true when timestamp is older than 24h', () => {
     const old = new Date(Date.now() - ITEM_STATUS_STALE_MS - 1000).toISOString();
     expect(service.isItemStatusStale({
       stage: 'implement',
-      is_waiting_for_user: true,
+      state: 'waiting_for_input',
       brief_description: '',
       timestamp: old,
     })).toBe(true);
@@ -217,7 +229,7 @@ describe('item status.json helpers', () => {
   test('isItemStatusStale is false for a fresh timestamp', () => {
     expect(service.isItemStatusStale({
       stage: 'implement',
-      is_waiting_for_user: true,
+      state: 'waiting_for_input',
       brief_description: '',
       timestamp: new Date().toISOString(),
     })).toBe(false);
@@ -226,7 +238,7 @@ describe('item status.json helpers', () => {
   test('isItemStatusStale is true when timestamp is unparseable', () => {
     expect(service.isItemStatusStale({
       stage: 'implement',
-      is_waiting_for_user: true,
+      state: 'waiting_for_input',
       brief_description: '',
       timestamp: 'not-a-date',
     })).toBe(true);
@@ -243,7 +255,7 @@ describe('getItemStage / listItemsByStage', () => {
     // index.json has it in discovery, status.json will report implement
     service.writeItemStatus(tmpDir, SLUG, {
       stage: 'implement',
-      is_waiting_for_user: false,
+      state: 'working',
       brief_description: 'writing code',
       timestamp: new Date().toISOString(),
     });
@@ -265,7 +277,7 @@ describe('getItemStage / listItemsByStage', () => {
     service.createItem(tmpDir, 'Two', 'implement', 'two');
     service.writeItemStatus(tmpDir, 'one', {
       stage: 'requirements',
-      is_waiting_for_user: false,
+      state: 'working',
       brief_description: '',
       timestamp: new Date().toISOString(),
     });
@@ -283,22 +295,25 @@ describe('moveItem mirrors stage into status.json', () => {
     expect(service.moveItem(tmpDir, 'moves', 'requirements')).toBe(true);
     const status = service.getItemStatus(tmpDir, 'moves');
     expect(status?.stage).toBe('requirements');
-    expect(status?.is_waiting_for_user).toBe(false);
+    expect(status?.state).toBe('working');
   });
 
-  test('preserves is_waiting_for_user across a move', () => {
-    service.createItem(tmpDir, 'Waiting', 'discovery', 'waits');
-    service.writeItemStatus(tmpDir, 'waits', {
-      stage: 'discovery',
-      is_waiting_for_user: true,
-      brief_description: 'pre-move wait',
+  test('advancing resets state to working and clears brief_description', () => {
+    // Advancing is typically the approval of a waiting_for_approval state —
+    // the previous brief ("caching layer complete") describes finished work,
+    // so the new stage should start fresh.
+    service.createItem(tmpDir, 'Approved', 'implement', 'approved');
+    service.writeItemStatus(tmpDir, 'approved', {
+      stage: 'implement',
+      state: 'waiting_for_approval',
+      brief_description: 'caching layer complete',
       timestamp: new Date().toISOString(),
     });
-    service.moveItem(tmpDir, 'waits', 'requirements');
-    const status = service.getItemStatus(tmpDir, 'waits');
-    expect(status?.stage).toBe('requirements');
-    expect(status?.is_waiting_for_user).toBe(true);
-    expect(status?.brief_description).toBe('pre-move wait');
+    service.moveItem(tmpDir, 'approved', 'cleanup');
+    const status = service.getItemStatus(tmpDir, 'approved');
+    expect(status?.stage).toBe('cleanup');
+    expect(status?.state).toBe('working');
+    expect(status?.brief_description).toBe('');
   });
 
   test('archive move does not write status.json', () => {
@@ -321,7 +336,9 @@ describe('defaultStageFileContent renders status + gate protocol', () => {
     const content = service.defaultStageFileContent(stage, {});
     expect(content).toContain('Agent status protocol');
     expect(content).toContain('status.json');
-    expect(content).toContain('is_waiting_for_user');
+    // The three-state enum is the canonical waiting signal.
+    expect(content).toContain('waiting_for_input');
+    expect(content).toContain('waiting_for_approval');
   });
 
   test.each(STAGES)('every stage renders the Input mode section', (stage) => {
@@ -427,9 +444,10 @@ describe('defaultStageFileContent renders status + gate protocol', () => {
     expect(clean).toMatch(/Gate on advance: `require_approval`/);
   });
 
-  test('require_approval gate instructs the agent to set awaiting_advance_approval', () => {
+  test('require_approval gate tells the agent to use waiting_for_approval state', () => {
     const content = service.defaultStageFileContent('requirements', {gate_on_advance: 'require_approval'});
-    expect(content).toContain('awaiting_advance_approval');
+    expect(content).toContain('waiting_for_approval');
+    expect(content).toMatch(/do not update.*stage.*until.*approves/i);
   });
 
   test('protocol tells the agent brief_description is about substance, not the stage', () => {
@@ -695,31 +713,6 @@ describe('loadStagesConfig / saveStageSettings', () => {
 // ─── defaultStageFileContent ─────────────────────────────────────────────────
 
 describe('defaultStageFileContent', () => {
-  test('backlog: default content has goal and steps', () => {
-    const content = service.defaultStageFileContent('backlog');
-    expect(content).toContain('# Stage 1: Backlog');
-    expect(content).toContain('Goal');
-    expect(content).toContain('Steps');
-    expect(content).toContain('Advancing');
-  });
-
-  test('backlog: effort_estimate=skip omits effort step', () => {
-    const withSkip = service.defaultStageFileContent('backlog', {effort_estimate: 'skip'});
-    const withRough = service.defaultStageFileContent('backlog', {effort_estimate: 'rough'});
-    expect(withSkip).not.toContain('t-shirt');
-    expect(withRough).toContain('t-shirt');
-  });
-
-  test('backlog: auto_discover=auto says advance automatically', () => {
-    const content = service.defaultStageFileContent('backlog', {auto_discover: 'auto'});
-    expect(content).toContain('automatically');
-  });
-
-  test('backlog: auto_discover=manual says stop here', () => {
-    const content = service.defaultStageFileContent('backlog', {auto_discover: 'manual'});
-    expect(content).toContain('Stop here');
-  });
-
   test('discovery: effort=skim stays minimal (no codebase-scan or web-search prose)', () => {
     const body = service.defaultStageFileContent('discovery', {effort: 'skim'}).split('## Agent status protocol')[0];
     expect(body).toContain('Skim codebase');
@@ -869,7 +862,7 @@ describe('ensureStageFiles', () => {
   test('creates all stage files and overview', () => {
     service.ensureStageFiles(tmpDir);
     const stagesDir = service.getStagesDir(tmpDir);
-    expect(fs.existsSync(path.join(stagesDir, '0-overview.md'))).toBe(true);
+    expect(fs.existsSync(path.join(stagesDir, 'overview.md'))).toBe(true);
     for (const stage of ['discovery', 'requirements', 'implement', 'cleanup'] as const) {
       expect(fs.existsSync(service.getStageFilePath(tmpDir, stage))).toBe(true);
     }

--- a/tests/unit/tracker.test.ts
+++ b/tests/unit/tracker.test.ts
@@ -211,6 +211,153 @@ describe('item status.json helpers', () => {
   });
 });
 
+// ─── stage derivation (status.json + index.json) ────────────────────────────
+
+describe('getItemStage / listItemsByStage', () => {
+  const SLUG = 'has-status';
+
+  test('getItemStage prefers status.json over index.json', () => {
+    service.createItem(tmpDir, 'Has Status', 'discovery', SLUG);
+    // index.json has it in discovery, status.json will report implement
+    service.writeItemStatus(tmpDir, SLUG, {
+      stage: 'implement',
+      is_waiting_for_user: false,
+      brief_description: 'writing code',
+      timestamp: new Date().toISOString(),
+    });
+    expect(service.getItemStage(tmpDir, SLUG)).toBe('implement');
+  });
+
+  test('getItemStage falls back to index.json when status.json is missing', () => {
+    service.createItem(tmpDir, 'No Status', 'requirements', 'no-status');
+    expect(service.getItemStage(tmpDir, 'no-status')).toBe('requirements');
+  });
+
+  test('getItemStage returns backlog for unknown slugs', () => {
+    service.ensureTracker(tmpDir);
+    expect(service.getItemStage(tmpDir, 'never-existed')).toBe('backlog');
+  });
+
+  test('listItemsByStage overrides index with status.json stage', () => {
+    service.createItem(tmpDir, 'One', 'discovery', 'one');
+    service.createItem(tmpDir, 'Two', 'implement', 'two');
+    service.writeItemStatus(tmpDir, 'one', {
+      stage: 'requirements',
+      is_waiting_for_user: false,
+      brief_description: '',
+      timestamp: new Date().toISOString(),
+    });
+    const out = service.listItemsByStage(tmpDir);
+    expect(out.get('one')).toBe('requirements');
+    expect(out.get('two')).toBe('implement');
+  });
+});
+
+// ─── moveItem writes status.json ────────────────────────────────────────────
+
+describe('moveItem mirrors stage into status.json', () => {
+  test('moves across stages and writes a fresh status.json', () => {
+    service.createItem(tmpDir, 'Moves Around', 'discovery', 'moves');
+    expect(service.moveItem(tmpDir, 'moves', 'requirements')).toBe(true);
+    const status = service.getItemStatus(tmpDir, 'moves');
+    expect(status?.stage).toBe('requirements');
+    expect(status?.is_waiting_for_user).toBe(false);
+  });
+
+  test('preserves is_waiting_for_user across a move', () => {
+    service.createItem(tmpDir, 'Waiting', 'discovery', 'waits');
+    service.writeItemStatus(tmpDir, 'waits', {
+      stage: 'discovery',
+      is_waiting_for_user: true,
+      brief_description: 'pre-move wait',
+      timestamp: new Date().toISOString(),
+    });
+    service.moveItem(tmpDir, 'waits', 'requirements');
+    const status = service.getItemStatus(tmpDir, 'waits');
+    expect(status?.stage).toBe('requirements');
+    expect(status?.is_waiting_for_user).toBe(true);
+    expect(status?.brief_description).toBe('pre-move wait');
+  });
+
+  test('archive move does not write status.json', () => {
+    service.createItem(tmpDir, 'Archives', 'discovery', 'arch');
+    service.moveItem(tmpDir, 'arch', 'archive');
+    // status.json may or may not exist from a prior move to a non-archive
+    // stage; what matters is that the archive move itself didn't (re)write
+    // it. We assert by ensuring moveItem returns true and index is updated.
+    const index = JSON.parse(fs.readFileSync(path.join(tmpDir, 'tracker', 'index.json'), 'utf8'));
+    expect(index.archive).toContain('arch');
+  });
+});
+
+// ─── defaultStageFileContent protocol suffix ────────────────────────────────
+
+describe('defaultStageFileContent renders status + gate protocol', () => {
+  const STAGES = ['discovery', 'requirements', 'implement', 'cleanup'] as const;
+
+  test.each(STAGES)('every stage includes the status.json protocol section', (stage) => {
+    const content = service.defaultStageFileContent(stage, {});
+    expect(content).toContain('Agent status protocol');
+    expect(content).toContain('status.json');
+    expect(content).toContain('is_waiting_for_user');
+  });
+
+  test.each(STAGES)('every stage renders Input mode + Gate on advance sections', (stage) => {
+    const content = service.defaultStageFileContent(stage, {});
+    expect(content).toContain('Input mode:');
+    expect(content).toContain('Gate on advance:');
+  });
+
+  test.each([
+    ['ask_questions', 'ask_questions'],
+    ['inline', 'Inline'],
+    ['batch', 'Batch'],
+    ['doc_review', 'review'],
+  ] as const)('input_mode=%s renders mode-specific guidance', (mode, needle) => {
+    const content = service.defaultStageFileContent('discovery', {input_mode: mode});
+    expect(content).toMatch(new RegExp(needle, 'i'));
+  });
+
+  test.each([
+    ['none', 'silently'],
+    ['review_and_advance', 'Stage review'],
+    ['wait_for_approval', 'approval'],
+  ] as const)('gate_on_advance=%s renders the right gate text', (gate, needle) => {
+    const content = service.defaultStageFileContent('requirements', {gate_on_advance: gate});
+    expect(content).toMatch(new RegExp(needle, 'i'));
+  });
+
+  test('submit=approve adds a submit gate to cleanup', () => {
+    const content = service.defaultStageFileContent('cleanup', {submit: 'approve'});
+    expect(content).toContain('Submit (PR creation)');
+    expect(content).toMatch(/approval/i);
+  });
+
+  test('submit=auto on cleanup tells the agent to open the PR automatically', () => {
+    const content = service.defaultStageFileContent('cleanup', {submit: 'auto'});
+    expect(content).toContain('Submit (PR creation)');
+    expect(content).toMatch(/automatically/i);
+  });
+
+  test('review_and_advance gate references the stage\'s output file', () => {
+    const disc = service.defaultStageFileContent('discovery', {gate_on_advance: 'review_and_advance'});
+    expect(disc).toContain('notes.md');
+    const req = service.defaultStageFileContent('requirements', {gate_on_advance: 'review_and_advance'});
+    expect(req).toContain('requirements.md');
+    const impl = service.defaultStageFileContent('implement', {gate_on_advance: 'review_and_advance'});
+    expect(impl).toContain('implementation.md');
+  });
+
+  test('gate defaults: requirements and cleanup default to wait_for_approval, implement to review_and_advance', () => {
+    const req = service.defaultStageFileContent('requirements', {});
+    expect(req).toMatch(/Gate on advance: `wait_for_approval`/);
+    const clean = service.defaultStageFileContent('cleanup', {});
+    expect(clean).toMatch(/Gate on advance: `wait_for_approval`/);
+    const impl = service.defaultStageFileContent('implement', {});
+    expect(impl).toMatch(/Gate on advance: `review_and_advance`/);
+  });
+});
+
 // ─── createItem ─────────────────────────────────────────────────────────────
 
 describe('createItem', () => {
@@ -490,10 +637,12 @@ describe('defaultStageFileContent', () => {
   });
 
   test('discovery: always_skip produces minimal short instructions', () => {
-    const content = service.defaultStageFileContent('discovery', {skip: 'always_skip'});
-    expect(content).toContain('always skip');
-    expect(content).not.toContain('codebase scan');
-    expect(content).not.toContain('ask_questions');
+    // The protocol suffix intentionally mentions ask_questions as the default
+    // input mode; scope the "must not appear" assertions to the body only.
+    const body = service.defaultStageFileContent('discovery', {skip: 'always_skip'}).split('## Agent status protocol')[0];
+    expect(body).toContain('always skip');
+    expect(body).not.toContain('codebase scan');
+    expect(body).not.toContain('ask_questions');
   });
 
   test('discovery: depth=quick omits codebase scan', () => {
@@ -508,8 +657,8 @@ describe('defaultStageFileContent', () => {
   });
 
   test('discovery: questions=none skips ask_questions step', () => {
-    const content = service.defaultStageFileContent('discovery', {depth: 'normal', skip: 'always_run', questions: 'none'});
-    expect(content).not.toContain('ask_questions');
+    const body = service.defaultStageFileContent('discovery', {depth: 'normal', skip: 'always_run', questions: 'none'}).split('## Agent status protocol')[0];
+    expect(body).not.toContain('ask_questions');
   });
 
   test('discovery: questions=standard includes ask_questions step', () => {
@@ -605,10 +754,10 @@ describe('defaultStageFileContent', () => {
   });
 
   test('implement: impl_notes=skip omits implementation.md step', () => {
-    const withSkip = service.defaultStageFileContent('implement', {impl_notes: 'skip'});
-    const withBrief = service.defaultStageFileContent('implement', {impl_notes: 'brief'});
-    expect(withSkip).not.toContain('implementation.md');
-    expect(withBrief).toContain('implementation.md');
+    const withSkipBody = service.defaultStageFileContent('implement', {impl_notes: 'skip'}).split('## Agent status protocol')[0];
+    const withBriefBody = service.defaultStageFileContent('implement', {impl_notes: 'brief'}).split('## Agent status protocol')[0];
+    expect(withSkipBody).not.toContain('implementation.md');
+    expect(withBriefBody).toContain('implementation.md');
   });
 
   test('cleanup: scope=quick says fix only critical issues', () => {

--- a/tracker/items/ralph-phase-automation/implementation.md
+++ b/tracker/items/ralph-phase-automation/implementation.md
@@ -1,0 +1,112 @@
+---
+title: Ralph-like phase automation — implementation notes
+slug: ralph-phase-automation
+updated: 2026-04-20
+---
+
+## What was built
+
+Four interlocking pieces, shipped as three commits on this branch:
+
+1. **`fdd9cf8` — Foundation.** `ItemStatus` schema, `TrackerService`
+   helpers (`getItemStatus`, `writeItemStatus`, `isItemStatusStale`,
+   `getItemStatusPath`), `ITEM_STATUS_STALE_MS = 24h`. Loose schema
+   validation + 120-char `brief_description` clamp. 9 unit tests.
+
+2. **`910d40b` — Stage protocol + new settings.** Every generated
+   stage guide now appends a common "Agent status protocol" section
+   that tells the agent to keep `status.json` current on every
+   transition. Three new settings expose in `TrackerStagesScreen`:
+   - `input_mode`: `ask_questions | inline | batch | doc_review`
+   - `gate_on_advance`: `none | review_and_advance | wait_for_approval`
+   - `submit` (cleanup only): `auto | approve`
+   `TrackerService.getItemStage` now prefers `status.json` and falls
+   back to legacy `index.json` buckets. `moveItem` mirrors the new
+   stage into `status.json`. New `listItemsByStage()` helper.
+
+3. **`b68841e` — Runtime + UI.** `src/cores/RalphCore.ts` with
+   per-worktree sampling loop (min 60s between samples), idle-window
+   tracking, cap logic, reset-on-stage-change / reset-on-fresh-wait,
+   stage-aware nudge text via `TmuxService.sendText`, append-only
+   `logs/ralph.log`. Per-project config at `tracker/ralph.json`
+   (`enabled`, `idleThresholdMs`, `maxNudgesPerStage`). New "Ralph"
+   tab in `TrackerStagesScreen`. `WorktreeContext` runs RalphCore
+   alongside WorktreeCore; rows show `⏸ <brief>` when waiting,
+   `n:X/Y` when nudged, `!` when capped.
+
+## Key design decisions
+
+- **`status.json` over MCP.** Evaluated early. Chose file-based
+  because it's tool-agnostic (works with Claude, Gemini, Codex),
+  needs zero bootstrapping per worktree, is inspectable via `cat`,
+  and the 4-field schema is small enough that LLMs reliably produce
+  correct JSON when given a template in the stage guide. Recorded
+  the rationale in `requirements.md` out-of-scope section so a
+  future PR proposing MCP can see the tradeoffs.
+
+- **`status.json` canonical for stage; `index.json` retained for
+  legacy.** Requirements called for removing the `index.json` stage
+  buckets entirely. Shipped a hybrid instead: `getItemStage` reads
+  `status.json` first and falls back to buckets; `moveItem` writes
+  to both; `listItemsByStage` lets the legacy buckets paper over
+  items that don't yet have a `status.json`. This keeps every
+  existing screen (kanban, item screen) working without a sweeping
+  refactor, and lets agents migrate their own items by simply
+  writing `status.json`. Cleanup work to delete the bucket schema
+  entirely belongs to a follow-up item.
+
+- **Agent-owned waiting flag.** The flag is never cleared by ralph
+  or by tmux-scraping "user typed something". The agent sets it on
+  pause and clears it on resume. Simpler protocol, no races. Safety
+  net: 24h staleness TTL so a crashed agent doesn't suppress nudges
+  forever.
+
+- **Nudge guards.** Ralph *only* fires when `ai_status === 'idle'`
+  (never on `working` or `waiting`), the stage hasn't changed, the
+  flag isn't fresh-set, the cap isn't hit, ralph is enabled, and a
+  main tmux session is attached. Every guard has a unit test.
+
+- **Common tail helper `renderStageProtocol`.** Kept the existing
+  `defaultStageFileContent` switch untouched (now
+  `defaultStageFileBody`) and wrapped it so every stage inherits the
+  same status/gate/input-mode tail. Adding a new setting in the
+  future needs one edit, not five.
+
+## Notes for cleanup
+
+- **Lint / comment pass.** RalphCore comments lean explanatory; if
+  cleanup is thorough, a second pass to tighten those would help.
+- **No E2E test yet.** Task #9 (mock-rendered fake-agent ralph flow)
+  is pending. Recommend adding it in cleanup — the unit coverage
+  is strong but a UI-level test would verify the projectFeature
+  suffix actually renders.
+- **`defaultStageFileBody` / `defaultStageFileContent` split.** The
+  old code path calling the public method still works; only the
+  internal rename is visible via a few existing test edits.
+- **Legacy index.json buckets.** Still present and still written
+  on `moveItem` for backwards compat. Safe to remove in a follow-up
+  once all existing items have `status.json`.
+- **Ralph UI chip styling.** The suffix is plain text appended to
+  the project/feature cell — terminal-safe, no ANSI, respects the
+  existing truncation. If the cell runs tight, the suffix gets
+  clipped first (by design).
+
+## How to try it manually
+
+1. Create a project with the tracker and open the stages screen.
+2. Navigate to the "Ralph" tab and flip enabled to On.
+3. Observe that idle agents get nudged after the configured threshold
+   (default 3 minutes).
+4. Have an agent write `tracker/items/<slug>/status.json` with
+   `is_waiting_for_user: true` and a `brief_description`. Observe
+   the suffix in the worktree list and verify ralph does not nudge.
+
+## Tests
+
+- `tests/unit/tracker.test.ts`: 129 tests (26 new covering
+  status.json round-trip, staleness, stage derivation, moveItem
+  mirroring, protocol rendering for every mode × gate × stage).
+- `tests/unit/ralph.test.ts`: 18 tests covering safety invariants,
+  detection, counter/cap/reset semantics, nudge text content, and
+  log entries.
+- Full suite: 664 passing, typecheck clean.

--- a/tracker/items/ralph-phase-automation/notes.md
+++ b/tracker/items/ralph-phase-automation/notes.md
@@ -1,0 +1,103 @@
+---
+title: Ralph-like phase automation
+slug: ralph-phase-automation
+updated: 2026-04-20
+---
+
+## User problem
+
+When an agent is working a tracker item autonomously, it sometimes halts mid-stage:
+the stage guide is read, some work is done, then the agent sits idle at a prompt
+without advancing the item's stage in `tracker/index.json`. Today, nothing detects
+this "stuck between stages" state and nothing nudges the agent to either finish
+and advance, or explain the blocker. The human has to notice and manually type
+"continue" in every tmux pane.
+
+The user wants: when an agent is **idle** (not working, not awaiting answer to a
+real question), **hasn't advanced the stage**, and no human input is arriving,
+the system should detect the stall and send a targeted nudge that reminds the
+agent which stage it's in and what the exit criteria are.
+
+Affects: anyone running multiple worktrees with devteam + the tracker workflow.
+Pain is proportional to worktree count — the more parallel agents, the more
+babysitting.
+
+## Recommendation
+
+Build this in three layers, re-using existing infra rather than inventing new systems:
+
+### 1. Phase source of truth: `tracker/index.json` (already exists)
+
+Each worktree slug is already bucketed into a stage in `tracker/index.json`
+(`backlog | discovery | requirements | implement | cleanup | archive`). That is
+the authoritative phase. Do **not** re-invent with md-file markers as the primary
+source — `index.json` is already updated by the agent when advancing, and
+`TrackerService` already has `getItemStage(slug)`, `nextStage()`, `moveItem()`.
+
+**Secondary markers** (optional, cheap): when we nudge, also peek at the expected
+output file for the current stage (e.g., `notes.md` for discovery,
+`requirements.md` for requirements) to tell the agent *"you already wrote
+notes.md — advance the index"* vs *"you haven't written notes.md yet — do that
+first"*. This gives the nudge more signal without a new marker format.
+
+### 2. Stall detection loop (new, per-worktree)
+
+Add a `RalphCore` (or extend `WorktreeCore`) that runs per worktree with a
+session:
+
+- Every ~30s, sample `(ai_status, stage, last_stage_change_at)`.
+  - `ai_status` comes from existing `AIToolService.getStatusForTool()` — states
+    are `working | waiting | idle`.
+  - `stage` comes from `TrackerService.getItemStage(slug)`.
+- Track: `idle_since` (first time we saw `idle` in a row) and
+  `stage_unchanged_since`.
+- Trigger condition: `ai_status === 'idle'` for ≥ `idleThresholdMs` **AND**
+  `stage` unchanged for ≥ same window **AND** not currently `waiting`
+  (i.e., not blocked on a real prompt the user should answer).
+
+Defaults: 3 minutes idle, max 3 nudges per stage before backing off.
+
+Key nuance: `waiting` (numbered prompt) must **never** be nudged — that means
+the agent is asking a human a real question. Only `idle` is safe.
+
+### 3. Nudge action (re-uses `TmuxService.sendText`)
+
+When the trigger fires, send a stage-aware message into the main session:
+
+```
+[ralph] You appear idle in stage "<discovery>". The item's index.json still
+shows this slug under "<discovery>". If notes.md is written and you're
+satisfied, advance the index to the next stage and read the next stage guide.
+If you're blocked, use ask_questions. Otherwise continue the current stage.
+```
+
+Stage-specific templates (map of 5 strings) keep the nudge pointed. The nudge
+text references the actual stage guide path so the agent can re-read it.
+
+### 4. Config + UX
+
+- Opt-in per project in `.devteam/config.json` under a new
+  `ralphAutomation: { enabled, idleThresholdMs, maxNudgesPerStage }` section.
+- Per-worktree opt-out via session env tag (same mechanism as
+  `@devteam_project`).
+- Surface nudge count + last-nudge time on the WorktreeListScreen row so the
+  user can see which agents are being auto-driven.
+- Log every nudge to `./logs/ralph.log` for auditing.
+
+### Why this shape
+
+- **No new protocol** — re-uses `ai_status`, `index.json`, `TmuxService.sendText`.
+- **Safe by default** — only nudges on `idle`, never on `waiting`.
+- **Observable** — nudges are logged and surfaced in the UI; easy to turn off.
+- **Stage-aware nudges** beat generic "continue" — they remind the agent of the
+  exit criteria so it makes real progress instead of just saying "ok" and
+  stalling again.
+
+### Open questions for requirements stage
+
+- Should nudges require a brief human confirmation the first N times, then go
+  fully automatic? Or silent from the start?
+- Should we also nudge on `working` if stage hasn't changed in ≥ 30 min?
+  (handles "agent is spinning in a long loop without advancing")
+- Backoff policy when 3 nudges fail: stop forever, stop until human input, or
+  page the human?

--- a/tracker/items/ralph-phase-automation/requirements.md
+++ b/tracker/items/ralph-phase-automation/requirements.md
@@ -1,7 +1,355 @@
 ---
-title: "implement a \"ralph\"-like system. the agent should be prompted to continue if it hasn't reached the next stage and has been idle for a while and is not getting user input. maybe make this a bit more sophisticated, so the agent has to understand the phase and progress to the next. need more robust detection of phases baased on what's in the repo etc (md files with certain sections maybe, or some other marker the agent puts in explictly). help me flesh this out"
+title: Ralph-like phase automation
 slug: ralph-phase-automation
 updated: 2026-04-20
 ---
 
-implement a "ralph"-like system. the agent should be prompted to continue if it hasn't reached the next stage and has been idle for a while and is not getting user input. maybe make this a bit more sophisticated, so the agent has to understand the phase and progress to the next. need more robust detection of phases baased on what's in the repo etc (md files with certain sections maybe, or some other marker the agent puts in explictly). help me flesh this out
+## Problem
+
+When an agent is working a tracker item autonomously, it sometimes halts
+mid-stage: the stage guide is read, some work is done, then the agent sits idle
+at a prompt without advancing the item's stage in `tracker/index.json`. Today
+nothing detects this "stuck between stages" state and nothing nudges the agent
+to either finish and advance, or explain the blocker. The human has to notice
+and manually type "continue" in every tmux pane. Pain scales with the number
+of parallel worktrees.
+
+Beyond just stalls: today there is no principled way for the user to say
+"run autonomously through most stages, but pause for my review before
+implementation" or "don't auto-submit the PR, let me approve it first." The
+agent either plows through or stops unpredictably — there is no knob.
+
+Also: the only reliable signal that an agent is waiting for input today is the
+`ask_questions` tool, which surfaces a numbered prompt detectable as
+`ai_status === 'waiting'`. But many users prefer to be asked inline, via doc
+review, or as a single batched message — in which case the tmux pane looks
+`idle` even though the agent is legitimately waiting. Ralph has no way to
+tell the difference from the pane alone.
+
+We solve this by giving the agent a tiny metadata file to write — no new
+infrastructure, no per-worktree MCP bootstrapping, tool-agnostic (works with
+Claude, Gemini, Codex), inspectable via `cat`, and trivially unit-testable.
+The failure modes are the same as any tool-based approach (agent forgets to
+update), and they're handled by stage-guide instructions + a staleness TTL.
+
+## Why
+
+- `ai_status` detection already exists (`AIToolService.getStatusForTool()` →
+  `working | waiting | idle`) and is refreshed every 2s by `WorktreeCore`.
+- Stage is already authoritative in `tracker/index.json` via `TrackerService`.
+- `TmuxService.sendText()` can deliver a prompt to the main session.
+- Per-stage settings already exist (`StageConfig.settings`, surfaced as cycle
+  dropdowns in `TrackerStagesScreen.tsx`, persisted in
+  `tracker/work-style.json` via `saveStageSettings`). Stage guide files are
+  regenerated from these settings via `defaultStageFileContent()`.
+- `waiting` (numbered prompt) only covers the `ask_questions`-tool case. For
+  any other input mode we need a second signal — an explicit metadata flag
+  the agent writes to the item directory.
+- Stage-aware nudges are more effective than a generic "continue" because they
+  remind the agent of the exit criteria for the current stage.
+- Nothing ties these pieces together yet, so the user has no autonomy policy,
+  no stall rescue, and no reliable way to tell the harness "I'm waiting for
+  you."
+
+## User stories
+
+- As a developer running multiple worktrees, I want idle agents that haven't
+  advanced a stage to be nudged automatically, so I don't have to babysit each
+  tmux pane.
+- As a developer, I want nudges to be stage-aware (reminding the agent what
+  the current stage expects) so the agent makes real progress instead of just
+  acknowledging and stalling again.
+- As a developer, I want to configure per stage whether the agent advances
+  autonomously or pauses for my review before moving to the next stage, so I
+  can be hands-off on low-stakes items but approve transitions on important
+  ones.
+- As a developer, I want a specific "submit" gate on the cleanup stage that
+  decides whether the agent creates the PR automatically or waits for my
+  approval first.
+- As a developer, I want to pick how I'm asked for input per stage
+  (ask_questions tool, inline, batched, doc review), because that affects how
+  I triage parallel worktrees — `ask_questions` is terminal-native, inline is
+  conversational, doc review is asynchronous.
+- As a developer, I want any agent that pauses for non-`ask_questions` input
+  to flag itself in the item's metadata with a short reason, so ralph can tell
+  "idle because waiting for me" from "idle because stuck", and so the UI can
+  show me what each paused agent needs.
+- As a developer, I want ralph to never interrupt an agent that's genuinely
+  working or legitimately waiting (via either `ask_questions` or the metadata
+  flag).
+- As a developer, I want to see in the worktree list: the current stage,
+  whether an agent is waiting on me (with the short reason), nudge count, and
+  whether it's capped — so one glance tells me which worktrees need
+  intervention.
+- As a developer, I want to turn ralph on/off and configure gates + input
+  mode from the existing `TrackerStagesScreen`, so I don't need new config
+  surface area.
+
+## Summary
+
+Four pieces that reinforce each other:
+
+1. **Autonomy policy (per-stage gates)** — new per-stage settings on
+   `StageConfig.settings`:
+   - `gate_on_advance`: `none | review_and_advance | wait_for_approval`.
+   - On `cleanup` only, `submit`: `auto | approve` (for the PR step).
+   The generated stage guide text incorporates the gate so the agent reads it
+   as part of its normal prompt.
+
+2. **Input mode (per-stage)** — new per-stage setting `input_mode` with
+   choices `ask_questions | inline | batch | doc_review`. The stage guide
+   tells the agent which mode to use when it needs input during the stage.
+
+3. **Agent status metadata file (canonical stage source)** — the agent
+   writes `tracker/items/<slug>/status.json` with
+   `{ stage, is_waiting_for_user, brief_description, timestamp }`.
+   `status.json` becomes the **canonical source of truth for an item's
+   current stage**. The agent updates it on every meaningful transition
+   (stage start/advance, pause, resume) in every input mode.
+   `tracker/index.json`'s stage buckets are refactored to be derived
+   from a scan of per-item `status.json` files. Ralph treats
+   `is_waiting_for_user: true` with a fresh timestamp the same as
+   `ai_status === 'waiting'` for nudge suppression.
+
+4. **Nudge loop** — a `RalphCore` samples `(ai_status, stage,
+   status_file)` per active worktree and fires a stage-aware continue
+   nudge (via `TmuxService.sendText` to the main session) when the agent
+   has been `idle` continuously, the stage is unchanged for ≥
+   `idleThresholdMs`, and no waiting status in status.json is present. Capped at
+   `maxNudgesPerStage`; counter resets on stage change.
+
+Config + UI: a new "Ralph" tab in `TrackerStagesScreen` exposes ralph-level
+settings. Gate + input mode settings live on each stage's existing tab as
+new dropdowns. `WorktreeListScreen` surfaces waiting state (with reason),
+nudge count, and cap.
+
+## Acceptance criteria
+
+### Agent status metadata file (foundational)
+
+1. Every item always has a `tracker/items/<slug>/status.json` file
+   maintained by the agent. Schema:
+   ```json
+   {
+     "stage": "discovery" | "requirements" | "implement" | "cleanup",
+     "is_waiting_for_user": boolean,
+     "brief_description": "string, ≤ 120 chars — describes current
+                           activity when is_waiting_for_user is false,
+                           and what is being waited on when true",
+     "timestamp": "ISO-8601"
+   }
+   ```
+2. The stage guide instructs the agent to update this file on every
+   meaningful transition, in all input modes (no exceptions). Updates
+   happen at: stage start, before pausing for input (set
+   `is_waiting_for_user: true` with a `brief_description` of what is
+   being waited on), when resuming work (flip back to false and update
+   `brief_description` to reflect current activity), and on stage
+   advance (update `stage`). The file is never deleted during an item's
+   lifetime — only overwritten.
+3. `status.json` is the canonical source of truth for an item's
+   stage. `index.json` is refactored so its per-stage buckets
+   (`backlog`, `discovery`, `requirements`, `implement`, `cleanup`)
+   are derived from scanning `tracker/items/*/status.json` on read,
+   not stored as authoritative data. `index.json` retains only:
+   project-level data that isn't per-item stage (the `archive` list,
+   the `sessions` map, any future project metadata). See the
+   "index.json refactor" AC section below.
+4. `TrackerService` gains helpers:
+   `getItemStatus(projectPath, slug): ItemStatus | null` and
+   `writeItemStatus(projectPath, slug, status): void`. Both unit-tested.
+5. Safety net: ralph ignores `is_waiting_for_user: true` when the
+   `timestamp` is older than 24 hours (handles crashed agents that
+   never cleared). Staleness is logged.
+
+### index.json refactor (stage buckets become derived)
+
+5a. `tracker/index.json` no longer stores per-stage slug buckets.
+    The fields `backlog.backlog`, `backlog.discovery`,
+    `backlog.requirements`, `implementation.implement`,
+    `implementation.cleanup` are removed from the canonical schema.
+    Retained fields: `archive` (list of archived slugs),
+    `sessions` (map of slug → metadata), and any future
+    project-level keys.
+5b. A new `TrackerService.listItemsByStage(projectPath):
+    Record<TrackerStage, string[]>` walks `tracker/items/*/` and
+    reads each `status.json`. Items without a status.json are
+    bucketed to `backlog` by convention. Archived items come from
+    `index.json.archive` (unchanged).
+5c. Existing call sites are updated:
+    - `getItemStage(slug)` reads `status.json` first; if absent,
+      falls back to a default (`backlog`).
+    - `moveItem(slug, toStage)` writes the new stage into
+      `status.json` (creating it if absent) and does **not** mutate
+      `index.json` buckets.
+    - `nextStage` / `previousStage` order is unchanged.
+    - The kanban view (`TrackerBoardScreen`) and any other screens
+      that enumerate items per stage call
+      `listItemsByStage()`.
+5d. Migration: on first run after the refactor, if a project's
+    `index.json` still contains legacy stage buckets, the service
+    materialises a `status.json` for each slug found there and
+    then writes `index.json` back without the buckets. Migration
+    is idempotent and logged. Unit tests cover a migration run on
+    a fixture `index.json` with the old shape.
+5e. Agent stage-advancement instructions in the generated stage
+    guide change to "update `status.json`" rather than "edit
+    `tracker/index.json`". `TrackerService.buildPlanningPrompt()`
+    and related helpers are updated accordingly.
+
+### Input-mode setting (per-stage)
+
+6. Each stage (`discovery | requirements | implement | cleanup`) gains
+   an `input_mode` dropdown in `STAGE_OPTION_DEFS`, choices:
+   - `ask_questions` — use the ask_questions tool (terminal-native
+     numbered prompt).
+   - `inline` — ask questions inline in chat.
+   - `batch` — ask all questions at once in a single message.
+   - `doc_review` — write the stage's output file then ask the user
+     to review it.
+7. In every mode, the agent must update `status.json` before pausing
+   and after resuming (per §2). The modes only differ in the *form* of
+   the user interaction, not in whether `status.json` is maintained.
+8. Default per stage: all four default to `ask_questions`.
+9. `defaultStageFileContent(stage, settings)` incorporates the chosen
+   input mode into the generated stage guide along with the
+   status.json update instructions. Unit tests cover four modes × four
+   stages.
+
+### Gate settings (per-stage autonomy policy)
+
+10. Each stage gains a `gate_on_advance` dropdown in
+    `STAGE_OPTION_DEFS`:
+    - `none` — agent advances silently.
+    - `review_and_advance` — agent appends a 1–3 sentence "Stage
+      review" section to the stage's output file (e.g., `notes.md`
+      for discovery, `requirements.md` for requirements,
+      `implementation.md` for implement), then advances.
+    - `wait_for_approval` — agent must ask for approval via the
+      stage's `input_mode` (and set `is_waiting_for_user: true` in
+      status.json) before advancing.
+11. Defaults: `discovery` = `none`; `requirements` =
+    `wait_for_approval`; `implement` = `review_and_advance`;
+    `cleanup` = `wait_for_approval` (the PR-submit gate is the
+    `submit` setting below).
+12. `cleanup` additionally gains a `submit: auto | approve` dropdown
+    (default `approve`) governing PR creation. When `approve`, the
+    stage guide instructs the agent to pause (per input_mode) before
+    opening the PR.
+13. `defaultStageFileContent()` renders the gate instruction into the
+    generated stage markdown. Changing a gate setting rewrites the
+    stage guide on disk immediately (same pattern as
+    `cycleStageOption` in `TrackerStagesScreen.tsx`).
+
+### Nudge detection
+
+14. A new `RalphCore` (under `src/cores/`) runs a sampling loop per
+    active worktree session. Minimum 60s between samples.
+15. Per-worktree state: `idle_since`, `stage_last_seen`,
+    `stage_unchanged_since`, `nudges_this_stage` (reset when stage
+    advances or when `is_waiting_for_user` flips true).
+16. A nudge fires iff all of:
+    - `ai_status === 'idle'` continuously for ≥ `idleThresholdMs`
+      (default **3 minutes**).
+    - `status.json.stage` unchanged for ≥ the same threshold.
+    - `status.json` does not report `is_waiting_for_user: true` with
+      a fresh (< 24h) timestamp.
+    - `nudges_this_stage < maxNudgesPerStage` (default 3).
+    - Ralph is enabled in the project config.
+    - The worktree has an active tmux main session.
+17. Observing a stage change, or a fresh flip of
+    `is_waiting_for_user` to true, resets `idle_since` and
+    `nudges_this_stage` to zero.
+
+### Nudge delivery
+
+18. Nudges use `TmuxService.sendText()` into the main session
+    (`dev-{project}-{feature}`). Shell and run sessions are never
+    targeted.
+19. Nudge text is a stage-specific template. Each template includes:
+    stage name, stage-guide path, expected output file, current
+    gate setting, current `input_mode`, and an explicit "if blocked,
+    set `is_waiting_for_user: true` in status.json" clause.
+20. Each nudge is appended to `./logs/ralph.log` as
+    `{timestamp, project, slug, stage, nudgeNumber, idleMs}`.
+
+### Backoff & visibility
+
+21. After `maxNudgesPerStage` nudges on the same stage without
+    advancement, no further nudges fire until the stage changes or
+    `is_waiting_for_user` flips true.
+22. `WorktreeListScreen` surfaces, per row:
+    - current stage
+    - waiting state: `ai_status === 'waiting'` or
+      `status.json.is_waiting_for_user === true` with fresh
+      timestamp. When waiting, show the ≤ 120-char
+      `brief_description` (truncated to fit row width).
+    - nudge count `n:X/Y` when X > 0 and not capped.
+    - a distinct "needs attention" indicator when capped.
+23. The cap resets automatically on stage change or on fresh waiting
+    flip.
+
+### Safety invariants (each has a unit test)
+
+24. Ralph never sends a nudge when `ai_status === 'waiting'`.
+25. Ralph never sends a nudge when `ai_status === 'working'`.
+26. Ralph never sends a nudge when `status.json.is_waiting_for_user`
+    is true with a fresh (< 24h) timestamp.
+27. Ralph never sends a nudge when ralph is disabled for the project.
+28. Ralph never sends a nudge to a session absent from tmux.
+
+### Config & UI
+
+29. Ralph-level config lives per project at `tracker/ralph.json`:
+    `{ enabled, idleThresholdMs, maxNudgesPerStage }`. Defaults
+    applied when file is missing.
+30. A new **"Ralph"** tab is added to `ALL_TABS` in
+    `TrackerStagesScreen` exposing the three ralph-level fields with
+    the same cycle-value UI.
+31. Each stage tab gains `gate_on_advance` and `input_mode` dropdowns.
+    The cleanup tab additionally gains `submit`.
+32. `WorktreeListScreen` renders the `brief_description` next to the
+    row while waiting (truncated) and nudge state per §22.
+
+### Tests
+
+33. Unit tests cover each safety invariant §24–28.
+34. Unit tests cover: nudge fires on sustained idle + unchanged
+    stage; counter increments; counter resets on stage change and on
+    fresh waiting flip; cap respected.
+35. Unit tests cover `getItemStatus` / `writeItemStatus` round-trips
+    and the 24h stale rule.
+36. Unit tests cover `defaultStageFileContent` rendering for:
+    - every `input_mode` × stage combination
+    - every `gate_on_advance` × stage combination
+    - `submit` on cleanup (both values)
+37. A fake `TmuxService` asserts nudge text contains current stage
+    name, expected output file path, current `input_mode`, and
+    current `gate_on_advance`.
+38. E2E (mock-rendered) test with a fake agent that writes
+    `is_waiting_for_user: true`: ralph does not nudge while fresh;
+    clearing the flag and advancing fake time produces a nudge;
+    hitting the cap surfaces "needs attention" on the UI row.
+39. E2E test that the `brief_description` appears (truncated) on the
+    `WorktreeListScreen` row while waiting.
+
+### Out of scope
+
+- Nudging when `ai_status === 'working'`.
+- md-file marker parsing as a primary phase source — `index.json`
+  remains authoritative.
+- Global (cross-project) ralph config.
+- Cross-process persistence of nudge counters (in-memory resets on
+  app restart; acceptable).
+- Gates / input_mode on `backlog` (no output file; advancement logic
+  is distinct).
+- Automatic detection of "user sent a message" to clear
+  `is_waiting_for_user`. The flag is agent-owned: the agent sets it
+  on pause and clears it on resume. Ralph only reads. Keeps the
+  protocol simple; avoids racing on tmux pane scraping.
+- A devteam-tracker MCP server. Rejected in favour of the status.json
+  file: tool-agnostic (works with Claude, Gemini, Codex), zero
+  bootstrapping, inspectable via `cat`, and the schema is small
+  enough that LLMs reliably produce correct JSON when given a
+  template in the stage guide. Revisit if MCP-native integrations
+  (live UI updates, richer typed tools) become a concrete need.

--- a/tracker/items/ralph-phase-automation/requirements.md
+++ b/tracker/items/ralph-phase-automation/requirements.md
@@ -1,0 +1,7 @@
+---
+title: "implement a \"ralph\"-like system. the agent should be prompted to continue if it hasn't reached the next stage and has been idle for a while and is not getting user input. maybe make this a bit more sophisticated, so the agent has to understand the phase and progress to the next. need more robust detection of phases baased on what's in the repo etc (md files with certain sections maybe, or some other marker the agent puts in explictly). help me flesh this out"
+slug: ralph-phase-automation
+updated: 2026-04-20
+---
+
+implement a "ralph"-like system. the agent should be prompted to continue if it hasn't reached the next stage and has been idle for a while and is not getting user input. maybe make this a bit more sophisticated, so the agent has to understand the phase and progress to the next. need more robust detection of phases baased on what's in the repo etc (md files with certain sections maybe, or some other marker the agent puts in explictly). help me flesh this out


### PR DESCRIPTION
## Summary

Adds a ralph-style "is the agent stuck?" nudger for tracker items, plus the on-disk contract that powers it, plus a round of UX polish on the stages/kanban flow that made the new signals more useful.

**The agent self-reports a live status.** Each tracker item gets a `tracker/items/<slug>/status.json` with three fields that matter: `stage`, `state: 'working' | 'waiting_for_input' | 'waiting_for_approval'`, and `brief_description` (≤ 200 chars). The stage guide tells the agent exactly when to flip state; the kanban reads it to render useful glyphs; ralph reads it to decide whether the agent is stuck or legitimately waiting.

**Ralph samples every 60s** and nudges when the agent is running but idle (`ai_status === 'idle'` ≥ `idleThresholdMs`, default 3 min), hasn't advanced stages, and hasn't self-reported a non-working state. Caps at `maxNudgesPerStage` (default 3) to avoid spam; resets on any stage change or fresh waiting flag. All guards covered by unit tests.

**Kanban + main-view surfaces the state.** Waiting_for_input cards get a yellow `!` with the agent's `brief_description`; waiting_for_approval cards get a green `✓ Ready — <brief>` banner and a dedicated "press [m] to approve and advance" hint when highlighted. The existing `m` key now does the approve+advance in one keystroke (resets state to working, clears brief, advances stage).

**Stage UX cleanup** bundled in since the new signals exposed friction:

- **Gate labels name the next step.** Was "Gate on advance / Auto-advance / Require approval"; now per-stage "After requirements / Move on / Ask me first", "After implementation / …", "After cleanup and submit / …".
- **"Cleanup" → "Cleanup and submit"** in all user-facing strings (kanban column, stage tab, action label, stage-guide title). The on-disk stage key (`cleanup`) and filename (`cleanup.md`) are unchanged so saved configs keep working.
- **Dropped the 1..5 numbering** from stage filenames — `stages/2-discovery.md` etc. became `stages/discovery.md`, `# Stage 2: Discovery` headings became `# Discovery`.
- **Removed the vestigial backlog-body generator** (it's been merged into discovery for display for a while).
- **Discovery stage body compressed ~180 → ~80 words**; requirements knobs cut from 4+1 to 2+1 and body compressed ~400 → ~90 words. Check-in cadence is driven by the project-global inputMode (Style tab) instead of per-stage `approval` flags.
- **Initial prompt now passes through to codex/gemini via native CLI args** (was silently dropped — only claude was wired up).
- **Ralph nudges any running agent**, not just attached sessions (attachment ≠ agent-running).

**Back-compat.** `normaliseItemState` reads legacy `is_waiting_for_user` / `awaiting_advance_approval` booleans and maps them to the new enum, so existing status.json files on disk keep working.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx jest` — 672 passing (new: status.json helpers, tri-state parse + legacy back-compat, ralph guard invariants including waiting_for_approval suppression, nudge text polite-check-in assertions, stage-guide generation per setting, moveItem resets state on advance)
- [ ] Manually verify on a live project: ralph nudges only when the agent is running+idle+working; waiting states suppress nudges; [m] approves on a waiting_for_approval card and the next stage starts with a clean brief_description
- [ ] Open the Stages screen: discovery/requirements/implement/cleanup-and-submit tabs all show the new labels; Style tab has inputMode; Ralph tab copy reads correctly
- [ ] Check kanban with fresh status.json in each of the three states — ⟳/!/✓ glyphs and green "Ready — …" banner render as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)