### PR TITLE
inactive rows gray text

### DIFF
--- a/src/screens/TrackerBoardScreen.tsx
+++ b/src/screens/TrackerBoardScreen.tsx
@@ -714,17 +714,17 @@ export default function TrackerBoardScreen({
                   const maxLines = isSelected ? 4 : SECONDARY_MAX_LINES;
                   const lines = wrapToLines(text, secMax, maxLines);
                   const color =
-                    readyToAdvance ? 'green'
+                    item.inactive ? 'gray'
+                    : readyToAdvance ? 'green'
                     : isWaiting ? 'yellow'
                     : isWorking ? 'cyan'
-                    : item.inactive ? 'gray'
                     : undefined;
-                  const dim = !readyToAdvance && !isWaiting && !isWorking;
+                  const dim = item.inactive || (!readyToAdvance && !isWaiting && !isWorking);
                   return lines.map((line, lineIdx) => (
                     <Text
                       key={lineIdx}
                       color={color}
-                      bold={isWaiting || readyToAdvance}
+                      bold={!item.inactive && (isWaiting || readyToAdvance)}
                       dimColor={dim}
                       wrap="truncate"
                     >

--- a/tracker/items/inactive-rows-gray-text/requirements.md
+++ b/tracker/items/inactive-rows-gray-text/requirements.md
@@ -1,0 +1,7 @@
+---
+title: "for inactive items, the second+ rows are showing as bright if waiting for input or ready etc. just show second+lines as gray"
+slug: inactive-rows-gray-text
+updated: 2026-04-22
+---
+
+for inactive items, the second+ rows are showing as bright if waiting for input or ready etc. just show second+lines as gray


### PR DESCRIPTION
- **tracker: seed item files for inactive-rows-gray-text**
- **fix(tracker): show inactive item secondary rows as gray regardless of agent state**
