### PR TITLE
fix(tracker): live AI status takes precedence over stale status.json

### DIFF
--- a/src/components/dialogs/TrackerProjectPickerDialog.tsx
+++ b/src/components/dialogs/TrackerProjectPickerDialog.tsx
@@ -4,7 +4,7 @@ import {TrackerService} from '../../services/TrackerService.js';
 import {useTerminalDimensions} from '../../hooks/useTerminalDimensions.js';
 import {useGitHubContext} from '../../contexts/GitHubContext.js';
 import {WorktreeInfo} from '../../models.js';
-import {computeCardStatusFlags, isItemPRMerged} from '../../screens/TrackerBoardScreen.js';
+import {computeCardStatusFlags, isItemPRMerged} from '../../shared/utils/trackerCardStatus.js';
 
 type ProjectRow = {
   name: string;

--- a/src/components/dialogs/TrackerProjectPickerDialog.tsx
+++ b/src/components/dialogs/TrackerProjectPickerDialog.tsx
@@ -42,12 +42,15 @@ export default function TrackerProjectPickerDialog({
       let working = 0;
       for (const w of worktrees) {
         if (w.project !== p.name) continue;
-        const aiStatus = w.session?.ai_status;
         const itemStatus = w.feature && hasTracker
           ? service.getItemStatus(p.path, w.feature)
           : null;
-        const prMerged = isItemPRMerged(w, pullRequests);
-        const flags = computeCardStatusFlags({aiStatus, itemStatus, prMerged, service});
+        const flags = computeCardStatusFlags({
+          aiStatus: w.session?.ai_status,
+          prMerged: isItemPRMerged(w, pullRequests),
+          freshWaiting: service.isItemWaiting(itemStatus),
+          freshReady: service.isItemReadyToAdvance(itemStatus),
+        });
         if (flags.isWaiting) waiting++;
         else if (flags.isWorking) working++;
       }

--- a/src/components/dialogs/TrackerProjectPickerDialog.tsx
+++ b/src/components/dialogs/TrackerProjectPickerDialog.tsx
@@ -2,7 +2,9 @@ import React, {useMemo, useState} from 'react';
 import {Box, Text, useInput} from 'ink';
 import {TrackerService} from '../../services/TrackerService.js';
 import {useTerminalDimensions} from '../../hooks/useTerminalDimensions.js';
+import {useGitHubContext} from '../../contexts/GitHubContext.js';
 import {WorktreeInfo} from '../../models.js';
+import {computeCardStatusFlags, isItemPRMerged} from '../../screens/TrackerBoardScreen.js';
 
 type ProjectRow = {
   name: string;
@@ -30,6 +32,7 @@ export default function TrackerProjectPickerDialog({
 }: Props) {
   const service = useMemo(() => new TrackerService(), []);
   const {rows: termRows} = useTerminalDimensions();
+  const {pullRequests} = useGitHubContext();
 
   const rows = useMemo<ProjectRow[]>(() => {
     return projects.map(p => {
@@ -39,13 +42,18 @@ export default function TrackerProjectPickerDialog({
       let working = 0;
       for (const w of worktrees) {
         if (w.project !== p.name) continue;
-        const s = w.session?.ai_status;
-        if (s === 'waiting') waiting++;
-        else if (s === 'working' || s === 'active') working++;
+        const aiStatus = w.session?.ai_status;
+        const itemStatus = w.feature && hasTracker
+          ? service.getItemStatus(p.path, w.feature)
+          : null;
+        const prMerged = isItemPRMerged(w, pullRequests);
+        const flags = computeCardStatusFlags({aiStatus, itemStatus, prMerged, service});
+        if (flags.isWaiting) waiting++;
+        else if (flags.isWorking) working++;
       }
       return {name: p.name, path: p.path, hasTracker, total, waiting, working};
     });
-  }, [projects, worktrees, service]);
+  }, [projects, worktrees, service, pullRequests]);
 
   const [selected, setSelected] = useState(() => {
     const idx = rows.findIndex(r => r.name === currentProjectName);

--- a/src/screens/TrackerBoardScreen.tsx
+++ b/src/screens/TrackerBoardScreen.tsx
@@ -697,15 +697,20 @@ export default function TrackerBoardScreen({
     );
   }
 
-  // Read each item's status.json once per render and reuse for both the
-  // title-bar tally below and the per-card render loop. Cheap reads, but the
-  // kanban re-renders on every keystroke — paying twice would be silly.
-  const itemStatusBySlug = new Map<string, ReturnType<TrackerService['getItemStatus']>>();
-  for (const col of board.columns) {
-    for (const item of col.items) {
-      itemStatusBySlug.set(item.slug, service.getItemStatus(projectPath, item.slug));
+  // Read each item's status.json once per worktree refresh and reuse for both
+  // the title-bar tally and the per-card render loop. Memoized on
+  // `[board, worktrees]` so keystroke re-renders don't replay disk reads;
+  // status.json updates land on the next refresh tick, matching the rest of
+  // the kanban's refresh cadence.
+  const itemStatusBySlug = React.useMemo(() => {
+    const map = new Map<string, ReturnType<TrackerService['getItemStatus']>>();
+    for (const col of board.columns) {
+      for (const item of col.items) {
+        map.set(item.slug, service.getItemStatus(projectPath, item.slug));
+      }
     }
-  }
+    return map;
+  }, [board, worktrees, service, projectPath]);
 
   let waitingCount = 0;
   let workingCount = 0;

--- a/src/screens/TrackerBoardScreen.tsx
+++ b/src/screens/TrackerBoardScreen.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import {Box, Text, useInput} from 'ink';
-import {ItemStatus, TrackerBoard, TrackerItem, TrackerService, TrackerStage} from '../services/TrackerService.js';
+import {TrackerBoard, TrackerItem, TrackerService, TrackerStage} from '../services/TrackerService.js';
 import {useKeyboardShortcuts} from '../hooks/useKeyboardShortcuts.js';
 import {useTerminalDimensions} from '../hooks/useTerminalDimensions.js';
 import {useUIContext} from '../contexts/UIContext.js';
@@ -72,21 +72,21 @@ function wrapToLines(text: string, width: number, maxLines: number): string[] {
 // inter-row gap so we get one extra item per column.
 const COLUMN_CHROME_ROWS = 3;
 
-// Single source of truth for "what does this card mean" flags. Live tmux AI
-// status takes precedence over file-based status.json signals so a stale
-// `waiting_for_input` / `waiting_for_approval` doesn't paint an actively
-// running agent yellow or green. Used by the per-card render, the title-bar
-// counts, and the project-switcher counts so all three stay in sync.
+// Live tmux AI status takes precedence over file-based status.json signals so
+// a stale `waiting_for_input` / `waiting_for_approval` doesn't paint an
+// actively running agent yellow or green. `freshWaiting` / `freshReady` come
+// from `TrackerService.isItemWaiting` / `isItemReadyToAdvance` (already
+// staleness-filtered).
 export function computeCardStatusFlags({
   aiStatus,
-  itemStatus,
   prMerged,
-  service,
+  freshWaiting,
+  freshReady,
 }: {
   aiStatus: AIStatus | undefined;
-  itemStatus: ItemStatus | null;
   prMerged: boolean;
-  service: Pick<TrackerService, 'isItemWaiting' | 'isItemReadyToAdvance'>;
+  freshWaiting: boolean;
+  freshReady: boolean;
 }): {
   readyToAdvance: boolean;
   isWaiting: boolean;
@@ -97,10 +97,8 @@ export function computeCardStatusFlags({
   const isWorking = aiStatus === 'working' || aiStatus === 'active';
   const hasSession = !!aiStatus && aiStatus !== 'not_running';
 
-  const readyToAdvance =
-    !prMerged && !isWorking && service.isItemReadyToAdvance(itemStatus);
-  const ralphWaiting =
-    !isWorking && !!itemStatus && !readyToAdvance && service.isItemWaiting(itemStatus);
+  const readyToAdvance = !prMerged && !isWorking && freshReady;
+  const ralphWaiting = !isWorking && !readyToAdvance && freshWaiting;
   const isWaiting = aiWaiting || ralphWaiting;
 
   return {readyToAdvance, isWaiting, isWorking, hasSession};
@@ -699,19 +697,28 @@ export default function TrackerBoardScreen({
     );
   }
 
-  // Count waiting / working items across all columns. Mirrors the per-card
-  // precedence so the title-bar tally agrees with what the cards show: live
-  // tmux state beats a stale status.json, but a fresh status.json still
-  // counts when there's no active session signal.
+  // Read each item's status.json once per render and reuse for both the
+  // title-bar tally below and the per-card render loop. Cheap reads, but the
+  // kanban re-renders on every keystroke — paying twice would be silly.
+  const itemStatusBySlug = new Map<string, ReturnType<TrackerService['getItemStatus']>>();
+  for (const col of board.columns) {
+    for (const item of col.items) {
+      itemStatusBySlug.set(item.slug, service.getItemStatus(projectPath, item.slug));
+    }
+  }
+
   let waitingCount = 0;
   let workingCount = 0;
   for (const col of board.columns) {
     for (const item of col.items) {
       const wt = getWorktreeForItem(item);
-      const aiStatus = wt?.session?.ai_status;
-      const itemStatus = service.getItemStatus(projectPath, item.slug);
-      const prMerged = isItemPRMerged(wt, pullRequests);
-      const flags = computeCardStatusFlags({aiStatus, itemStatus, prMerged, service});
+      const itemStatus = itemStatusBySlug.get(item.slug) ?? null;
+      const flags = computeCardStatusFlags({
+        aiStatus: wt?.session?.ai_status,
+        prMerged: isItemPRMerged(wt, pullRequests),
+        freshWaiting: service.isItemWaiting(itemStatus),
+        freshReady: service.isItemReadyToAdvance(itemStatus),
+      });
       if (flags.isWaiting) waitingCount++;
       else if (flags.isWorking) workingCount++;
     }
@@ -807,10 +814,15 @@ export default function TrackerBoardScreen({
             const isSelected = isActiveColumn && selectedRow === itemIndex;
             const wt = getWorktreeForItem(item);
             const aiStatus: AIStatus | undefined = wt?.session?.ai_status;
-            const itemStatus = service.getItemStatus(projectPath, item.slug);
+            const itemStatus = itemStatusBySlug.get(item.slug) ?? null;
             const prMerged = isItemPRMerged(wt, pullRequests);
             const {readyToAdvance, isWaiting, isWorking, hasSession} =
-              computeCardStatusFlags({aiStatus, itemStatus, prMerged, service});
+              computeCardStatusFlags({
+                aiStatus,
+                prMerged,
+                freshWaiting: service.isItemWaiting(itemStatus),
+                freshReady: service.isItemReadyToAdvance(itemStatus),
+              });
 
             // Session presence is now signalled by the running-status chip row
             // (rendered separately below); the ◆ branch in

--- a/src/screens/TrackerBoardScreen.tsx
+++ b/src/screens/TrackerBoardScreen.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import {Box, Text, useInput} from 'ink';
-import {TrackerBoard, TrackerItem, TrackerService, TrackerStage} from '../services/TrackerService.js';
+import {ItemStatus, TrackerBoard, TrackerItem, TrackerService, TrackerStage} from '../services/TrackerService.js';
 import {useKeyboardShortcuts} from '../hooks/useKeyboardShortcuts.js';
 import {useTerminalDimensions} from '../hooks/useTerminalDimensions.js';
 import {useUIContext} from '../contexts/UIContext.js';
@@ -71,6 +71,40 @@ function wrapToLines(text: string, width: number, maxLines: number): string[] {
 // 2 borders + 1 header. Items area starts on the row directly below the title — no
 // inter-row gap so we get one extra item per column.
 const COLUMN_CHROME_ROWS = 3;
+
+// Single source of truth for "what does this card mean" flags. Live tmux AI
+// status takes precedence over file-based status.json signals so a stale
+// `waiting_for_input` / `waiting_for_approval` doesn't paint an actively
+// running agent yellow or green. Used by the per-card render, the title-bar
+// counts, and the project-switcher counts so all three stay in sync.
+export function computeCardStatusFlags({
+  aiStatus,
+  itemStatus,
+  prMerged,
+  service,
+}: {
+  aiStatus: AIStatus | undefined;
+  itemStatus: ItemStatus | null;
+  prMerged: boolean;
+  service: Pick<TrackerService, 'isItemWaiting' | 'isItemReadyToAdvance'>;
+}): {
+  readyToAdvance: boolean;
+  isWaiting: boolean;
+  isWorking: boolean;
+  hasSession: boolean;
+} {
+  const aiWaiting = aiStatus === 'waiting';
+  const isWorking = aiStatus === 'working' || aiStatus === 'active';
+  const hasSession = !!aiStatus && aiStatus !== 'not_running';
+
+  const readyToAdvance =
+    !prMerged && !isWorking && service.isItemReadyToAdvance(itemStatus);
+  const ralphWaiting =
+    !isWorking && !!itemStatus && !readyToAdvance && service.isItemWaiting(itemStatus);
+  const isWaiting = aiWaiting || ralphWaiting;
+
+  return {readyToAdvance, isWaiting, isWorking, hasSession};
+}
 
 export function getTrackerCardDisplayState({
   prMerged,
@@ -665,14 +699,21 @@ export default function TrackerBoardScreen({
     );
   }
 
-  // Count waiting items across all columns
+  // Count waiting / working items across all columns. Mirrors the per-card
+  // precedence so the title-bar tally agrees with what the cards show: live
+  // tmux state beats a stale status.json, but a fresh status.json still
+  // counts when there's no active session signal.
   let waitingCount = 0;
   let workingCount = 0;
   for (const col of board.columns) {
     for (const item of col.items) {
-      const s = getSessionForItem(item)?.session?.ai_status;
-      if (s === 'waiting') waitingCount++;
-      else if (s === 'working' || s === 'active') workingCount++;
+      const wt = getWorktreeForItem(item);
+      const aiStatus = wt?.session?.ai_status;
+      const itemStatus = service.getItemStatus(projectPath, item.slug);
+      const prMerged = isItemPRMerged(wt, pullRequests);
+      const flags = computeCardStatusFlags({aiStatus, itemStatus, prMerged, service});
+      if (flags.isWaiting) waitingCount++;
+      else if (flags.isWorking) workingCount++;
     }
   }
 
@@ -765,21 +806,11 @@ export default function TrackerBoardScreen({
             const itemIndex = scrollTop + sliceIndex;
             const isSelected = isActiveColumn && selectedRow === itemIndex;
             const wt = getWorktreeForItem(item);
-            const sessWt = (wt?.session?.ai_status && wt.session.ai_status !== 'not_running') ? wt : null;
-            const aiStatus: AIStatus | undefined = sessWt?.session?.ai_status;
-            const aiWaiting = aiStatus === 'waiting';
-            const isWorking = aiStatus === 'working' || aiStatus === 'active';
-            const hasSession = !!sessWt;
-
-            // Ralph status signal: the agent self-reported a non-working
-            // state in status.json. `waiting_for_approval` gets its own green
-            // "ready to advance" treatment so it's spottable at a glance and
-            // can be acted on with the `m` shortcut from the board.
+            const aiStatus: AIStatus | undefined = wt?.session?.ai_status;
             const itemStatus = service.getItemStatus(projectPath, item.slug);
             const prMerged = isItemPRMerged(wt, pullRequests);
-            const readyToAdvance = !prMerged && service.isItemReadyToAdvance(itemStatus);
-            const ralphWaiting = !!itemStatus && !readyToAdvance && service.isItemWaiting(itemStatus);
-            const isWaiting = aiWaiting || ralphWaiting;
+            const {readyToAdvance, isWaiting, isWorking, hasSession} =
+              computeCardStatusFlags({aiStatus, itemStatus, prMerged, service});
 
             // Session presence is now signalled by the running-status chip row
             // (rendered separately below); the ◆ branch in

--- a/src/screens/TrackerBoardScreen.tsx
+++ b/src/screens/TrackerBoardScreen.tsx
@@ -670,6 +670,8 @@ export default function TrackerBoardScreen({
       }
     }
     return map;
+    // `worktrees` isn't read inside the memo body — it's the refresh tick we
+    // re-run on, since session state changes alongside it.
   }, [board, worktrees, service, projectPath]);
 
   let waitingCount = 0;

--- a/src/screens/TrackerBoardScreen.tsx
+++ b/src/screens/TrackerBoardScreen.tsx
@@ -7,8 +7,9 @@ import {useUIContext} from '../contexts/UIContext.js';
 import {useWorktreeContext} from '../contexts/WorktreeContext.js';
 import {useGitHubContext} from '../contexts/GitHubContext.js';
 import {WorktreeInfo} from '../models.js';
-import type {AIStatus, AITool, PRStatus} from '../models.js';
+import type {AIStatus, AITool} from '../models.js';
 import {truncateDisplay} from '../shared/utils/formatting.js';
+import {computeCardStatusFlags, isItemPRMerged} from '../shared/utils/trackerCardStatus.js';
 import {logError} from '../shared/utils/logger.js';
 import {startIntervalIfEnabled} from '../shared/utils/intervals.js';
 import {VISIBLE_STATUS_REFRESH_DURATION} from '../constants.js';
@@ -71,38 +72,6 @@ function wrapToLines(text: string, width: number, maxLines: number): string[] {
 // 2 borders + 1 header. Items area starts on the row directly below the title — no
 // inter-row gap so we get one extra item per column.
 const COLUMN_CHROME_ROWS = 3;
-
-// Live tmux AI status takes precedence over file-based status.json signals so
-// a stale `waiting_for_input` / `waiting_for_approval` doesn't paint an
-// actively running agent yellow or green. `freshWaiting` / `freshReady` come
-// from `TrackerService.isItemWaiting` / `isItemReadyToAdvance` (already
-// staleness-filtered).
-export function computeCardStatusFlags({
-  aiStatus,
-  prMerged,
-  freshWaiting,
-  freshReady,
-}: {
-  aiStatus: AIStatus | undefined;
-  prMerged: boolean;
-  freshWaiting: boolean;
-  freshReady: boolean;
-}): {
-  readyToAdvance: boolean;
-  isWaiting: boolean;
-  isWorking: boolean;
-  hasSession: boolean;
-} {
-  const aiWaiting = aiStatus === 'waiting';
-  const isWorking = aiStatus === 'working' || aiStatus === 'active';
-  const hasSession = !!aiStatus && aiStatus !== 'not_running';
-
-  const readyToAdvance = !prMerged && !isWorking && freshReady;
-  const ralphWaiting = !isWorking && !readyToAdvance && freshWaiting;
-  const isWaiting = aiWaiting || ralphWaiting;
-
-  return {readyToAdvance, isWaiting, isWorking, hasSession};
-}
 
 export function getTrackerCardDisplayState({
   prMerged,
@@ -205,15 +174,6 @@ function computeColumnScroll(selected: number, total: number, visible: number): 
   const max = total - visible;
   const top = selected - Math.floor((visible - 1) / 2);
   return Math.max(0, Math.min(max, top));
-}
-
-// Reads from GitHubContext (keyed by path), not wt.pr — which is never assigned in prod.
-export function isItemPRMerged(
-  worktree: WorktreeInfo | null,
-  pullRequests: Record<string, PRStatus>,
-): boolean {
-  if (!worktree) return false;
-  return pullRequests[worktree.path]?.is_merged === true;
 }
 
 function findSlugPosition(board: TrackerBoard, slug: string): {column: number; row: number} | null {

--- a/src/shared/utils/trackerCardStatus.ts
+++ b/src/shared/utils/trackerCardStatus.ts
@@ -37,7 +37,7 @@ export function computeCardStatusFlags({
   const hasSession = !!aiStatus && aiStatus !== 'not_running';
 
   const readyToAdvance = !prMerged && !isWorking && !aiWaiting && freshReady;
-  const ralphWaiting = !isWorking && !readyToAdvance && freshWaiting;
+  const ralphWaiting = !isWorking && !aiWaiting && !readyToAdvance && freshWaiting;
   const isWaiting = aiWaiting || ralphWaiting;
 
   return {readyToAdvance, isWaiting, isWorking, hasSession};

--- a/src/shared/utils/trackerCardStatus.ts
+++ b/src/shared/utils/trackerCardStatus.ts
@@ -1,0 +1,44 @@
+import type {AIStatus, PRStatus, WorktreeInfo} from '../../models.js';
+
+// Reads from GitHubContext (keyed by path), not wt.pr — which is never assigned in prod.
+export function isItemPRMerged(
+  worktree: WorktreeInfo | null,
+  pullRequests: Record<string, PRStatus>,
+): boolean {
+  if (!worktree) return false;
+  return pullRequests[worktree.path]?.is_merged === true;
+}
+
+// Live tmux AI status takes precedence over file-based status.json signals so
+// a stale `waiting_for_input` / `waiting_for_approval` doesn't paint an
+// actively running agent yellow or green, and a real consent gate
+// (`aiStatus === 'waiting'`) doesn't get hidden behind a stale "ready"
+// state. `freshWaiting` / `freshReady` come from
+// `TrackerService.isItemWaiting` / `isItemReadyToAdvance` (already
+// staleness-filtered).
+export function computeCardStatusFlags({
+  aiStatus,
+  prMerged,
+  freshWaiting,
+  freshReady,
+}: {
+  aiStatus: AIStatus | undefined;
+  prMerged: boolean;
+  freshWaiting: boolean;
+  freshReady: boolean;
+}): {
+  readyToAdvance: boolean;
+  isWaiting: boolean;
+  isWorking: boolean;
+  hasSession: boolean;
+} {
+  const aiWaiting = aiStatus === 'waiting';
+  const isWorking = aiStatus === 'working' || aiStatus === 'active';
+  const hasSession = !!aiStatus && aiStatus !== 'not_running';
+
+  const readyToAdvance = !prMerged && !isWorking && !aiWaiting && freshReady;
+  const ralphWaiting = !isWorking && !readyToAdvance && freshWaiting;
+  const isWaiting = aiWaiting || ralphWaiting;
+
+  return {readyToAdvance, isWaiting, isWorking, hasSession};
+}

--- a/tests/unit/TrackerBoardScreen.test.ts
+++ b/tests/unit/TrackerBoardScreen.test.ts
@@ -1,26 +1,6 @@
 import {describe, expect, test} from '@jest/globals';
 import {computeCardStatusFlags, getTrackerCardDisplayState, isItemPRMerged} from '../../src/screens/TrackerBoardScreen.js';
 import {PRStatus, WorktreeInfo} from '../../src/models.js';
-import {ItemStatus} from '../../src/services/TrackerService.js';
-
-type StubService = Parameters<typeof computeCardStatusFlags>[0]['service'];
-
-function makeFreshStatus(state: ItemStatus['state'], stage: ItemStatus['stage'] = 'requirements'): ItemStatus {
-  return {
-    stage,
-    state,
-    brief_description: 'doing things',
-    timestamp: new Date().toISOString(),
-  };
-}
-
-// Mirrors TrackerService.isItemWaiting / isItemReadyToAdvance without the
-// freshness check so tests stay deterministic — every status passed in is
-// treated as fresh, which is what we want when verifying precedence rules.
-const stubService: StubService = {
-  isItemWaiting: status => !!status && status.state !== 'working',
-  isItemReadyToAdvance: status => !!status && status.state === 'waiting_for_approval',
-};
 
 const baseFlags = {
   prMerged: false,
@@ -246,9 +226,9 @@ describe('computeCardStatusFlags', () => {
   test('live working overrides file-based waiting_for_input (yellow → cyan)', () => {
     const flags = computeCardStatusFlags({
       aiStatus: 'working',
-      itemStatus: makeFreshStatus('waiting_for_input'),
       prMerged: false,
-      service: stubService,
+      freshWaiting: true,
+      freshReady: false,
     });
 
     expect(flags).toEqual({
@@ -262,9 +242,9 @@ describe('computeCardStatusFlags', () => {
   test('live working overrides file-based waiting_for_approval (green → cyan, no [m] hint)', () => {
     const flags = computeCardStatusFlags({
       aiStatus: 'working',
-      itemStatus: makeFreshStatus('waiting_for_approval'),
       prMerged: false,
-      service: stubService,
+      freshWaiting: true,
+      freshReady: true,
     });
 
     expect(flags).toEqual({
@@ -278,9 +258,9 @@ describe('computeCardStatusFlags', () => {
   test('live "active" treated as working and overrides file waiting', () => {
     const flags = computeCardStatusFlags({
       aiStatus: 'active',
-      itemStatus: makeFreshStatus('waiting_for_input'),
       prMerged: false,
-      service: stubService,
+      freshWaiting: true,
+      freshReady: false,
     });
 
     expect(flags.isWorking).toBe(true);
@@ -291,9 +271,9 @@ describe('computeCardStatusFlags', () => {
   test('live "waiting" (consent gate) keeps card yellow regardless of file state', () => {
     const flags = computeCardStatusFlags({
       aiStatus: 'waiting',
-      itemStatus: makeFreshStatus('working'),
       prMerged: false,
-      service: stubService,
+      freshWaiting: false,
+      freshReady: false,
     });
 
     expect(flags).toEqual({
@@ -307,9 +287,9 @@ describe('computeCardStatusFlags', () => {
   test('no session + file waiting_for_input renders yellow', () => {
     const flags = computeCardStatusFlags({
       aiStatus: undefined,
-      itemStatus: makeFreshStatus('waiting_for_input'),
       prMerged: false,
-      service: stubService,
+      freshWaiting: true,
+      freshReady: false,
     });
 
     expect(flags).toEqual({
@@ -323,9 +303,9 @@ describe('computeCardStatusFlags', () => {
   test('no session + file waiting_for_approval renders green ready-to-advance', () => {
     const flags = computeCardStatusFlags({
       aiStatus: undefined,
-      itemStatus: makeFreshStatus('waiting_for_approval'),
       prMerged: false,
-      service: stubService,
+      freshWaiting: true,
+      freshReady: true,
     });
 
     expect(flags).toEqual({
@@ -339,9 +319,9 @@ describe('computeCardStatusFlags', () => {
   test('not_running session reports hasSession=false', () => {
     const flags = computeCardStatusFlags({
       aiStatus: 'not_running',
-      itemStatus: null,
       prMerged: false,
-      service: stubService,
+      freshWaiting: false,
+      freshReady: false,
     });
 
     expect(flags).toEqual({
@@ -355,9 +335,9 @@ describe('computeCardStatusFlags', () => {
   test('prMerged suppresses readyToAdvance even when file says waiting_for_approval', () => {
     const flags = computeCardStatusFlags({
       aiStatus: undefined,
-      itemStatus: makeFreshStatus('waiting_for_approval'),
       prMerged: true,
-      service: stubService,
+      freshWaiting: true,
+      freshReady: true,
     });
 
     expect(flags.readyToAdvance).toBe(false);
@@ -366,9 +346,9 @@ describe('computeCardStatusFlags', () => {
   test('idle session with no item status produces empty flags', () => {
     const flags = computeCardStatusFlags({
       aiStatus: 'idle',
-      itemStatus: null,
       prMerged: false,
-      service: stubService,
+      freshWaiting: false,
+      freshReady: false,
     });
 
     expect(flags).toEqual({

--- a/tests/unit/TrackerBoardScreen.test.ts
+++ b/tests/unit/TrackerBoardScreen.test.ts
@@ -1,6 +1,26 @@
 import {describe, expect, test} from '@jest/globals';
-import {getTrackerCardDisplayState, isItemPRMerged} from '../../src/screens/TrackerBoardScreen.js';
+import {computeCardStatusFlags, getTrackerCardDisplayState, isItemPRMerged} from '../../src/screens/TrackerBoardScreen.js';
 import {PRStatus, WorktreeInfo} from '../../src/models.js';
+import {ItemStatus} from '../../src/services/TrackerService.js';
+
+type StubService = Parameters<typeof computeCardStatusFlags>[0]['service'];
+
+function makeFreshStatus(state: ItemStatus['state'], stage: ItemStatus['stage'] = 'requirements'): ItemStatus {
+  return {
+    stage,
+    state,
+    brief_description: 'doing things',
+    timestamp: new Date().toISOString(),
+  };
+}
+
+// Mirrors TrackerService.isItemWaiting / isItemReadyToAdvance without the
+// freshness check so tests stay deterministic — every status passed in is
+// treated as fresh, which is what we want when verifying precedence rules.
+const stubService: StubService = {
+  isItemWaiting: status => !!status && status.state !== 'working',
+  isItemReadyToAdvance: status => !!status && status.state === 'waiting_for_approval',
+};
 
 const baseFlags = {
   prMerged: false,
@@ -219,5 +239,143 @@ describe('isItemPRMerged', () => {
     const wtWithStrayPr = new WorktreeInfo({...wt});
     (wtWithStrayPr as any).pr = new PRStatus({state: 'MERGED'});
     expect(isItemPRMerged(wtWithStrayPr, {})).toBe(false);
+  });
+});
+
+describe('computeCardStatusFlags', () => {
+  test('live working overrides file-based waiting_for_input (yellow → cyan)', () => {
+    const flags = computeCardStatusFlags({
+      aiStatus: 'working',
+      itemStatus: makeFreshStatus('waiting_for_input'),
+      prMerged: false,
+      service: stubService,
+    });
+
+    expect(flags).toEqual({
+      readyToAdvance: false,
+      isWaiting: false,
+      isWorking: true,
+      hasSession: true,
+    });
+  });
+
+  test('live working overrides file-based waiting_for_approval (green → cyan, no [m] hint)', () => {
+    const flags = computeCardStatusFlags({
+      aiStatus: 'working',
+      itemStatus: makeFreshStatus('waiting_for_approval'),
+      prMerged: false,
+      service: stubService,
+    });
+
+    expect(flags).toEqual({
+      readyToAdvance: false,
+      isWaiting: false,
+      isWorking: true,
+      hasSession: true,
+    });
+  });
+
+  test('live "active" treated as working and overrides file waiting', () => {
+    const flags = computeCardStatusFlags({
+      aiStatus: 'active',
+      itemStatus: makeFreshStatus('waiting_for_input'),
+      prMerged: false,
+      service: stubService,
+    });
+
+    expect(flags.isWorking).toBe(true);
+    expect(flags.isWaiting).toBe(false);
+    expect(flags.readyToAdvance).toBe(false);
+  });
+
+  test('live "waiting" (consent gate) keeps card yellow regardless of file state', () => {
+    const flags = computeCardStatusFlags({
+      aiStatus: 'waiting',
+      itemStatus: makeFreshStatus('working'),
+      prMerged: false,
+      service: stubService,
+    });
+
+    expect(flags).toEqual({
+      readyToAdvance: false,
+      isWaiting: true,
+      isWorking: false,
+      hasSession: true,
+    });
+  });
+
+  test('no session + file waiting_for_input renders yellow', () => {
+    const flags = computeCardStatusFlags({
+      aiStatus: undefined,
+      itemStatus: makeFreshStatus('waiting_for_input'),
+      prMerged: false,
+      service: stubService,
+    });
+
+    expect(flags).toEqual({
+      readyToAdvance: false,
+      isWaiting: true,
+      isWorking: false,
+      hasSession: false,
+    });
+  });
+
+  test('no session + file waiting_for_approval renders green ready-to-advance', () => {
+    const flags = computeCardStatusFlags({
+      aiStatus: undefined,
+      itemStatus: makeFreshStatus('waiting_for_approval'),
+      prMerged: false,
+      service: stubService,
+    });
+
+    expect(flags).toEqual({
+      readyToAdvance: true,
+      isWaiting: false,
+      isWorking: false,
+      hasSession: false,
+    });
+  });
+
+  test('not_running session reports hasSession=false', () => {
+    const flags = computeCardStatusFlags({
+      aiStatus: 'not_running',
+      itemStatus: null,
+      prMerged: false,
+      service: stubService,
+    });
+
+    expect(flags).toEqual({
+      readyToAdvance: false,
+      isWaiting: false,
+      isWorking: false,
+      hasSession: false,
+    });
+  });
+
+  test('prMerged suppresses readyToAdvance even when file says waiting_for_approval', () => {
+    const flags = computeCardStatusFlags({
+      aiStatus: undefined,
+      itemStatus: makeFreshStatus('waiting_for_approval'),
+      prMerged: true,
+      service: stubService,
+    });
+
+    expect(flags.readyToAdvance).toBe(false);
+  });
+
+  test('idle session with no item status produces empty flags', () => {
+    const flags = computeCardStatusFlags({
+      aiStatus: 'idle',
+      itemStatus: null,
+      prMerged: false,
+      service: stubService,
+    });
+
+    expect(flags).toEqual({
+      readyToAdvance: false,
+      isWaiting: false,
+      isWorking: false,
+      hasSession: true,
+    });
   });
 });

--- a/tests/unit/TrackerBoardScreen.test.ts
+++ b/tests/unit/TrackerBoardScreen.test.ts
@@ -1,5 +1,6 @@
 import {describe, expect, test} from '@jest/globals';
-import {computeCardStatusFlags, getTrackerCardDisplayState, isItemPRMerged} from '../../src/screens/TrackerBoardScreen.js';
+import {getTrackerCardDisplayState} from '../../src/screens/TrackerBoardScreen.js';
+import {computeCardStatusFlags, isItemPRMerged} from '../../src/shared/utils/trackerCardStatus.js';
 import {PRStatus, WorktreeInfo} from '../../src/models.js';
 
 const baseFlags = {
@@ -274,6 +275,22 @@ describe('computeCardStatusFlags', () => {
       prMerged: false,
       freshWaiting: false,
       freshReady: false,
+    });
+
+    expect(flags).toEqual({
+      readyToAdvance: false,
+      isWaiting: true,
+      isWorking: false,
+      hasSession: true,
+    });
+  });
+
+  test('live "waiting" beats stale waiting_for_approval — yellow consent gate, not green Ready', () => {
+    const flags = computeCardStatusFlags({
+      aiStatus: 'waiting',
+      prMerged: false,
+      freshWaiting: true,
+      freshReady: true,
     });
 
     expect(flags).toEqual({

--- a/tests/unit/TrackerBoardScreen.test.ts
+++ b/tests/unit/TrackerBoardScreen.test.ts
@@ -333,6 +333,22 @@ describe('computeCardStatusFlags', () => {
     });
   });
 
+  test('readyToAdvance fires on freshReady alone (no freshWaiting required)', () => {
+    const flags = computeCardStatusFlags({
+      aiStatus: undefined,
+      prMerged: false,
+      freshWaiting: false,
+      freshReady: true,
+    });
+
+    expect(flags).toEqual({
+      readyToAdvance: true,
+      isWaiting: false,
+      isWorking: false,
+      hasSession: false,
+    });
+  });
+
   test('not_running session reports hasSession=false', () => {
     const flags = computeCardStatusFlags({
       aiStatus: 'not_running',


### PR DESCRIPTION
## Summary

- A worktree's `tracker/items/<slug>/status.json` lags behind reality whenever the agent forgets to update it on resume. The kanban OR'd `aiStatus === 'waiting'` with the file's `waiting_for_input` / `waiting_for_approval` flags, so an actively running agent kept showing yellow "waiting for you" or green "Ready — …" until the file caught up.
- Extracted `computeCardStatusFlags` as the single source of truth: when live tmux says `working` / `active`, both file-based waiting states are suppressed. Real consent gates (`aiStatus === 'waiting'`) and no-session fallbacks keep their existing colours.
- Routed the title-bar `! N waiting / ⟳ N running` count and the project-switcher counts through the same helper so all three displays agree, with `getItemStatus` results cached once per render.

## Test plan

- [x] `npx tsc -p tsconfig.test.json` clean
- [x] `npx jest tests/unit/TrackerBoardScreen.test.ts` — 24/24 (9 new precedence cases)
- [x] `npx jest tests/unit/` — 562/563 (one unrelated flake in `dialog-navigation-bug.test.ts`, passes on its own)
- [x] `npm run build` clean
- [ ] CI: typecheck + unit + e2e + terminal tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)