### PR TITLE
Hide binary content in diff view

### DIFF
--- a/src/shared/utils/diff/loadDiff.ts
+++ b/src/shared/utils/diff/loadDiff.ts
@@ -3,6 +3,8 @@ import {findBaseBranch} from '../gitHelpers.js';
 import {BASE_BRANCH_CANDIDATES} from '../../../constants.js';
 import type {DiffLine, DiffType} from './types.js';
 
+const BINARY_FILE_PLACEHOLDER = 'Binary file not shown';
+
 export function parseUnifiedDiff(diff: string): Map<string, DiffLine[]> {
   const fileContents = new Map<string, DiffLine[]>();
   if (!diff || !diff.trim()) return fileContents;
@@ -74,6 +76,23 @@ export async function resolveBaseCommitHash(worktreePath: string, diffType: Diff
   }
 }
 
+async function isBinaryUntrackedFile(worktreePath: string, filePath: string): Promise<boolean> {
+  try {
+    const numstat = await runCommandAsync([
+      'bash',
+      '-lc',
+      `cd ${JSON.stringify(worktreePath)} && git diff --no-index --numstat -- /dev/null ${JSON.stringify(filePath)} || true`,
+    ]);
+
+    if (!numstat.trim()) return true;
+
+    const firstLine = numstat.split('\n').find(Boolean) || '';
+    return firstLine.startsWith('-\t-\t');
+  } catch {
+    return true;
+  }
+}
+
 export async function loadDiff(worktreePath: string, diffType: DiffType = 'full', baseCommitHash?: string): Promise<DiffLine[]> {
   let diff: string | null = null;
 
@@ -91,6 +110,11 @@ export async function loadDiff(worktreePath: string, diffType: DiffType = 'full'
     for (const fp of untracked.split('\n').filter(Boolean)) {
       const fileLines: DiffLine[] = [];
       fileLines.push({type: 'header', text: `📁 ${fp} (new file)`, fileName: fp, headerType: 'file'});
+      if (await isBinaryUntrackedFile(worktreePath, fp)) {
+        fileLines.push({type: 'context', text: BINARY_FILE_PLACEHOLDER, fileName: fp});
+        fileContents.set(fp, fileLines);
+        continue;
+      }
       try {
         const cat = await runCommandAsync(['bash', '-lc', `cd ${JSON.stringify(worktreePath)} && sed -n '1,200p' ${JSON.stringify(fp)}`]);
         for (const l of (cat || '').split('\n')) {

--- a/tests/unit/loadDiff.test.ts
+++ b/tests/unit/loadDiff.test.ts
@@ -1,5 +1,6 @@
-import {describe, test, expect} from '@jest/globals';
-import {parseUnifiedDiff} from '../../src/shared/utils/diff/loadDiff.js';
+import {describe, test, expect, jest, beforeEach, afterEach} from '@jest/globals';
+import * as commandExecutor from '../../src/shared/utils/commandExecutor.js';
+import {loadDiff, parseUnifiedDiff} from '../../src/shared/utils/diff/loadDiff.js';
 
 describe('parseUnifiedDiff', () => {
   test('returns an empty map for empty input', () => {
@@ -102,5 +103,53 @@ describe('parseUnifiedDiff', () => {
     const lines = parseUnifiedDiff(diff).get('x.ts')!;
     const blank = lines.find(l => l.type === 'context' && l.text === ' ');
     expect(blank).toBeDefined();
+  });
+});
+
+describe('loadDiff', () => {
+  beforeEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('shows a placeholder for untracked binary files', async () => {
+    const runCommandAsync = jest.spyOn(commandExecutor, 'runCommandAsync').mockImplementation(async (args) => {
+      const command = args.join(' ');
+      if (command.includes('git diff --no-color --no-ext-diff')) return '';
+      if (command.includes('ls-files --others --exclude-standard')) return 'image.png';
+      if (command.includes('git diff --no-index --numstat -- /dev/null "image.png"')) return '-\t-\timage.png';
+      if (command.includes('sed -n')) return 'PNG_BINARY_CONTENT';
+      return '';
+    });
+
+    const lines = await loadDiff('/tmp/worktree', 'uncommitted');
+
+    expect(runCommandAsync).toHaveBeenCalled();
+    expect(lines).toEqual([
+      {type: 'header', text: '📁 image.png (new file)', fileName: 'image.png', headerType: 'file'},
+      {type: 'context', text: 'Binary file not shown', fileName: 'image.png'},
+    ]);
+  });
+
+  test('keeps preview lines for untracked text files', async () => {
+    jest.spyOn(commandExecutor, 'runCommandAsync').mockImplementation(async (args) => {
+      const command = args.join(' ');
+      if (command.includes('git diff --no-color --no-ext-diff')) return '';
+      if (command.includes('ls-files --others --exclude-standard')) return 'notes.txt';
+      if (command.includes('git diff --no-index --numstat -- /dev/null "notes.txt"')) return '2\t0\tnotes.txt';
+      if (command.includes('sed -n')) return 'hello\nworld';
+      return '';
+    });
+
+    const lines = await loadDiff('/tmp/worktree', 'uncommitted');
+
+    expect(lines).toEqual([
+      {type: 'header', text: '📁 notes.txt (new file)', fileName: 'notes.txt', headerType: 'file'},
+      {type: 'added', text: 'hello', fileName: 'notes.txt'},
+      {type: 'added', text: 'world', fileName: 'notes.txt'},
+    ]);
   });
 });

--- a/tracker/items/hide-binary-diff-content/implementation.md
+++ b/tracker/items/hide-binary-diff-content/implementation.md
@@ -1,0 +1,26 @@
+---
+title: "dont show binary file contents in diffview"
+slug: hide-binary-diff-content
+updated: 2026-04-26
+---
+
+## What changed
+
+- Updated `src/shared/utils/diff/loadDiff.ts` so untracked files are classified with Git before previewing contents.
+- If Git reports an untracked file as binary, the diff view now renders the file header and a single `Binary file not shown` placeholder row instead of reading file bytes into the terminal.
+- Untracked text files keep the existing preview behavior based on `sed -n '1,200p'`.
+- Added unit coverage in `tests/unit/loadDiff.test.ts` for both the binary placeholder path and the unchanged text preview path.
+
+## Key decisions
+
+- Used Git's own `diff --no-index --numstat` classification for untracked files so the behavior stays aligned with the existing tracked-file diff path.
+- Kept the fallback conservative: if the binary check does not produce a usable result, the file is treated as binary and its contents stay hidden.
+
+## Cleanup notes
+
+- Focused verification passed: `npm test -- tests/unit/loadDiff.test.ts --runInBand`.
+- Full repo verification passed for this change: `npm run typecheck` and `npm run build`.
+
+## Stage review
+
+Implemented the diff-loader change without altering the diff view UI model. The only behavior change is that untracked binary files now stay visible in review as file entries but no longer dump their contents into the terminal.

--- a/tracker/items/hide-binary-diff-content/notes.md
+++ b/tracker/items/hide-binary-diff-content/notes.md
@@ -1,0 +1,24 @@
+---
+title: "dont show binary file contents in diffview"
+slug: hide-binary-diff-content
+updated: 2026-04-21
+---
+
+## Problem
+
+The diff view currently renders raw contents for untracked files by shelling out to `sed -n '1,200p'` in [src/shared/utils/diff/loadDiff.ts](/home/mserv/projects/devteam-branches/hide-binary-diff-content/src/shared/utils/diff/loadDiff.ts:92). That works for text files, but it also means an untracked binary file can dump unreadable bytes directly into the CLI diff view. The tracked-file path is safer because it relies on `git diff`, which already suppresses binary content.
+
+## Why
+
+Showing binary payloads in the terminal is noisy and not useful for review. It can also break the readability of the diff view, create odd terminal output, and make navigation/commenting worse for a case where the user really just needs to know that a binary file exists and changed.
+
+## Findings
+
+- The bug is isolated to the untracked-file branch in `loadDiff()`.
+- Tracked diffs already go through `git diff --no-color --no-ext-diff`, so they inherit Git's binary handling and do not need a broader redesign.
+- The smallest fix is to detect whether an untracked file is text before reading it. If it is binary, render only a file header plus a short placeholder row instead of file contents.
+- The most practical detection path is to let Git classify the file from the worktree, rather than maintaining our own extension-based allowlist.
+
+## Recommendation
+
+Keep the existing diff model and UI. Change untracked-file loading so `loadDiff()` asks Git whether each untracked file is text or binary before attempting to read it. For binary files, add a single synthetic row such as `Binary file not shown` under the file header; for text files, preserve the current preview behavior. Add a focused unit test for `loadDiff()` and one diff-view rendering test that proves binary content is hidden.

--- a/tracker/items/hide-binary-diff-content/requirements.md
+++ b/tracker/items/hide-binary-diff-content/requirements.md
@@ -1,0 +1,7 @@
+---
+title: "dont show binary file contents in diffview"
+slug: hide-binary-diff-content
+updated: 2026-04-21
+---
+
+dont show binary file contents in diffview

--- a/tracker/items/hide-binary-diff-content/requirements.md
+++ b/tracker/items/hide-binary-diff-content/requirements.md
@@ -4,4 +4,30 @@ slug: hide-binary-diff-content
 updated: 2026-04-21
 ---
 
-dont show binary file contents in diffview
+## Problem
+
+The diff view currently renders raw contents for untracked files by shelling out to `sed -n '1,200p'` in [src/shared/utils/diff/loadDiff.ts](/home/mserv/projects/devteam-branches/hide-binary-diff-content/src/shared/utils/diff/loadDiff.ts:92). That works for text files, but it also means an untracked binary file can dump unreadable bytes directly into the CLI diff view. The tracked-file path is safer because it relies on `git diff`, which already suppresses binary content.
+
+## Why
+
+Showing binary payloads in the terminal is noisy and not useful for review. It can also break the readability of the diff view, create odd terminal output, and make navigation/commenting worse for a case where the user really just needs to know that a binary file exists and changed.
+
+## Summary
+
+Update diff loading so the diff view never renders raw contents for binary files. The change should focus on untracked-file handling in `loadDiff()`: text files should continue to show a preview, while binary files should appear in the file list and diff body with a clear placeholder message instead of content. The UI structure, navigation model, and comment flow should otherwise stay unchanged.
+
+## Acceptance criteria
+
+1. Opening diff view for a worktree with an untracked binary file does not render the file's raw bytes or decoded payload in the diff body.
+2. The diff still includes the binary file as a file entry so the user can see that it exists in the review set.
+3. Binary files render a concise placeholder row that makes it clear the content is intentionally hidden.
+4. Untracked text files keep the existing behavior of showing preview lines in the diff body.
+5. Existing tracked-file diffs continue to render through the current `git diff` path without regressions to normal text diffs.
+6. Automated test coverage is added for the binary-file path and proves the hidden-content behavior.
+
+## Edge cases
+
+- An untracked file with no readable text content should still produce a stable placeholder rather than an empty or broken section.
+- The binary check should work for nested paths and filenames with spaces or shell-sensitive characters.
+- If binary detection fails unexpectedly, the fallback should prefer not showing raw content over dumping unreadable bytes.
+- The placeholder row should behave like a normal diff row in unified and side-by-side rendering so navigation remains stable.


### PR DESCRIPTION
## Summary
- classify untracked files with Git before previewing them in diff view
- render a `Binary file not shown` placeholder for untracked binary files instead of dumping bytes into the terminal
- add unit coverage for the binary placeholder path and the existing text preview path

## Verification
- `npm test -- tests/unit/loadDiff.test.ts --runInBand`
- `npm run typecheck`
- `npm run build`
