### PR TITLE
fix(tracker): drain item description into worktree on first attach

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -253,7 +253,7 @@ function AppContent() {
     let worktree = worktrees.find(wt => wt.project === project.name && wt.feature === item.slug) || null;
     if (!worktree) worktree = await recreateImplementWorktree(project.name, item.slug);
     if (!worktree) return null;
-    tracker.ensureItemFiles(project.path, item.slug, worktree.path, item);
+    tracker.ensureItemFiles(project.path, item.slug, worktree.path);
     return worktree;
   };
 

--- a/src/services/TrackerService.ts
+++ b/src/services/TrackerService.ts
@@ -681,8 +681,7 @@ export class TrackerService {
   // old behaviour. No requirements.md stub is created — that file only appears
   // once the requirements stage produces real content. Commits to the worktree
   // branch so the seed survives a future worktree obliteration.
-  ensureItemFiles(mainProjectPath: string, slug: string, worktreePath: string, item?: TrackerItem): void {
-    void item; // signature retained for callers; title fallback now reads from the index
+  ensureItemFiles(mainProjectPath: string, slug: string, worktreePath: string, _item?: TrackerItem): void {
     const destDir = path.join(worktreePath, 'tracker', 'items', slug);
     ensureDirectory(destDir);
 
@@ -741,8 +740,7 @@ export class TrackerService {
     const index = this.readIndex(projectPath);
     const entry = index.sessions?.[slug];
     if (!entry || entry.description === undefined) return;
-    const {description: _drop, ...rest} = entry;
-    void _drop;
+    const {description: _, ...rest} = entry;
     const sessions = {...(index.sessions ?? {})};
     sessions[slug] = rest;
     index.sessions = sessions;

--- a/src/services/TrackerService.ts
+++ b/src/services/TrackerService.ts
@@ -673,22 +673,19 @@ export class TrackerService {
   }
 
   // Ensures the item's content files exist inside the worktree at
-  // <wt>/tracker/items/<slug>/. New items don't have any files yet; this is where
-  // the user-typed description (stashed on `index.sessions[slug].description` by
-  // createItem) gets drained into notes.md so the body lands in the worktree, not
-  // the project root. Pre-existing legacy main-project layouts are migrated and
-  // then the source dir is deleted to clean up project-root pollution from the
-  // old behaviour. No requirements.md stub is created — that file only appears
-  // once the requirements stage produces real content. Commits to the worktree
-  // branch so the seed survives a future worktree obliteration.
-  ensureItemFiles(mainProjectPath: string, slug: string, worktreePath: string, _item?: TrackerItem): void {
+  // <wt>/tracker/items/<slug>/. New items have no files yet; this is where the
+  // user-typed description (stashed on `index.sessions[slug].description` by
+  // createItem) drains into notes.md so the body lands in the worktree, not the
+  // project root. Pre-existing legacy main-project layouts are migrated and the
+  // source dir is removed to clean up project-root pollution from the old
+  // behaviour. Commits to the worktree branch so the seed survives a future
+  // worktree obliteration.
+  ensureItemFiles(mainProjectPath: string, slug: string, worktreePath: string): void {
     const destDir = path.join(worktreePath, 'tracker', 'items', slug);
     ensureDirectory(destDir);
 
     let wroteAnything = false;
 
-    // 1) Migrate from legacy locations into the worktree, then delete the source dir
-    // so the main project tree gets cleaned up. Highest-priority sources first.
     const legacySources = [
       path.join(worktreePath, 'tracker', slug),
       ...this.findLegacyMainProjectDirs(mainProjectPath, slug),
@@ -701,50 +698,36 @@ export class TrackerService {
         fs.copyFileSync(path.join(src, file), destFile);
         wroteAnything = true;
       }
-      // The legacy worktree-internal source (`<wt>/tracker/<slug>/`) sits inside the
-      // worktree itself; deleting it is the same act as moving its contents up. The
-      // main-project legacy sources are real project-root pollution that we want gone.
       fs.rmSync(src, {recursive: true, force: true});
     }
 
-    // 2) Drain a user-typed description from the index into notes.md. createItem
-    // stashes the body here when no worktree exists; we only get to write it once.
-    const notesPath = path.join(destDir, 'notes.md');
-    if (!fs.existsSync(notesPath)) {
-      const description = this.readSessionDescription(mainProjectPath, slug);
-      if (description) {
-        fs.writeFileSync(notesPath, `${description}\n`);
-        wroteAnything = true;
+    // Drain (and clear) any stashed description from the index in a single
+    // read-modify-write. We always clear it once a worktree exists — even if
+    // notes.md already came from legacy migration, the description has served
+    // its purpose and shouldn't linger.
+    if (this.hasTracker(mainProjectPath)) {
+      const index = this.readIndex(mainProjectPath);
+      const entry = index.sessions?.[slug];
+      if (entry?.description !== undefined) {
+        const notesPath = path.join(destDir, 'notes.md');
+        if (!fs.existsSync(notesPath)) {
+          fs.writeFileSync(notesPath, `${entry.description}\n`);
+          wroteAnything = true;
+        }
+        const {description: _, ...rest} = entry;
+        const sessions = {...(index.sessions ?? {})};
+        sessions[slug] = rest;
+        index.sessions = sessions;
+        writeJSONAtomic(this.getIndexPath(mainProjectPath), index);
       }
     }
-    // Always clear the field once we've reached the worktree — even if notes.md
-    // already existed (e.g. legacy migration produced one), the description has
-    // served its purpose and shouldn't linger on the index.
-    this.clearSessionDescription(mainProjectPath, slug);
 
-    // 3) Commit the seeded files only if we actually wrote something. Skipping the
+    // Commit the seeded files only if we actually wrote something. Skipping the
     // empty-commit attempt avoids a couple of git fork+exec calls on every reattach.
     if (!wroteAnything) return;
     const relativeDestDir = path.relative(worktreePath, destDir);
     runCommandQuick(['git', '-C', worktreePath, 'add', relativeDestDir]);
     runCommandQuick(['git', '-C', worktreePath, 'commit', '-m', `tracker: seed item files for ${slug}`]);
-  }
-
-  private readSessionDescription(projectPath: string, slug: string): string | undefined {
-    if (!this.hasTracker(projectPath)) return undefined;
-    return this.readIndex(projectPath).sessions?.[slug]?.description;
-  }
-
-  private clearSessionDescription(projectPath: string, slug: string): void {
-    if (!this.hasTracker(projectPath)) return;
-    const index = this.readIndex(projectPath);
-    const entry = index.sessions?.[slug];
-    if (!entry || entry.description === undefined) return;
-    const {description: _, ...rest} = entry;
-    const sessions = {...(index.sessions ?? {})};
-    sessions[slug] = rest;
-    index.sessions = sessions;
-    writeJSONAtomic(this.getIndexPath(projectPath), index);
   }
 
   private findLegacyMainProjectDirs(projectPath: string, slug: string): string[] {

--- a/src/services/TrackerService.ts
+++ b/src/services/TrackerService.ts
@@ -221,9 +221,12 @@ export interface TrackerIndex {
   backlog?: Partial<Record<TrackerBacklogStage, string[]>>;
   implementation?: Partial<Record<TrackerImplementationStage, string[]>>;
   archive?: string[];
-  // Sidecar metadata keyed by slug (currently just the title, used to display items
-  // on the board before their requirements file is materialised).
-  sessions?: Record<string, {title?: string; inactive?: boolean}>;
+  // Sidecar metadata keyed by slug. `title` is used to display items on the board
+  // before their requirements file is materialised. `description` is the user-typed
+  // body captured at item creation; ensureItemFiles drains it into notes.md inside
+  // the worktree the first time one exists, so the body lands in the worktree (not
+  // in the project root) without leaving a staging file behind.
+  sessions?: Record<string, {title?: string; inactive?: boolean; description?: string}>;
 }
 
 export interface TrackerFrontmatter {
@@ -553,30 +556,15 @@ export class TrackerService {
     this.removeSlugFromIndexObj(index, slug);
     this.addSlugToIndexObj(index, slug, stage);
     const sessions = (index.sessions ?? {}) as NonNullable<TrackerIndex['sessions']>;
-    sessions[slug] = {...sessions[slug], title};
+    const entry: NonNullable<TrackerIndex['sessions']>[string] = {...sessions[slug], title};
+    // The user's initial description (the "what / why" they had in mind when they
+    // created the item) is the discovery stage's notes.md content. We can't write
+    // notes.md here because no worktree exists yet — stash it on the index and let
+    // ensureItemFiles drain it into the worktree once one is created.
+    if (body && body !== title) entry.description = body;
+    sessions[slug] = entry;
     index.sessions = sessions;
     writeJSONAtomic(this.getIndexPath(projectPath), index);
-    const mainItemDir = path.join(projectPath, 'tracker', 'items', slug);
-    ensureDirectory(mainItemDir);
-    // Requirements is just a stub with the title — it's written for real during
-    // the requirements stage. The user's initial description (the "what / why"
-    // they had in mind when they created the item) goes into notes.md, which is
-    // the discovery stage's output file.
-    this.writeRequirementsStub(path.join(mainItemDir, 'requirements.md'), title, slug, title);
-    if (body && body !== title) {
-      const notesPath = path.join(mainItemDir, 'notes.md');
-      if (!fs.existsSync(notesPath)) fs.writeFileSync(notesPath, `${body}\n`);
-    }
-  }
-
-  private writeRequirementsStub(reqPath: string, title: string, slug: string, body: string): boolean {
-    if (fs.existsSync(reqPath)) return false;
-    const today = new Date().toISOString().slice(0, 10);
-    // Strip newlines and quote the title so YAML-significant characters (":",
-    // "'", "[", "!") in user-typed titles can't forge frontmatter keys.
-    const yamlTitle = JSON.stringify(title.replace(/[\r\n]+/g, ' ').trim());
-    fs.writeFileSync(reqPath, `---\ntitle: ${yamlTitle}\nslug: ${slug}\nupdated: ${today}\n---\n\n${body}\n`);
-    return true;
   }
 
   async deriveSlug(title: string, existingSlugs: string[]): Promise<string> {
@@ -685,19 +673,23 @@ export class TrackerService {
   }
 
   // Ensures the item's content files exist inside the worktree at
-  // <wt>/tracker/items/<slug>/. Migrates files from any legacy location (older
-  // `<wt>/tracker/<slug>/` layout, or pre-refactor main-project bucket dirs) if
-  // present, otherwise creates a fresh requirements.md stub. Commits to the worktree
+  // <wt>/tracker/items/<slug>/. New items don't have any files yet; this is where
+  // the user-typed description (stashed on `index.sessions[slug].description` by
+  // createItem) gets drained into notes.md so the body lands in the worktree, not
+  // the project root. Pre-existing legacy main-project layouts are migrated and
+  // then the source dir is deleted to clean up project-root pollution from the
+  // old behaviour. No requirements.md stub is created — that file only appears
+  // once the requirements stage produces real content. Commits to the worktree
   // branch so the seed survives a future worktree obliteration.
   ensureItemFiles(mainProjectPath: string, slug: string, worktreePath: string, item?: TrackerItem): void {
+    void item; // signature retained for callers; title fallback now reads from the index
     const destDir = path.join(worktreePath, 'tracker', 'items', slug);
     ensureDirectory(destDir);
-    const reqPath = path.join(destDir, 'requirements.md');
 
     let wroteAnything = false;
 
-    // 1) Migrate from legacy locations (highest priority first), then the main-project
-    // stub written by createItem as a last resort.
+    // 1) Migrate from legacy locations into the worktree, then delete the source dir
+    // so the main project tree gets cleaned up. Highest-priority sources first.
     const legacySources = [
       path.join(worktreePath, 'tracker', slug),
       ...this.findLegacyMainProjectDirs(mainProjectPath, slug),
@@ -710,13 +702,26 @@ export class TrackerService {
         fs.copyFileSync(path.join(src, file), destFile);
         wroteAnything = true;
       }
+      // The legacy worktree-internal source (`<wt>/tracker/<slug>/`) sits inside the
+      // worktree itself; deleting it is the same act as moving its contents up. The
+      // main-project legacy sources are real project-root pollution that we want gone.
+      fs.rmSync(src, {recursive: true, force: true});
     }
 
-    // 2) If we still have no requirements.md, write a fresh stub.
-    const stubTitle = item?.title || slug;
-    if (this.writeRequirementsStub(reqPath, stubTitle, slug, stubTitle)) {
-      wroteAnything = true;
+    // 2) Drain a user-typed description from the index into notes.md. createItem
+    // stashes the body here when no worktree exists; we only get to write it once.
+    const notesPath = path.join(destDir, 'notes.md');
+    if (!fs.existsSync(notesPath)) {
+      const description = this.readSessionDescription(mainProjectPath, slug);
+      if (description) {
+        fs.writeFileSync(notesPath, `${description}\n`);
+        wroteAnything = true;
+      }
     }
+    // Always clear the field once we've reached the worktree — even if notes.md
+    // already existed (e.g. legacy migration produced one), the description has
+    // served its purpose and shouldn't linger on the index.
+    this.clearSessionDescription(mainProjectPath, slug);
 
     // 3) Commit the seeded files only if we actually wrote something. Skipping the
     // empty-commit attempt avoids a couple of git fork+exec calls on every reattach.
@@ -724,6 +729,24 @@ export class TrackerService {
     const relativeDestDir = path.relative(worktreePath, destDir);
     runCommandQuick(['git', '-C', worktreePath, 'add', relativeDestDir]);
     runCommandQuick(['git', '-C', worktreePath, 'commit', '-m', `tracker: seed item files for ${slug}`]);
+  }
+
+  private readSessionDescription(projectPath: string, slug: string): string | undefined {
+    if (!this.hasTracker(projectPath)) return undefined;
+    return this.readIndex(projectPath).sessions?.[slug]?.description;
+  }
+
+  private clearSessionDescription(projectPath: string, slug: string): void {
+    if (!this.hasTracker(projectPath)) return;
+    const index = this.readIndex(projectPath);
+    const entry = index.sessions?.[slug];
+    if (!entry || entry.description === undefined) return;
+    const {description: _drop, ...rest} = entry;
+    void _drop;
+    const sessions = {...(index.sessions ?? {})};
+    sessions[slug] = rest;
+    index.sessions = sessions;
+    writeJSONAtomic(this.getIndexPath(projectPath), index);
   }
 
   private findLegacyMainProjectDirs(projectPath: string, slug: string): string[] {
@@ -794,7 +817,7 @@ export class TrackerService {
       body = parsed.body;
     }
     const resolvedSlug = frontmatter.slug || slug;
-    const title = frontmatter.title || firstNonEmptyLine(body) || resolvedSlug;
+    const title = frontmatter.title || index.sessions?.[slug]?.title || firstNonEmptyLine(body) || resolvedSlug;
     const implementationPath = path.join(itemDir, 'implementation.md');
     const notesPath = path.join(itemDir, 'notes.md');
     return {

--- a/tests/unit/tracker-board-create-flow.test.ts
+++ b/tests/unit/tracker-board-create-flow.test.ts
@@ -29,13 +29,29 @@ describe('board create-item flow (derive-first, no rename)', () => {
     expect(col.items.map(i => i.slug)).not.toContain('add-oauth-login-for'); // no temp slug
   });
 
-  test('user-typed description is written to notes.md (discovery output), not requirements.md', () => {
+  test('user-typed description is stashed on the index for the worktree to drain, not written to the project root', () => {
     const description = 'Allow users to sign in with Google and GitHub via OAuth2.';
     service.createItem(tmpDir, 'OAuth Login', 'backlog', 'oauth-login', description);
-    const notesPath = path.join(tmpDir, 'tracker', 'items', 'oauth-login', 'notes.md');
-    expect(fs.readFileSync(notesPath, 'utf8')).toContain(description);
-    const reqPath = path.join(tmpDir, 'tracker', 'items', 'oauth-login', 'requirements.md');
-    expect(fs.readFileSync(reqPath, 'utf8')).not.toContain(description);
+
+    const itemDir = path.join(tmpDir, 'tracker', 'items', 'oauth-login');
+    expect(fs.existsSync(itemDir)).toBe(false);
+
+    const index = JSON.parse(fs.readFileSync(path.join(tmpDir, 'tracker', 'index.json'), 'utf8'));
+    expect(index.sessions['oauth-login'].description).toBe(description);
+
+    const worktreeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'board-create-wt-'));
+    try {
+      service.ensureItemFiles(tmpDir, 'oauth-login', worktreeDir);
+      const wtItemDir = path.join(worktreeDir, 'tracker', 'items', 'oauth-login');
+      const notesPath = path.join(wtItemDir, 'notes.md');
+      expect(fs.readFileSync(notesPath, 'utf8')).toContain(description);
+      expect(fs.existsSync(path.join(wtItemDir, 'requirements.md'))).toBe(false);
+
+      const after = JSON.parse(fs.readFileSync(path.join(tmpDir, 'tracker', 'index.json'), 'utf8'));
+      expect(after.sessions['oauth-login'].description).toBeUndefined();
+    } finally {
+      fs.rmSync(worktreeDir, {recursive: true, force: true});
+    }
   });
 
   test('single-tool path calls onLaunchItemBackground immediately after slug derivation', async () => {

--- a/tests/unit/tracker-proposal-create.test.ts
+++ b/tests/unit/tracker-proposal-create.test.ts
@@ -40,31 +40,38 @@ describe('proposal acceptance: slug and description', () => {
     expect(index.backlog.backlog ?? []).not.toContain('oauth-login'.replace('-', '')); // not re-slugified
   });
 
-  test('proposal description is written to notes.md (discovery output)', () => {
+  test('proposal description is stashed on sessions[slug].description for the worktree to drain', () => {
     acceptProposals(tmpDir, proposals, new Set([0]));
-    const notesPath = path.join(tmpDir, 'tracker', 'items', 'oauth-login', 'notes.md');
-    expect(fs.existsSync(notesPath)).toBe(true);
-    expect(fs.readFileSync(notesPath, 'utf8')).toContain('Implement Google and GitHub OAuth2 sign-in flows.');
-    const reqPath = path.join(tmpDir, 'tracker', 'items', 'oauth-login', 'requirements.md');
-    const reqContent = fs.readFileSync(reqPath, 'utf8');
-    expect(reqContent).toMatch(/^title: "OAuth Login"$/m);
-    expect(reqContent).toMatch(/^slug: oauth-login$/m);
-    expect(reqContent).not.toContain('Implement Google and GitHub OAuth2 sign-in flows.');
+    const itemDir = path.join(tmpDir, 'tracker', 'items', 'oauth-login');
+    expect(fs.existsSync(itemDir)).toBe(false);
+
+    const index = JSON.parse(fs.readFileSync(path.join(tmpDir, 'tracker', 'index.json'), 'utf8'));
+    expect(index.sessions['oauth-login'].title).toBe('OAuth Login');
+    expect(index.sessions['oauth-login'].description).toBe('Implement Google and GitHub OAuth2 sign-in flows.');
+
+    const worktreeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'proposal-wt-'));
+    try {
+      service.ensureItemFiles(tmpDir, 'oauth-login', worktreeDir);
+      const notesPath = path.join(worktreeDir, 'tracker', 'items', 'oauth-login', 'notes.md');
+      expect(fs.readFileSync(notesPath, 'utf8')).toContain('Implement Google and GitHub OAuth2 sign-in flows.');
+      expect(fs.existsSync(path.join(worktreeDir, 'tracker', 'items', 'oauth-login', 'requirements.md'))).toBe(false);
+    } finally {
+      fs.rmSync(worktreeDir, {recursive: true, force: true});
+    }
   });
 
-  test('accepting multiple proposals creates notes.md for each with its description', () => {
+  test('accepting multiple proposals stashes a description for each on the index', () => {
     acceptProposals(tmpDir, proposals, new Set([0, 1]));
     const index = JSON.parse(fs.readFileSync(path.join(tmpDir, 'tracker', 'index.json'), 'utf8'));
     expect(index.backlog.backlog).toContain('oauth-login');
     expect(index.backlog.backlog).toContain('dark-mode');
-
-    const notesDark = path.join(tmpDir, 'tracker', 'items', 'dark-mode', 'notes.md');
-    expect(fs.readFileSync(notesDark, 'utf8')).toContain('Add a dark color scheme toggle to settings.');
+    expect(index.sessions['dark-mode'].description).toBe('Add a dark color scheme toggle to settings.');
   });
 
-  test('unaccepted proposals are not created', () => {
+  test('unaccepted proposals are not added to the index', () => {
     acceptProposals(tmpDir, proposals, new Set([0]));
-    const darkDir = path.join(tmpDir, 'tracker', 'items', 'dark-mode');
-    expect(fs.existsSync(darkDir)).toBe(false);
+    const index = JSON.parse(fs.readFileSync(path.join(tmpDir, 'tracker', 'index.json'), 'utf8'));
+    expect(index.backlog.backlog ?? []).not.toContain('dark-mode');
+    expect(index.sessions?.['dark-mode']).toBeUndefined();
   });
 });

--- a/tests/unit/tracker.test.ts
+++ b/tests/unit/tracker.test.ts
@@ -475,16 +475,15 @@ describe('defaultStageFileContent renders status + gate protocol', () => {
 // ─── createItem ─────────────────────────────────────────────────────────────
 
 describe('createItem', () => {
-  test('adds slug to index.json and writes requirements stub to main project', () => {
+  test('adds slug to index.json and stores the title in sessions; writes no files to the project root', () => {
     service.createItem(tmpDir, 'Add user auth', 'discovery');
 
     const indexPath = path.join(tmpDir, 'tracker', 'index.json');
     const index = JSON.parse(fs.readFileSync(indexPath, 'utf8'));
     expect(index.backlog.discovery).toContain('add-user-auth');
     expect(index.sessions['add-user-auth'].title).toBe('Add user auth');
-    const reqPath = path.join(tmpDir, 'tracker', 'items', 'add-user-auth', 'requirements.md');
-    expect(fs.existsSync(reqPath)).toBe(true);
-    expect(fs.readFileSync(reqPath, 'utf8')).toContain('Add user auth');
+    const itemDir = path.join(tmpDir, 'tracker', 'items', 'add-user-auth');
+    expect(fs.existsSync(itemDir)).toBe(false);
   });
 
   test('adds slug to index.json in correct stage', () => {
@@ -501,30 +500,38 @@ describe('createItem', () => {
     expect(index.implementation.implement).toContain('build-api');
   });
 
-  test('writes provided body to notes.md (discovery output), keeping requirements.md as a title stub', () => {
-    service.createItem(tmpDir, 'Add auth', 'discovery', undefined, 'Implement OAuth2 login with Google and GitHub providers.');
-    const notesPath = path.join(tmpDir, 'tracker', 'items', 'add-auth', 'notes.md');
-    expect(fs.readFileSync(notesPath, 'utf8')).toContain('Implement OAuth2 login with Google and GitHub providers.');
-    const reqContent = fs.readFileSync(path.join(tmpDir, 'tracker', 'items', 'add-auth', 'requirements.md'), 'utf8');
-    expect(reqContent).not.toContain('Implement OAuth2 login with Google and GitHub providers.');
+  test('stashes a provided body on sessions[slug].description for ensureItemFiles to drain into the worktree', () => {
+    const description = 'Implement OAuth2 login with Google and GitHub providers.';
+    service.createItem(tmpDir, 'Add auth', 'discovery', undefined, description);
+
+    const index = JSON.parse(fs.readFileSync(path.join(tmpDir, 'tracker', 'index.json'), 'utf8'));
+    expect(index.sessions['add-auth'].description).toBe(description);
+    const itemDir = path.join(tmpDir, 'tracker', 'items', 'add-auth');
+    expect(fs.existsSync(itemDir)).toBe(false);
   });
 
-  test('does not create notes.md when body is omitted', () => {
+  test('does not stash a description when body is omitted', () => {
     service.createItem(tmpDir, 'My Feature', 'discovery');
-    const notesPath = path.join(tmpDir, 'tracker', 'items', 'my-feature', 'notes.md');
-    expect(fs.existsSync(notesPath)).toBe(false);
-    const reqContent = fs.readFileSync(path.join(tmpDir, 'tracker', 'items', 'my-feature', 'requirements.md'), 'utf8');
-    expect(reqContent).toMatch(/\nMy Feature\n/);
+    const index = JSON.parse(fs.readFileSync(path.join(tmpDir, 'tracker', 'index.json'), 'utf8'));
+    expect(index.sessions['my-feature'].description).toBeUndefined();
+    const itemDir = path.join(tmpDir, 'tracker', 'items', 'my-feature');
+    expect(fs.existsSync(itemDir)).toBe(false);
+  });
+
+  test('does not stash a description when body is identical to the title (avoids the duplicate-of-title placeholder)', () => {
+    service.createItem(tmpDir, 'Same Body', 'discovery', undefined, 'Same Body');
+    const index = JSON.parse(fs.readFileSync(path.join(tmpDir, 'tracker', 'index.json'), 'utf8'));
+    expect(index.sessions['same-body'].description).toBeUndefined();
   });
 
   test('uses explicit slug when provided alongside body', () => {
-    service.createItem(tmpDir, 'Proposal Title', 'backlog', 'ai-derived-slug', 'Detailed description from proposal.');
-    const reqPath = path.join(tmpDir, 'tracker', 'items', 'ai-derived-slug', 'requirements.md');
-    expect(fs.existsSync(reqPath)).toBe(true);
-    const notesPath = path.join(tmpDir, 'tracker', 'items', 'ai-derived-slug', 'notes.md');
-    expect(fs.readFileSync(notesPath, 'utf8')).toContain('Detailed description from proposal.');
-    const reqContent = fs.readFileSync(reqPath, 'utf8');
-    expect(reqContent).toMatch(/^slug: ai-derived-slug$/m);
+    const description = 'Detailed description from proposal.';
+    service.createItem(tmpDir, 'Proposal Title', 'backlog', 'ai-derived-slug', description);
+    const index = JSON.parse(fs.readFileSync(path.join(tmpDir, 'tracker', 'index.json'), 'utf8'));
+    expect(index.sessions['ai-derived-slug'].title).toBe('Proposal Title');
+    expect(index.sessions['ai-derived-slug'].description).toBe(description);
+    const itemDir = path.join(tmpDir, 'tracker', 'items', 'ai-derived-slug');
+    expect(fs.existsSync(itemDir)).toBe(false);
   });
 });
 
@@ -1060,13 +1067,28 @@ describe('ensureItemFiles', () => {
     fs.rmSync(worktreeDir, {recursive: true, force: true});
   });
 
-  test('creates a fresh requirements.md in the worktree at tracker/items/<slug>/', () => {
-    service.ensureItemFiles(tmpDir, 'my-feature', worktreeDir, {title: 'My Feature'} as any);
+  test('writes notes.md (no requirements.md stub) when sessions[slug].description is set', () => {
+    const description = 'Build the thing the way the user described it.';
+    service.createItem(tmpDir, 'My Feature', 'implement', 'with-body', description);
+    service.ensureItemFiles(tmpDir, 'with-body', worktreeDir);
+    const destDir = path.join(worktreeDir, 'tracker', 'items', 'with-body');
+    expect(fs.readFileSync(path.join(destDir, 'notes.md'), 'utf8')).toBe(`${description}\n`);
+    expect(fs.existsSync(path.join(destDir, 'requirements.md'))).toBe(false);
+  });
+
+  test('clears sessions[slug].description from the index after draining it into the worktree', () => {
+    service.createItem(tmpDir, 'My Feature', 'implement', 'drain-once', 'one-shot description');
+    service.ensureItemFiles(tmpDir, 'drain-once', worktreeDir);
+    const index = JSON.parse(fs.readFileSync(service.getIndexPath(tmpDir), 'utf8'));
+    expect(index.sessions['drain-once'].description).toBeUndefined();
+    expect(index.sessions['drain-once'].title).toBe('My Feature');
+  });
+
+  test('writes nothing when there is no description and no legacy source', () => {
+    service.ensureItemFiles(tmpDir, 'my-feature', worktreeDir);
     const destDir = path.join(worktreeDir, 'tracker', 'items', 'my-feature');
-    expect(fs.existsSync(destDir)).toBe(true);
-    const reqPath = path.join(destDir, 'requirements.md');
-    expect(fs.existsSync(reqPath)).toBe(true);
-    expect(fs.readFileSync(reqPath, 'utf8')).toContain('title: "My Feature"');
+    expect(fs.existsSync(path.join(destDir, 'requirements.md'))).toBe(false);
+    expect(fs.existsSync(path.join(destDir, 'notes.md'))).toBe(false);
   });
 
   test('does NOT create tracker/index.json in the worktree', () => {
@@ -1074,15 +1096,16 @@ describe('ensureItemFiles', () => {
     expect(fs.existsSync(path.join(worktreeDir, 'tracker', 'index.json'))).toBe(false);
   });
 
-  test('does not overwrite existing files in worktree', () => {
-    const destDir = path.join(worktreeDir, 'tracker', 'items', 'my-feature');
+  test('does not overwrite existing notes.md in worktree', () => {
+    service.createItem(tmpDir, 'Existing', 'implement', 'existing-notes', 'fresh description');
+    const destDir = path.join(worktreeDir, 'tracker', 'items', 'existing-notes');
     fs.mkdirSync(destDir, {recursive: true});
-    fs.writeFileSync(path.join(destDir, 'requirements.md'), 'existing content');
-    service.ensureItemFiles(tmpDir, 'my-feature', worktreeDir);
-    expect(fs.readFileSync(path.join(destDir, 'requirements.md'), 'utf8')).toBe('existing content');
+    fs.writeFileSync(path.join(destDir, 'notes.md'), 'pre-existing notes');
+    service.ensureItemFiles(tmpDir, 'existing-notes', worktreeDir);
+    expect(fs.readFileSync(path.join(destDir, 'notes.md'), 'utf8')).toBe('pre-existing notes');
   });
 
-  test('migrates legacy main-project bucket files into the worktree', () => {
+  test('migrates legacy main-project bucket files into the worktree and deletes the source dir', () => {
     // Simulate a pre-refactor item with files in the main project tracker dir.
     const legacyDir = path.join(tmpDir, 'tracker', 'implementation', 'my-feature');
     fs.mkdirSync(legacyDir, {recursive: true});
@@ -1093,12 +1116,17 @@ describe('ensureItemFiles', () => {
     const destDir = path.join(worktreeDir, 'tracker', 'items', 'my-feature');
     expect(fs.readFileSync(path.join(destDir, 'requirements.md'), 'utf8')).toContain('Legacy');
     expect(fs.readFileSync(path.join(destDir, 'notes.md'), 'utf8')).toBe('legacy notes');
+    expect(fs.existsSync(legacyDir)).toBe(false);
   });
 
-  test('main project index.json is unchanged by seeding', () => {
-    const indexBefore = fs.readFileSync(service.getIndexPath(tmpDir), 'utf8');
+  test('migrates a legacy main-project items dir and deletes the source dir', () => {
+    const legacyItemsDir = path.join(tmpDir, 'tracker', 'items', 'my-feature');
+    fs.mkdirSync(legacyItemsDir, {recursive: true});
+    fs.writeFileSync(path.join(legacyItemsDir, 'requirements.md'), '---\ntitle: From Main\n---\nlegacy body');
+
     service.ensureItemFiles(tmpDir, 'my-feature', worktreeDir);
-    const indexAfter = fs.readFileSync(service.getIndexPath(tmpDir), 'utf8');
-    expect(indexAfter).toBe(indexBefore);
+    const destDir = path.join(worktreeDir, 'tracker', 'items', 'my-feature');
+    expect(fs.readFileSync(path.join(destDir, 'requirements.md'), 'utf8')).toContain('From Main');
+    expect(fs.existsSync(legacyItemsDir)).toBe(false);
   });
 });

--- a/tracker/items/requirements-in-worktree/requirements.md
+++ b/tracker/items/requirements-in-worktree/requirements.md
@@ -1,0 +1,7 @@
+---
+title: "requirements.md is created in project root instead of in the worktree. it should actually make notes.md, and in the worktree after a worktree is created. this is for the new item flow"
+slug: requirements-in-worktree
+updated: 2026-04-26
+---
+
+requirements.md is created in project root instead of in the worktree. it should actually make notes.md, and in the worktree after a worktree is created. this is for the new item flow


### PR DESCRIPTION
## Summary

- `createItem` no longer writes any files to `<projectPath>/tracker/items/<slug>/`. The user-typed description is stashed on `index.sessions[slug].description` and drained into `<worktree>/tracker/items/<slug>/notes.md` on the first `ensureItemFiles` call.
- No more `requirements.md` stub anywhere — that file only appears when the requirements stage produces real content. Existing orphan probes (`!currentItem.requirementsPath`) keep working because they check the path string, not file existence.
- `ensureItemFiles` migrates files from any legacy main-project location (the old `tracker/items/<slug>/` staging dir, plus pre-refactor `tracker/{backlog,implementation}/<slug>/` layouts) and **deletes the source dir** so the project root gets cleaned up.
- `readItem` title fallback now reads `index.sessions[slug].title` so the kanban renders the correct title even without the stub.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm test` — 724/724 pass
- [x] Updated tests in `tests/unit/tracker.test.ts`, `tests/unit/tracker-board-create-flow.test.ts`, `tests/unit/tracker-proposal-create.test.ts` to reflect index-only `createItem` and `ensureItemFiles` doing the file writes
- [ ] Smoke check: create an item via the kanban with a description, attach to its worktree, confirm `notes.md` lands in the worktree (not the project root) and `index.sessions[slug].description` is cleared
- [ ] Smoke check: open an existing pre-fix item, confirm legacy `<projectPath>/tracker/items/<slug>/` is migrated into the worktree and the source dir is removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)