### PR TITLE
fix(tracker): hoist itemStatusBySlug memo above early returns

### DIFF
--- a/src/screens/TrackerBoardScreen.tsx
+++ b/src/screens/TrackerBoardScreen.tsx
@@ -627,6 +627,23 @@ export default function TrackerBoardScreen({
     return null;
   })();
 
+  // Read each item's status.json once per worktree refresh and reuse for both
+  // the title-bar tally and the per-card render loop. Memoized on
+  // `[board, worktrees]` so keystroke re-renders don't replay disk reads;
+  // status.json updates land on the next refresh tick, matching the rest of
+  // the kanban's refresh cadence.
+  const itemStatusBySlug = React.useMemo(() => {
+    const map = new Map<string, ReturnType<TrackerService['getItemStatus']>>();
+    for (const col of board.columns) {
+      for (const item of col.items) {
+        map.set(item.slug, service.getItemStatus(projectPath, item.slug));
+      }
+    }
+    return map;
+    // `worktrees` isn't read inside the memo body — it's the refresh tick we
+    // re-run on, since session state changes alongside it.
+  }, [board, worktrees, service, projectPath]);
+
   // When the picker is open, render it full-screen instead of the board. The board
   // fills terminal height with its columns, so anything rendered below gets clipped.
   // discoverProjects does sync filesystem work; cache it across re-renders.
@@ -656,23 +673,6 @@ export default function TrackerBoardScreen({
       </Box>
     );
   }
-
-  // Read each item's status.json once per worktree refresh and reuse for both
-  // the title-bar tally and the per-card render loop. Memoized on
-  // `[board, worktrees]` so keystroke re-renders don't replay disk reads;
-  // status.json updates land on the next refresh tick, matching the rest of
-  // the kanban's refresh cadence.
-  const itemStatusBySlug = React.useMemo(() => {
-    const map = new Map<string, ReturnType<TrackerService['getItemStatus']>>();
-    for (const col of board.columns) {
-      for (const item of col.items) {
-        map.set(item.slug, service.getItemStatus(projectPath, item.slug));
-      }
-    }
-    return map;
-    // `worktrees` isn't read inside the memo body — it's the refresh tick we
-    // re-run on, since session state changes alongside it.
-  }, [board, worktrees, service, projectPath]);
 
   let waitingCount = 0;
   let workingCount = 0;


### PR DESCRIPTION
## Summary

`TrackerBoardScreen` crashed with `Rendered fewer hooks than expected. This may be caused by an accidental early return statement.` whenever the project picker (`pickerMode`) or AI-tool picker (`toolPickPending`) modal opened. The `itemStatusBySlug` `React.useMemo` was declared *after* both early-return guards, so on a render that took an early-return path React saw one fewer hook than on a normal render.

This PR moves the memo above the early returns so the hook order is stable across all render paths. The memo body, deps, and call sites are unchanged.

## Test plan
- [x] `npx tsc -p .` passes
- [ ] Open the project picker (`P`) on the tracker board — no crash; picker renders normally
- [ ] Trigger the AI-tool picker (create a new item with multiple AI tools available) — no crash; tool picker renders
- [ ] Close each picker and confirm the board still renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)