### PR TITLE
refactor: simplify tracker style tab

### DIFF
--- a/src/screens/TrackerStagesScreen.tsx
+++ b/src/screens/TrackerStagesScreen.tsx
@@ -149,25 +149,10 @@ const STYLE_OPTIONS: StyleOptionDef[] = [
     {value: 'batch', label: 'Batch together'},
     {value: 'one_at_a_time', label: 'One at a time'},
   ]},
-  {key: 'contextDepth', label: 'Research depth', choices: [
-    {value: 'light', label: 'Light'},
-    {value: 'moderate', label: 'Moderate'},
-    {value: 'deep', label: 'Deep'},
-  ]},
   {key: 'codeScope', label: 'Code scope', choices: [
     {value: 'minimal', label: 'Minimal'},
     {value: 'clean_as_go', label: 'Clean as you go'},
     {value: 'thorough', label: 'Thorough'},
-  ]},
-  {key: 'testing', label: 'Tests', choices: [
-    {value: 'skip', label: 'Skip'},
-    {value: 'suggest', label: 'Suggest'},
-    {value: 'always', label: 'Always write'},
-  ]},
-  {key: 'commits', label: 'Commits', choices: [
-    {value: 'never', label: 'Never'},
-    {value: 'milestones', label: 'At milestones'},
-    {value: 'often', label: 'Frequently'},
   ]},
   {key: 'onBlockers', label: 'On blockers', choices: [
     {value: 'ask', label: 'Stop & ask'},

--- a/src/screens/TrackerStagesScreen.tsx
+++ b/src/screens/TrackerStagesScreen.tsx
@@ -139,26 +139,6 @@ const STYLE_OPTIONS: StyleOptionDef[] = [
     {value: 'brief', label: 'Brief'},
     {value: 'detailed', label: 'Detailed'},
   ]},
-  {key: 'planning', label: 'Before starting', choices: [
-    {value: 'dive_in', label: 'Dive in'},
-    {value: 'plan_first', label: 'Show plan first'},
-    {value: 'plan_approval', label: 'Plan + wait for approval'},
-  ]},
-  {key: 'questions', label: 'Questions', choices: [
-    {value: 'minimal', label: 'Minimal'},
-    {value: 'batch', label: 'Batch together'},
-    {value: 'one_at_a_time', label: 'One at a time'},
-  ]},
-  {key: 'codeScope', label: 'Code scope', choices: [
-    {value: 'minimal', label: 'Minimal'},
-    {value: 'clean_as_go', label: 'Clean as you go'},
-    {value: 'thorough', label: 'Thorough'},
-  ]},
-  {key: 'onBlockers', label: 'On blockers', choices: [
-    {value: 'ask', label: 'Stop & ask'},
-    {value: 'try_first', label: 'Try alternatives first'},
-    {value: 'continue', label: 'Note & continue'},
-  ]},
   {key: 'inputMode', label: 'Input mode', choices: [
     {value: 'ask_questions', label: 'ask_questions tool'},
     {value: 'inline', label: 'Inline chat'},

--- a/src/services/TrackerService.ts
+++ b/src/services/TrackerService.ts
@@ -80,10 +80,7 @@ export type VerbosityStyle = 'brief' | 'detailed';
 export type PlanningStyle = 'dive_in' | 'plan_first' | 'plan_approval';
 export type QuestionsStyle = 'minimal' | 'one_at_a_time' | 'batch';
 export type CodeScopeStyle = 'minimal' | 'clean_as_go' | 'thorough';
-export type TestingStyle = 'always' | 'suggest' | 'skip';
-export type CommitStyle = 'never' | 'milestones' | 'often';
 export type BlockerStyle = 'ask' | 'try_first' | 'continue';
-export type ContextDepthStyle = 'light' | 'moderate' | 'deep';
 // How the agent should deliver questions/requests for review. Project-wide
 // preference; drives the "Input mode" block in every generated stage guide.
 export type InputModeStyle = 'ask_questions' | 'inline' | 'batch' | 'doc_review';
@@ -97,10 +94,7 @@ export interface WorkStyle {
   planning: PlanningStyle;
   questions: QuestionsStyle;
   codeScope: CodeScopeStyle;
-  testing: TestingStyle;
-  commits: CommitStyle;
   onBlockers: BlockerStyle;
-  contextDepth: ContextDepthStyle;
   inputMode: InputModeStyle;
   customInstructions: string;
 }
@@ -111,10 +105,7 @@ export const DEFAULT_WORK_STYLE: WorkStyle = {
   planning: 'dive_in',
   questions: 'batch',
   codeScope: 'minimal',
-  testing: 'suggest',
-  commits: 'never',
   onBlockers: 'ask',
-  contextDepth: 'moderate',
   inputMode: 'ask_questions',
   customInstructions: '',
 };
@@ -932,25 +923,10 @@ export class TrackerService {
       batch: ['Batch together', 'When you have multiple questions, ask them all in one message.'],
       one_at_a_time: ['One at a time', 'Ask one question at a time, wait for the answer before asking the next.'],
     };
-    const RESEARCH_LABELS: Record<string, [string, string]> = {
-      light: ['Light', 'Read only what is directly relevant to the task. Minimal upfront research.'],
-      moderate: ['Moderate', 'Read relevant files and a few related ones for context before acting.'],
-      deep: ['Deep', 'Explore the codebase broadly, read related files, and understand the full picture before acting.'],
-    };
     const SCOPE_LABELS: Record<string, [string, string]> = {
       minimal: ['Minimal', 'Change only what is necessary. Avoid scope creep and opportunistic cleanup.'],
       clean_as_go: ['Clean as you go', 'Fix small nearby issues when you encounter them, but stay close to the task.'],
       thorough: ['Thorough', 'Improve code quality proactively — refactor, clean up patterns, improve structure when relevant.'],
-    };
-    const TESTS_LABELS: Record<string, [string, string]> = {
-      skip: ['Skip', 'Do not write tests unless explicitly asked.'],
-      suggest: ['Suggest', 'Recommend tests where valuable, but do not write them unless asked.'],
-      always: ['Always write', 'Write tests for every meaningful change. Tests are required.'],
-    };
-    const COMMITS_LABELS: Record<string, [string, string]> = {
-      never: ['Never', 'Do not commit. The user handles commits.'],
-      milestones: ['At milestones', 'Commit when a coherent chunk of work is complete.'],
-      often: ['Frequently', 'Commit frequently with small focused commits after each meaningful change.'],
     };
     const BLOCKERS_LABELS: Record<string, [string, string]> = {
       ask: ['Stop & ask', 'When blocked, stop and ask the user how to proceed.'],
@@ -985,13 +961,7 @@ ${row('Before starting', PLANNING_LABELS, workStyle.planning)}
 
 ${row('Questions', QUESTIONS_LABELS, workStyle.questions)}
 
-${row('Research depth', RESEARCH_LABELS, workStyle.contextDepth)}
-
 ${row('Code scope', SCOPE_LABELS, workStyle.codeScope)}
-
-${row('Tests', TESTS_LABELS, workStyle.testing)}
-
-${row('Commits', COMMITS_LABELS, workStyle.commits)}
 
 ${row('On blockers', BLOCKERS_LABELS, workStyle.onBlockers)}
 

--- a/src/services/TrackerService.ts
+++ b/src/services/TrackerService.ts
@@ -77,9 +77,6 @@ export interface StageConfig {
 
 export type DecisionStyle = 'ask' | 'recommend' | 'decide';
 export type VerbosityStyle = 'brief' | 'detailed';
-export type PlanningStyle = 'dive_in' | 'plan_first' | 'plan_approval';
-export type QuestionsStyle = 'minimal' | 'one_at_a_time' | 'batch';
-export type CodeScopeStyle = 'minimal' | 'clean_as_go' | 'thorough';
 export type BlockerStyle = 'ask' | 'try_first' | 'continue';
 // How the agent should deliver questions/requests for review. Project-wide
 // preference; drives the "Input mode" block in every generated stage guide.
@@ -91,10 +88,6 @@ export const TRACKER_SKILL_REL_PATH = `.agents/skills/${TRACKER_SKILL_NAME}/SKIL
 export interface WorkStyle {
   decisionStyle: DecisionStyle;
   verbosity: VerbosityStyle;
-  planning: PlanningStyle;
-  questions: QuestionsStyle;
-  codeScope: CodeScopeStyle;
-  onBlockers: BlockerStyle;
   inputMode: InputModeStyle;
   customInstructions: string;
 }
@@ -102,10 +95,6 @@ export interface WorkStyle {
 export const DEFAULT_WORK_STYLE: WorkStyle = {
   decisionStyle: 'recommend',
   verbosity: 'brief',
-  planning: 'dive_in',
-  questions: 'batch',
-  codeScope: 'minimal',
-  onBlockers: 'ask',
   inputMode: 'ask_questions',
   customInstructions: '',
 };
@@ -913,26 +902,6 @@ export class TrackerService {
       brief: ['Brief', 'Be brief and concise. Skip preamble. Get to the point immediately.'],
       detailed: ['Detailed', 'Be thorough. Explain your reasoning and walk through your thinking.'],
     };
-    const PLANNING_LABELS: Record<string, [string, string]> = {
-      dive_in: ['Dive in', 'Start working immediately. No upfront plan needed unless the task is genuinely complex.'],
-      plan_first: ['Show plan first', 'Always present a plan of what you will do before starting work.'],
-      plan_approval: ['Plan + approval', 'Present a plan and wait for explicit approval before proceeding.'],
-    };
-    const QUESTIONS_LABELS: Record<string, [string, string]> = {
-      minimal: ['Minimal', 'Minimise questions. Infer intent and make reasonable assumptions. Only ask when truly blocked.'],
-      batch: ['Batch together', 'When you have multiple questions, ask them all in one message.'],
-      one_at_a_time: ['One at a time', 'Ask one question at a time, wait for the answer before asking the next.'],
-    };
-    const SCOPE_LABELS: Record<string, [string, string]> = {
-      minimal: ['Minimal', 'Change only what is necessary. Avoid scope creep and opportunistic cleanup.'],
-      clean_as_go: ['Clean as you go', 'Fix small nearby issues when you encounter them, but stay close to the task.'],
-      thorough: ['Thorough', 'Improve code quality proactively — refactor, clean up patterns, improve structure when relevant.'],
-    };
-    const BLOCKERS_LABELS: Record<string, [string, string]> = {
-      ask: ['Stop & ask', 'When blocked, stop and ask the user how to proceed.'],
-      try_first: ['Try alternatives first', 'Try reasonable alternatives before asking. Ask only if exhausted.'],
-      continue: ['Note & continue', 'Note the issue clearly and continue with the rest of the work.'],
-    };
     const INPUT_MODE_LABELS: Record<string, [string, string]> = {
       ask_questions: ['ask_questions tool', 'Use the ask_questions tool whenever you need input. Produces a detectable numbered prompt in the terminal.'],
       inline: ['Inline chat', 'Ask questions inline in the conversation. Before pausing, set state: "waiting_for_input" in status.json with a brief_description; set it back to "working" on resume.'],
@@ -956,14 +925,6 @@ export class TrackerService {
 ${row('Decisions', DECISION_LABELS, workStyle.decisionStyle)}
 
 ${row('Verbosity', VERBOSITY_LABELS, workStyle.verbosity)}
-
-${row('Before starting', PLANNING_LABELS, workStyle.planning)}
-
-${row('Questions', QUESTIONS_LABELS, workStyle.questions)}
-
-${row('Code scope', SCOPE_LABELS, workStyle.codeScope)}
-
-${row('On blockers', BLOCKERS_LABELS, workStyle.onBlockers)}
 
 ${row('Input mode', INPUT_MODE_LABELS, workStyle.inputMode)}
 ${custom}`;

--- a/src/services/TrackerService.ts
+++ b/src/services/TrackerService.ts
@@ -1142,10 +1142,7 @@ This skill is generated from tracker configuration. Treat \`tracker/stages.json\
 
 - Decisions: \`${workStyle.decisionStyle}\`
 - Verbosity: \`${workStyle.verbosity}\`
-- Questions: \`${workStyle.questions}\`
 - Input mode: \`${workStyle.inputMode}\`
-- Code scope: \`${workStyle.codeScope}\`
-- Testing: \`${workStyle.testing}\`
 
 ## Stage Playbooks
 

--- a/tracker/items/clean-up-style-tab/implementation.md
+++ b/tracker/items/clean-up-style-tab/implementation.md
@@ -1,0 +1,20 @@
+---
+title: "clean up the Style tab in the stages config. it seems redundant with some of the others. what can be removed?"
+slug: clean-up-style-tab
+updated: 2026-04-26
+---
+
+Removed the redundant global Style-tab settings from the tracker work-style model and UI. The Style tab now keeps only cross-stage preferences, while test, commit, and research controls remain expressed through their stage-specific settings.
+
+Key decisions:
+- Removed global `testing`, `commits`, and `contextDepth` from `WorkStyle` and `DEFAULT_WORK_STYLE`.
+- Removed the matching Style-tab rows from `TrackerStagesScreen`.
+- Removed the corresponding sections from generated `working-style.md`, so the generated guidance no longer duplicates stage-specific controls.
+- Kept `planning` and `codeScope` because they still express project-wide behavior that is not directly replaced by a single stage setting.
+
+Notes for cleanup:
+- Existing `work-style.json` files may still contain the removed keys, but loading remains backward-compatible because unknown JSON keys are ignored when merged into the current defaults.
+
+## Stage review
+
+Implemented the approved cleanup by removing the redundant global Style-tab controls for testing, commits, and research depth. Verified with `npm run build`, `npm run typecheck`, and `npm test -- --runInBand tests/unit/tracker.test.ts`.

--- a/tracker/items/clean-up-style-tab/implementation.md
+++ b/tracker/items/clean-up-style-tab/implementation.md
@@ -4,17 +4,18 @@ slug: clean-up-style-tab
 updated: 2026-04-26
 ---
 
-Removed the redundant global Style-tab settings from the tracker work-style model and UI. The Style tab now keeps only cross-stage preferences, while test, commit, and research controls remain expressed through their stage-specific settings.
+Removed the redundant global Style-tab settings from the tracker work-style model and UI. The Style tab now keeps only the smallest set of cross-stage preferences that still have clear direct meaning in the generated guidance.
 
 Key decisions:
 - Removed global `testing`, `commits`, and `contextDepth` from `WorkStyle` and `DEFAULT_WORK_STYLE`.
 - Removed the matching Style-tab rows from `TrackerStagesScreen`.
 - Removed the corresponding sections from generated `working-style.md`, so the generated guidance no longer duplicates stage-specific controls.
-- Kept `planning` and `codeScope` because they still express project-wide behavior that is not directly replaced by a single stage setting.
+- After review, also removed global `planning`, `questions`, `codeScope`, and `onBlockers` to keep the Style tab short and focused.
+- The remaining Style-tab controls are `decisionStyle`, `verbosity`, `inputMode`, and `customInstructions`.
 
 Notes for cleanup:
 - Existing `work-style.json` files may still contain the removed keys, but loading remains backward-compatible because unknown JSON keys are ignored when merged into the current defaults.
 
 ## Stage review
 
-Implemented the approved cleanup by removing the redundant global Style-tab controls for testing, commits, and research depth. Verified with `npm run build`, `npm run typecheck`, and `npm test -- --runInBand tests/unit/tracker.test.ts`.
+Implemented the Style-tab reduction in two passes: first removed the clearly redundant stage-overlap controls, then reduced the remaining prompt-shaping globals so the tab stays short. Verified with `npm run typecheck` and `npm test -- --runInBand tests/unit/tracker.test.ts`.

--- a/tracker/items/clean-up-style-tab/notes.md
+++ b/tracker/items/clean-up-style-tab/notes.md
@@ -1,0 +1,26 @@
+---
+title: "clean up the Style tab in the stages config. it seems redundant with some of the others. what can be removed?"
+slug: clean-up-style-tab
+updated: 2026-04-26
+---
+
+## Problem
+
+The Style tab in the tracker stages configuration currently mixes true project-wide workflow preferences with settings that overlap stage-specific controls. That makes the UI harder to understand and creates multiple places that appear to control similar behavior.
+
+## Why
+
+If the same behavior is configurable from both the Style tab and an individual stage tab, users have to guess which setting wins or whether both matter. Cleaning that up should make stage configuration easier to reason about and reduce redundant prompts and generated guidance.
+
+## Findings
+
+- `requirements.style` and `requirements.detail` are already stage-specific and have distinct effects in generated requirements guidance.
+- Global `inputMode` is intentionally shared across stages and is referenced explicitly from stage generation and the Style tab comments.
+- Global `testing` overlaps with stage-specific `implement.tdd` and `cleanup.tests`.
+- Global `commits` overlaps with stage-specific `implement.commit_style`.
+- Global `contextDepth` is close to `discovery.effort` and partially overlaps `implement.start_with=explore`, though it still acts as a broader project-wide research preference.
+- Global `planning` and `codeScope` are broad behavioral preferences, but they should be reviewed for whether they still add value now that stage tabs carry more concrete knobs.
+
+## Recommendation
+
+Remove the clearly redundant Style-tab controls first: `testing` and `commits`. Evaluate `contextDepth` next and either remove it or narrow its meaning so it no longer overlaps discovery and implementation exploration controls. Keep `decisionStyle`, `verbosity`, `questions`, `onBlockers`, `inputMode`, and `customInstructions` as global preferences. Treat `planning` and `codeScope` as follow-up review items unless code inspection shows they are unused or fully duplicated elsewhere.

--- a/tracker/items/clean-up-style-tab/requirements.md
+++ b/tracker/items/clean-up-style-tab/requirements.md
@@ -1,7 +1,27 @@
 ---
 title: "clean up the Style tab in the stages config. it seems redundant with some of the others. what can be removed?"
 slug: clean-up-style-tab
-updated: 2026-04-22
+updated: 2026-04-26
 ---
 
-clean up the Style tab in the stages config. it seems redundant with some of the others. what can be removed?
+## Problem
+
+The Style tab in the tracker stages configuration currently mixes true project-wide workflow preferences with settings that overlap stage-specific controls. That makes the UI harder to understand and creates multiple places that appear to control similar behavior.
+
+## Why
+
+If the same behavior is configurable from both the Style tab and an individual stage tab, users have to guess which setting wins or whether both matter. Cleaning that up should make stage configuration easier to reason about and reduce redundant prompts and generated guidance.
+
+## Summary
+
+Simplify the Style tab so it contains only project-wide agent preferences. Remove the controls that are already represented more concretely on individual stage tabs, starting with global testing and commit preferences. Review the remaining borderline fields and either keep them with a clearly global meaning or remove them if they are effectively duplicates of per-stage controls.
+
+## Acceptance criteria
+
+1. The implementation identifies which current Style-tab fields are retained as global preferences and which are removed as redundant.
+2. The implementation removes global `testing` because its behavior is already covered by `implement.tdd` and `cleanup.tests`.
+3. The implementation removes global `commits` because its behavior is already covered by `implement.commit_style`.
+4. The implementation explicitly decides the fate of global `contextDepth`, documenting whether it is removed or kept with a narrowed, clearly distinct meaning from `discovery.effort` and `implement.start_with`.
+5. The implementation keeps global controls that still have genuinely cross-stage meaning, including `decisionStyle`, `verbosity`, `questions`, `onBlockers`, `inputMode`, and `customInstructions`, unless code inspection proves one of them unused.
+6. The implementation updates generated guidance, defaults, and any affected tests so the tracker UI and generated stage skill no longer describe removed Style-tab settings.
+7. The implementation does not remove `requirements.style` or `requirements.detail`, because those are stage-specific controls with distinct tested behavior.

--- a/tracker/items/clean-up-style-tab/requirements.md
+++ b/tracker/items/clean-up-style-tab/requirements.md
@@ -1,0 +1,7 @@
+---
+title: "clean up the Style tab in the stages config. it seems redundant with some of the others. what can be removed?"
+slug: clean-up-style-tab
+updated: 2026-04-22
+---
+
+clean up the Style tab in the stages config. it seems redundant with some of the others. what can be removed?


### PR DESCRIPTION
## Summary
- simplify the tracker Style tab to keep only the core global controls
- remove redundant work-style fields and generated working-style snapshot lines that overlapped stage settings
- add tracker item notes, requirements, and implementation docs for the cleanup item

## Why
The Style tab had grown into a mix of true global preferences and knobs that either duplicated stage-specific settings or only added prompt-shaping noise. This change keeps the tab short and makes the generated guidance easier to reason about.

## Testing
- npm run typecheck
- npm test -- --runInBand tests/unit/tracker.test.ts
