### PR TITLE
merged item stays green

### DIFF
--- a/src/screens/TrackerBoardScreen.tsx
+++ b/src/screens/TrackerBoardScreen.tsx
@@ -652,7 +652,8 @@ export default function TrackerBoardScreen({
             // "ready to advance" treatment so it's spottable at a glance and
             // can be acted on with the `m` shortcut from the board.
             const itemStatus = service.getItemStatus(projectPath, item.slug);
-            const readyToAdvance = service.isItemReadyToAdvance(itemStatus);
+            const prMerged = getWorktreeForItem(item)?.pr?.is_merged === true;
+            const readyToAdvance = !prMerged && service.isItemReadyToAdvance(itemStatus);
             const ralphWaiting = !!itemStatus && !readyToAdvance && service.isItemWaiting(itemStatus);
             const isWaiting = aiWaiting || ralphWaiting;
 

--- a/tracker/items/merged-item-stays-green/implementation.md
+++ b/tracker/items/merged-item-stays-green/implementation.md
@@ -1,0 +1,13 @@
+---
+title: "after a PR is merged, the item still shows up as green and ready"
+slug: merged-item-stays-green
+updated: 2026-04-25
+---
+
+## What was built
+
+One line added in `TrackerBoardScreen.tsx` (item render loop): look up `getWorktreeForItem(item)?.pr?.is_merged` and short-circuit `readyToAdvance` to false when true. All downstream color, glyph, label, and hint logic already flows from `readyToAdvance`, so no other changes needed.
+
+## Stage review
+
+Trivial change — one guard added, no new dependencies, all pre-existing type errors unrelated to this fix.

--- a/tracker/items/merged-item-stays-green/notes.md
+++ b/tracker/items/merged-item-stays-green/notes.md
@@ -1,0 +1,47 @@
+---
+title: "after a PR is merged, the item still shows up as green and ready"
+slug: merged-item-stays-green
+updated: 2026-04-25
+---
+
+## Problem
+
+After a PR is merged on GitHub, the corresponding tracker item remains green ("ready to advance") on the kanban board indefinitely, until the 24-hour staleness window expires.
+
+## Findings
+
+**What drives the green color**
+
+`TrackerBoardScreen.tsx:664–665` — an item is green when `service.isItemReadyToAdvance(itemStatus)` is true. That function (`TrackerService.ts:532–533`) returns true when `status.json` has `state: "waiting_for_approval"` and the timestamp is under 24 hours old (`ITEM_STATUS_STALE_MS = 24h`).
+
+**How the typical path leads to the bug**
+
+1. Agent completes cleanup and sets `status.json → state: "waiting_for_approval"` → item turns green.
+2. User merges the PR directly on GitHub (skipping the `[m]` shortcut in the board).
+3. GitHubCore polls GitHub every ~5 min and detects `PRStatus.state === 'MERGED'` (`models.ts:71`).
+4. **Nothing connects that detection back to `status.json`.** The item stays green.
+5. After 24 hours the staleness guard kicks in and the green disappears silently.
+
+**PR merge detection exists but is disconnected**
+
+- `WorktreeStatus.ts:41,91` — computes `PR_MERGED` reason when `worktree.pr.is_merged`.
+- `MainView` uses this to render the worktree row as gray/dimmed — but only in the worktree list, not the kanban board.
+- `TrackerBoardScreen` never checks `worktree.pr?.is_merged`; its item color logic reads only `status.json`.
+
+**The `[m]` happy path works correctly**
+
+When the user presses `[m]` on the board, `moveItem(slug, 'archive')` is called, which updates `index.json` and resets `status.json` to `state: "working"` (then the item moves to archive and disappears from the board). The bug only occurs when the PR is merged externally without using `[m]`.
+
+**Available data to fix it**
+
+`TrackerBoardScreen` already has access to the full `worktrees` array (each `WorktreeInfo` has `.feature` = item slug and `.pr.is_merged`). The fix can look up an item's worktree, check `pr.is_merged`, and suppress/clear the green state.
+
+## Recommendation
+
+Two-layer fix:
+
+1. **Display layer (immediate, safe):** In the `isItemReadyToAdvance` call site inside `TrackerBoardScreen`, also check whether the item's worktree has a merged PR. If so, treat `readyToAdvance` as false — the item shouldn't be green after merge. This is a read-only change to rendering.
+
+2. **Data layer (correct, one extra step):** When rendering detects a merged PR for a `waiting_for_approval` item, call `moveItem(slug, 'archive')` (or at minimum `writeItemStatus(…, {state: 'working'})`) so the tracker data reflects reality. This mirrors what `[m]` does manually.
+
+The display fix alone stops the symptom. The data fix makes the board accurate durably (the item moves to archive, which is the expected outcome after a merge). Both changes belong in `TrackerBoardScreen.tsx`; no new infrastructure needed.

--- a/tracker/items/merged-item-stays-green/requirements.md
+++ b/tracker/items/merged-item-stays-green/requirements.md
@@ -1,0 +1,7 @@
+---
+title: "after a PR is merged, the item still shows up as green and ready"
+slug: merged-item-stays-green
+updated: 2026-04-22
+---
+
+after a PR is merged, the item still shows up as green and ready

--- a/tracker/items/merged-item-stays-green/requirements.md
+++ b/tracker/items/merged-item-stays-green/requirements.md
@@ -1,7 +1,25 @@
 ---
 title: "after a PR is merged, the item still shows up as green and ready"
 slug: merged-item-stays-green
-updated: 2026-04-22
+updated: 2026-04-25
 ---
 
-after a PR is merged, the item still shows up as green and ready
+## Problem
+
+After a PR is merged on GitHub, the corresponding tracker item remains green ("ready to advance") on the kanban board indefinitely, until the 24-hour staleness window expires.
+
+## Why
+
+When an agent completes cleanup it sets `status.json → state: "waiting_for_approval"`, making the item green. If the user merges the PR on GitHub directly (without pressing `[m]` on the board), `status.json` is never updated. The kanban's green logic reads only `status.json` — it never checks whether the worktree's PR has been merged — so the card stays green for up to 24 hours with no indication the work is done.
+
+## Summary
+
+When the kanban detects that an item's worktree PR has been merged, suppress the green "ready to advance" highlight — the item stays in its current stage but renders as plain/dim instead of highlighted green. No state is written, no automatic stage transition. The `TrackerBoardScreen` already has the worktrees list with `worktree.pr.is_merged`; the fix is a small condition in the existing color/glyph logic.
+
+## Acceptance criteria
+
+1. An item whose worktree PR is detected as merged does not render green, regardless of what `status.json.state` says.
+2. Such an item renders as plain/dim — no green color, no `✓` glyph, no "Ready" label, no `[m] approve and advance` hint.
+3. Items without a worktree, or whose PR status is not yet fetched, are unaffected (no crash, no change in appearance).
+4. Items whose PR is not merged continue to show green when `state: "waiting_for_approval"` as before.
+5. No `status.json` is written and no stage transition occurs — this is a rendering-only change.

--- a/tracker/items/merged-item-stays-green/status.json
+++ b/tracker/items/merged-item-stays-green/status.json
@@ -1,0 +1,6 @@
+{
+  "stage": "cleanup",
+  "state": "waiting_for_approval",
+  "brief_description": "ready to submit — 2-line fix in TrackerBoardScreen.tsx suppresses green when worktree PR is merged",
+  "timestamp": "2026-04-25T16:52:00.000Z"
+}


### PR DESCRIPTION
- **tracker: seed item files for merged-item-stays-green**
- **fix(tracker): suppress green highlight on items whose PR has merged**
