### PR TITLE
fix(sessions): restore resume-or-fresh fallback chain for AI tool launches

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -151,6 +151,12 @@ tests/
 - **Constants**: UPPER_SNAKE_CASE
 - **Interfaces**: PascalCase, often with `Info` or `State` suffix
 
+### Comments
+
+- Default to no comments — well-named identifiers and types should carry the load.
+- When a comment is genuinely warranted (a non-obvious WHY, a hidden constraint, a workaround), prefer a single line. Multi-line comment blocks and multi-paragraph JSDoc are not banned, but should be rare.
+- Don't explain WHAT the code does or restate parameter names; don't reference current task / fix / caller (those belong in PR descriptions and rot in the codebase).
+
 ### Architecture Layers
 
 1. **Service Layer** (Stateless External I/O):

--- a/src/cores/WorktreeCore.ts
+++ b/src/cores/WorktreeCore.ts
@@ -594,39 +594,43 @@ export class WorktreeCore implements CoreBase<State> {
 
   // `freshWorktree=true` (createFeature / recreateImplementWorktree paths) launches
   // claude with no `--continue` flag — there is no prior session to resume.
-  // `freshWorktree=false` (plain attach to an existing worktree) trusts that a
-  // prior session exists and uses the resume form without a fallback chain.
+  // `freshWorktree=false` (plain attach to an existing worktree) tries the resume
+  // form first and falls back to a fresh launch if it exits nonzero. This covers
+  // the common case where the user switches the worktree to claude after running
+  // a different agent — `claude --continue` finds no prior session and exits, so
+  // without the fallback the tmux pane would be left empty.
   private launchClaudeSessionWithFallback(sessionName: string, cwd: string, flagStr: string = '', displayName?: string, initialPrompt?: string, freshWorktree: boolean = false): void {
     const nameFlag = displayName ? ` -n ${shellQuote(displayName)}` : '';
     const promptArg = initialPrompt ? ` ${shellQuote(initialPrompt)}` : '';
+    const freshCmd = 'claude' + nameFlag + flagStr + promptArg;
     const cmd = freshWorktree
-      ? 'claude' + nameFlag + flagStr + promptArg
-      : aiLaunchCommand('claude') + nameFlag + flagStr + promptArg;
+      ? freshCmd
+      : `${aiLaunchCommand('claude') + nameFlag + flagStr + promptArg} || ${freshCmd}`;
     this.tmux.createSessionWithCommand(sessionName, cwd, cmd, true);
   }
 
   // codex / gemini: same shape — `freshWorktree=true` launches fresh,
-  // `freshWorktree=false` launches with the resume form and trusts a prior
-  // session exists in this cwd.
+  // `freshWorktree=false` chains `<resume> || <fresh>` so an empty/missing
+  // saved session falls through to a clean session in the same pane.
   private launchAISessionWithFallback(sessionName: string, cwd: string, tool: AITool, flagStr: string = '', initialPrompt?: string, freshWorktree: boolean = false): void {
     const promptQ = initialPrompt ? shellQuote(initialPrompt) : '';
-    let cmd: string;
-    if (freshWorktree) {
-      if (tool === 'codex') cmd = initialPrompt ? `codex${flagStr} ${promptQ}` : `codex${flagStr}`;
-      else if (tool === 'gemini') cmd = initialPrompt ? `gemini${flagStr} -i ${promptQ}` : `gemini${flagStr}`;
-      else cmd = (AI_TOOLS[tool as Exclude<AITool, 'none'>].command) + flagStr + (initialPrompt ? ` ${promptQ}` : '');
+    let freshCmd: string;
+    let resumeCmd: string;
+    if (tool === 'codex') {
+      freshCmd = initialPrompt ? `codex${flagStr} ${promptQ}` : `codex${flagStr}`;
+      // `codex resume [SESSION_ID] [PROMPT]`; with --last the SESSION_ID slot
+      // is filled, so a trailing positional maps to PROMPT.
+      resumeCmd = initialPrompt ? `codex resume --last${flagStr} ${promptQ}` : `codex resume --last${flagStr}`;
+    } else if (tool === 'gemini') {
+      freshCmd = initialPrompt ? `gemini${flagStr} -i ${promptQ}` : `gemini${flagStr}`;
+      // -i/--prompt-interactive runs the prompt then stays interactive.
+      resumeCmd = initialPrompt ? `gemini --resume latest${flagStr} -i ${promptQ}` : `gemini --resume latest${flagStr}`;
     } else {
-      if (tool === 'codex') {
-        // `codex resume [SESSION_ID] [PROMPT]`; with --last the SESSION_ID slot
-        // is filled, so a trailing positional maps to PROMPT.
-        cmd = initialPrompt ? `codex resume --last${flagStr} ${promptQ}` : `codex resume --last${flagStr}`;
-      } else if (tool === 'gemini') {
-        // -i/--prompt-interactive runs the prompt then stays interactive.
-        cmd = initialPrompt ? `gemini --resume latest${flagStr} -i ${promptQ}` : `gemini --resume latest${flagStr}`;
-      } else {
-        cmd = aiLaunchCommand(tool as Exclude<AITool, 'none'>) + flagStr + (initialPrompt ? ` ${promptQ}` : '');
-      }
+      const base = AI_TOOLS[tool as Exclude<AITool, 'none'>].command;
+      freshCmd = base + flagStr + (initialPrompt ? ` ${promptQ}` : '');
+      resumeCmd = aiLaunchCommand(tool as Exclude<AITool, 'none'>) + flagStr + (initialPrompt ? ` ${promptQ}` : '');
     }
+    const cmd = freshWorktree ? freshCmd : `${resumeCmd} || ${freshCmd}`;
     this.tmux.createSessionWithCommand(sessionName, cwd, cmd, true);
   }
 

--- a/src/cores/WorktreeCore.ts
+++ b/src/cores/WorktreeCore.ts
@@ -5,7 +5,7 @@ import {getProjectsDirectory} from '../config.js';
 import {TmuxService} from '../services/TmuxService.js';
 import {WorkspaceService} from '../services/WorkspaceService.js';
 import {MemoryMonitorService, MemoryStatus} from '../services/MemoryMonitorService.js';
-import {RUN_CONFIG_FILE, DIR_BRANCHES_SUFFIX, TMUX_DISPLAY_TIME, RUN_CONFIG_CLAUDE_PROMPT, SETTINGS_EDIT_CLAUDE_PROMPT, AI_TOOLS, SESSION_PREFIX, type ProjectConfig} from '../constants.js';
+import {RUN_CONFIG_FILE, DIR_BRANCHES_SUFFIX, TMUX_DISPLAY_TIME, RUN_CONFIG_CLAUDE_PROMPT, SETTINGS_EDIT_CLAUDE_PROMPT, SESSION_PREFIX, type ProjectConfig} from '../constants.js';
 import {detectAvailableAITools, runCommandQuick, runClaudeAsync} from '../shared/utils/commandExecutor.js';
 import path from 'node:path';
 import fs from 'node:fs';
@@ -400,8 +400,8 @@ export class WorktreeCore implements CoreBase<State> {
       const flags = this.getAIToolFlags(worktree.project, selectedTool);
       const flagStr = flags.length > 0 ? ' ' + flags.map(shellQuote).join(' ') : '';
       const fresh = !!opts?.freshWorktree;
-      if (selectedTool === 'claude') this.launchClaudeSessionWithFallback(sessionName, worktree.path, flagStr, `${worktree.feature} - ${worktree.project}`, initialPrompt, fresh);
-      else this.launchAISessionWithFallback(sessionName, worktree.path, selectedTool, flagStr, initialPrompt, fresh);
+      const displayName = selectedTool === 'claude' ? `${worktree.feature} - ${worktree.project}` : undefined;
+      this.launchAISessionWithFallback(sessionName, worktree.path, selectedTool, flagStr, initialPrompt, fresh, displayName);
       setLastTool(selectedTool, worktree.path);
     } else {
       this.tmux.createSession(sessionName, worktree.path, true);
@@ -593,42 +593,40 @@ export class WorktreeCore implements CoreBase<State> {
   }
 
   // `freshWorktree=true` (createFeature / recreateImplementWorktree paths) launches
-  // claude with no `--continue` flag — there is no prior session to resume.
+  // the tool fresh — there is no prior session to resume.
   // `freshWorktree=false` (plain attach to an existing worktree) tries the resume
   // form first and falls back to a fresh launch if it exits nonzero. This covers
-  // the common case where the user switches the worktree to claude after running
-  // a different agent — `claude --continue` finds no prior session and exits, so
-  // without the fallback the tmux pane would be left empty.
-  private launchClaudeSessionWithFallback(sessionName: string, cwd: string, flagStr: string = '', displayName?: string, initialPrompt?: string, freshWorktree: boolean = false): void {
-    const nameFlag = displayName ? ` -n ${shellQuote(displayName)}` : '';
-    const promptArg = initialPrompt ? ` ${shellQuote(initialPrompt)}` : '';
-    const freshCmd = 'claude' + nameFlag + flagStr + promptArg;
-    const cmd = freshWorktree
-      ? freshCmd
-      : `${aiLaunchCommand('claude') + nameFlag + flagStr + promptArg} || ${freshCmd}`;
-    this.tmux.createSessionWithCommand(sessionName, cwd, cmd, true);
-  }
-
-  // codex / gemini: same shape — `freshWorktree=true` launches fresh,
-  // `freshWorktree=false` chains `<resume> || <fresh>` so an empty/missing
-  // saved session falls through to a clean session in the same pane.
-  private launchAISessionWithFallback(sessionName: string, cwd: string, tool: AITool, flagStr: string = '', initialPrompt?: string, freshWorktree: boolean = false): void {
+  // the common case where the user switches the worktree to a different tool —
+  // e.g. `claude --continue` on a worktree that previously ran codex finds no
+  // prior session and exits, so without the fallback the tmux pane would be empty.
+  // `displayName` is only honored by claude (its `-n` tmux pane title flag).
+  private launchAISessionWithFallback(
+    sessionName: string,
+    cwd: string,
+    tool: AITool,
+    flagStr: string = '',
+    initialPrompt?: string,
+    freshWorktree: boolean = false,
+    displayName?: string,
+  ): void {
+    if (tool === 'none') return;
     const promptQ = initialPrompt ? shellQuote(initialPrompt) : '';
     let freshCmd: string;
     let resumeCmd: string;
-    if (tool === 'codex') {
-      freshCmd = initialPrompt ? `codex${flagStr} ${promptQ}` : `codex${flagStr}`;
+    if (tool === 'claude') {
+      const nameFlag = displayName ? ` -n ${shellQuote(displayName)}` : '';
+      const promptArg = initialPrompt ? ` ${promptQ}` : '';
+      freshCmd = 'claude' + nameFlag + flagStr + promptArg;
+      resumeCmd = aiLaunchCommand('claude') + nameFlag + flagStr + promptArg;
+    } else if (tool === 'codex') {
       // `codex resume [SESSION_ID] [PROMPT]`; with --last the SESSION_ID slot
       // is filled, so a trailing positional maps to PROMPT.
+      freshCmd = initialPrompt ? `codex${flagStr} ${promptQ}` : `codex${flagStr}`;
       resumeCmd = initialPrompt ? `codex resume --last${flagStr} ${promptQ}` : `codex resume --last${flagStr}`;
-    } else if (tool === 'gemini') {
-      freshCmd = initialPrompt ? `gemini${flagStr} -i ${promptQ}` : `gemini${flagStr}`;
-      // -i/--prompt-interactive runs the prompt then stays interactive.
-      resumeCmd = initialPrompt ? `gemini --resume latest${flagStr} -i ${promptQ}` : `gemini --resume latest${flagStr}`;
     } else {
-      const base = AI_TOOLS[tool as Exclude<AITool, 'none'>].command;
-      freshCmd = base + flagStr + (initialPrompt ? ` ${promptQ}` : '');
-      resumeCmd = aiLaunchCommand(tool as Exclude<AITool, 'none'>) + flagStr + (initialPrompt ? ` ${promptQ}` : '');
+      // gemini: -i/--prompt-interactive runs the prompt then stays interactive.
+      freshCmd = initialPrompt ? `gemini${flagStr} -i ${promptQ}` : `gemini${flagStr}`;
+      resumeCmd = initialPrompt ? `gemini --resume latest${flagStr} -i ${promptQ}` : `gemini --resume latest${flagStr}`;
     }
     const cmd = freshWorktree ? freshCmd : `${resumeCmd} || ${freshCmd}`;
     this.tmux.createSessionWithCommand(sessionName, cwd, cmd, true);

--- a/src/cores/WorktreeCore.ts
+++ b/src/cores/WorktreeCore.ts
@@ -5,7 +5,7 @@ import {getProjectsDirectory} from '../config.js';
 import {TmuxService} from '../services/TmuxService.js';
 import {WorkspaceService} from '../services/WorkspaceService.js';
 import {MemoryMonitorService, MemoryStatus} from '../services/MemoryMonitorService.js';
-import {RUN_CONFIG_FILE, DIR_BRANCHES_SUFFIX, TMUX_DISPLAY_TIME, RUN_CONFIG_CLAUDE_PROMPT, SETTINGS_EDIT_CLAUDE_PROMPT, SESSION_PREFIX, type ProjectConfig} from '../constants.js';
+import {RUN_CONFIG_FILE, DIR_BRANCHES_SUFFIX, TMUX_DISPLAY_TIME, RUN_CONFIG_CLAUDE_PROMPT, SETTINGS_EDIT_CLAUDE_PROMPT, AI_TOOLS, SESSION_PREFIX, type ProjectConfig} from '../constants.js';
 import {detectAvailableAITools, runCommandQuick, runClaudeAsync} from '../shared/utils/commandExecutor.js';
 import path from 'node:path';
 import fs from 'node:fs';
@@ -400,7 +400,7 @@ export class WorktreeCore implements CoreBase<State> {
       const flags = this.getAIToolFlags(worktree.project, selectedTool);
       const flagStr = flags.length > 0 ? ' ' + flags.map(shellQuote).join(' ') : '';
       const fresh = !!opts?.freshWorktree;
-      const displayName = selectedTool === 'claude' ? `${worktree.feature} - ${worktree.project}` : undefined;
+      const displayName = `${worktree.feature} - ${worktree.project}`;
       this.launchAISessionWithFallback(sessionName, worktree.path, selectedTool, flagStr, initialPrompt, fresh, displayName);
       setLastTool(selectedTool, worktree.path);
     } else {
@@ -592,42 +592,31 @@ export class WorktreeCore implements CoreBase<State> {
     for (const name of [s, sh, rn]) { if (active.includes(name)) this.tmux.killSession(name); }
   }
 
-  // `freshWorktree=true` (createFeature / recreateImplementWorktree paths) launches
-  // the tool fresh — there is no prior session to resume.
-  // `freshWorktree=false` (plain attach to an existing worktree) tries the resume
-  // form first and falls back to a fresh launch if it exits nonzero. This covers
-  // the common case where the user switches the worktree to a different tool —
-  // e.g. `claude --continue` on a worktree that previously ran codex finds no
-  // prior session and exits, so without the fallback the tmux pane would be empty.
-  // `displayName` is only honored by claude (its `-n` tmux pane title flag).
+  // Resume-or-fresh chain on existing worktrees: switching the AI tool on a
+  // worktree (e.g. codex → claude) makes the resume form exit with no prior
+  // session, and without the chain the tmux pane would be left empty. The
+  // `freshWorktree=true` callers skip the chain because the worktree was
+  // just created, so there is nothing to resume.
+  // `displayName` is claude-only (its `-n` tmux pane title flag); ignored by
+  // codex/gemini.
   private launchAISessionWithFallback(
     sessionName: string,
     cwd: string,
-    tool: AITool,
+    tool: Exclude<AITool, 'none'>,
     flagStr: string = '',
     initialPrompt?: string,
     freshWorktree: boolean = false,
     displayName?: string,
   ): void {
-    if (tool === 'none') return;
-    const promptQ = initialPrompt ? shellQuote(initialPrompt) : '';
-    let freshCmd: string;
-    let resumeCmd: string;
-    if (tool === 'claude') {
-      const nameFlag = displayName ? ` -n ${shellQuote(displayName)}` : '';
-      const promptArg = initialPrompt ? ` ${promptQ}` : '';
-      freshCmd = 'claude' + nameFlag + flagStr + promptArg;
-      resumeCmd = aiLaunchCommand('claude') + nameFlag + flagStr + promptArg;
-    } else if (tool === 'codex') {
-      // `codex resume [SESSION_ID] [PROMPT]`; with --last the SESSION_ID slot
-      // is filled, so a trailing positional maps to PROMPT.
-      freshCmd = initialPrompt ? `codex${flagStr} ${promptQ}` : `codex${flagStr}`;
-      resumeCmd = initialPrompt ? `codex resume --last${flagStr} ${promptQ}` : `codex resume --last${flagStr}`;
-    } else {
-      // gemini: -i/--prompt-interactive runs the prompt then stays interactive.
-      freshCmd = initialPrompt ? `gemini${flagStr} -i ${promptQ}` : `gemini${flagStr}`;
-      resumeCmd = initialPrompt ? `gemini --resume latest${flagStr} -i ${promptQ}` : `gemini --resume latest${flagStr}`;
-    }
+    const base = AI_TOOLS[tool].command;
+    const resumeBase = aiLaunchCommand(tool);
+    const nameFlag = tool === 'claude' && displayName ? ` -n ${shellQuote(displayName)}` : '';
+    // gemini takes `-i <prompt>` (interactive); claude/codex take a positional.
+    const promptArg = initialPrompt
+      ? (tool === 'gemini' ? ` -i ${shellQuote(initialPrompt)}` : ` ${shellQuote(initialPrompt)}`)
+      : '';
+    const freshCmd = `${base}${nameFlag}${flagStr}${promptArg}`;
+    const resumeCmd = `${resumeBase}${nameFlag}${flagStr}${promptArg}`;
     const cmd = freshWorktree ? freshCmd : `${resumeCmd} || ${freshCmd}`;
     this.tmux.createSessionWithCommand(sessionName, cwd, cmd, true);
   }

--- a/src/services/AIToolService.ts
+++ b/src/services/AIToolService.ts
@@ -175,15 +175,7 @@ export class AIToolService {
     return AI_TOOLS[tool];
   }
 
-  /**
-   * Launch an AI tool in a tmux session.
-   *
-   * Currently unused in production — the live launch path is
-   * `WorktreeCore.launchAISessionWithFallback`, which chains
-   * `<resume> || <fresh>` so a missing/stale on-disk session does not leave
-   * the pane empty. If this method gains a caller again, mirror that chain
-   * here before shipping.
-   */
+  // Unused in src/; the live launch path is WorktreeCore.launchAISessionWithFallback. If wired up again, mirror its `<resume> || <fresh>` chain.
   launchTool(tool: AITool, sessionName: string, cwd: string): void {
     if (tool === 'none') return;
     runCommand(['tmux', 'new-session', '-ds', sessionName, '-c', cwd, aiLaunchCommand(tool)]);

--- a/src/services/AIToolService.ts
+++ b/src/services/AIToolService.ts
@@ -176,7 +176,13 @@ export class AIToolService {
   }
 
   /**
-   * Launch an AI tool in a tmux session
+   * Launch an AI tool in a tmux session.
+   *
+   * Currently unused in production — the live launch path is
+   * `WorktreeCore.launchAISessionWithFallback`, which chains
+   * `<resume> || <fresh>` so a missing/stale on-disk session does not leave
+   * the pane empty. If this method gains a caller again, mirror that chain
+   * here before shipping.
    */
   launchTool(tool: AITool, sessionName: string, cwd: string): void {
     if (tool === 'none') return;

--- a/tests/unit/WorktreeCoreAutoResume.test.ts
+++ b/tests/unit/WorktreeCoreAutoResume.test.ts
@@ -46,14 +46,16 @@ describe('WorktreeCore auto-resume', () => {
     fs.rmSync(tmpDir, {recursive: true, force: true});
   });
 
-  test('attachSession to an existing worktree resumes claude and records lastTool', async () => {
+  test('attachSession to an existing worktree resumes claude with a fresh-launch fallback and records lastTool', async () => {
     const {core, tmux} = buildCore();
     const wt = worktreeFor('proj', 'feat');
 
     await core.attachSession(wt, 'claude');
 
     const sessionName = tmux.sessionName('proj', 'feat');
-    expect(getExecutedCommands(tmux, sessionName)).toEqual([`claude --continue -n 'feat - proj'`]);
+    expect(getExecutedCommands(tmux, sessionName)).toEqual([
+      `claude --continue -n 'feat - proj' || claude -n 'feat - proj'`,
+    ]);
     expect(getLastTool(wt.path)).toBe('claude');
   });
 
@@ -77,7 +79,7 @@ describe('WorktreeCore auto-resume', () => {
     expect(getExecutedCommands(tmux, sessionName)).toEqual(['codex']);
   });
 
-  test('attachSession uses remembered tool when no explicit choice', async () => {
+  test('attachSession uses remembered tool when no explicit choice and chains a fresh-launch fallback', async () => {
     const {core, tmux} = buildCore();
     const wt = worktreeFor('proj', 'feat');
     setLastTool('codex', wt.path);
@@ -85,7 +87,24 @@ describe('WorktreeCore auto-resume', () => {
     await core.attachSession(wt);
 
     const sessionName = tmux.sessionName('proj', 'feat');
-    expect(getExecutedCommands(tmux, sessionName)).toEqual(['codex resume --last']);
+    expect(getExecutedCommands(tmux, sessionName)).toEqual(['codex resume --last || codex']);
+  });
+
+  test('switching to claude on a worktree previously used with codex still chains the fresh-launch fallback', async () => {
+    const {core, tmux} = buildCore();
+    const wt = worktreeFor('proj', 'feat');
+    // Simulate a worktree that was previously running codex.
+    setLastTool('codex', wt.path);
+
+    // Now the user explicitly picks claude — no fresh-worktree flag, since the
+    // worktree directory already exists.
+    await core.attachSession(wt, 'claude');
+
+    const sessionName = tmux.sessionName('proj', 'feat');
+    expect(getExecutedCommands(tmux, sessionName)).toEqual([
+      `claude --continue -n 'feat - proj' || claude -n 'feat - proj'`,
+    ]);
+    expect(getLastTool(wt.path)).toBe('claude');
   });
 
   test('attachSession with existing tmux session does not re-spawn the tool', async () => {

--- a/tracker/items/claude-launch-fallback/implementation.md
+++ b/tracker/items/claude-launch-fallback/implementation.md
@@ -1,0 +1,25 @@
+# Implementation — claude-launch-fallback
+
+## What was built
+
+Restored the resume-or-fresh shell-level fallback chain that commit `ca72a85` (2026-04-26) had dropped. The fix lives entirely in `src/cores/WorktreeCore.ts`:
+
+- `launchClaudeSessionWithFallback` (`src/cores/WorktreeCore.ts:599`): on the non-fresh path the launch command is now `claude --continue <name+flags+prompt> || claude <name+flags+prompt>`. The `freshWorktree=true` path is unchanged (plain `claude` only — no resume to fall back from).
+- `launchAISessionWithFallback`: on the non-fresh path the launch command is now `<resume-form> || <fresh-form>` for codex (`codex resume --last … || codex …`) and gemini (`gemini --resume latest -i … || gemini -i …`). Refactored the body to compute `freshCmd` and `resumeCmd` once instead of re-deriving the same shape twice across the fresh/non-fresh branches.
+
+Both helpers preserve the exact display-name (`-n`), config flag suffix, and initial-prompt argument across the resume and fresh halves of the chain so the user sees identical behavior either way.
+
+## Tests
+
+Updated `tests/unit/WorktreeCoreAutoResume.test.ts`:
+
+- Existing assertions for the non-fresh claude and codex command shapes now expect the `||`-chained command.
+- Added `'switching to claude on a worktree previously used with codex still chains the fresh-launch fallback'` — the agent-switch scenario that motivated this item. Sets `lastTool=codex` on the worktree, then attaches with `aiTool='claude'`, and asserts the launch command is the chained form.
+
+`npm test` (781 tests across 77 suites) and `npx tsc -p tsconfig.test.json` both pass.
+
+## Notes for cleanup
+
+- The function names (`launchClaudeSessionWithFallback`, `launchAISessionWithFallback`) once again match their behavior. No rename needed.
+- `AIToolService.launchTool` (`src/services/AIToolService.ts:181`) still launches `claude --continue` with no fallback. It is unused in production (`grep` shows no callers in `src/`), so it was left untouched. If a future caller wires it back up, the same fallback shape should be applied there.
+- The fallback is intentionally silent — no extra UI/print line — so the user's pane just shows a working AI prompt whether the resume succeeded or not. Matches the original pre-`ca72a85` behavior and the user's preference confirmed during discovery.

--- a/tracker/items/claude-launch-fallback/implementation.md
+++ b/tracker/items/claude-launch-fallback/implementation.md
@@ -2,12 +2,16 @@
 
 ## What was built
 
-Restored the resume-or-fresh shell-level fallback chain that commit `ca72a85` (2026-04-26) had dropped. The fix lives entirely in `src/cores/WorktreeCore.ts`:
+Restored the resume-or-fresh shell-level fallback chain that commit `ca72a85` (2026-04-26) had dropped. The fix lives entirely in `src/cores/WorktreeCore.ts`.
 
-- `launchClaudeSessionWithFallback` (`src/cores/WorktreeCore.ts:599`): on the non-fresh path the launch command is now `claude --continue <name+flags+prompt> || claude <name+flags+prompt>`. The `freshWorktree=true` path is unchanged (plain `claude` only — no resume to fall back from).
-- `launchAISessionWithFallback`: on the non-fresh path the launch command is now `<resume-form> || <fresh-form>` for codex (`codex resume --last … || codex …`) and gemini (`gemini --resume latest -i … || gemini -i …`). Refactored the body to compute `freshCmd` and `resumeCmd` once instead of re-deriving the same shape twice across the fresh/non-fresh branches.
+- Merged `launchClaudeSessionWithFallback` into the unified `launchAISessionWithFallback` helper. The previous split existed only because Claude takes a `-n displayName` flag — that's now an optional trailing parameter on the unified helper, threaded from the call site only when the selected tool is claude.
+- On the non-fresh path the launch command is now `<resume-form> || <fresh-form>` for all three tools:
+  - claude: `claude --continue -n … <flags> [prompt] || claude -n … <flags> [prompt]`
+  - codex: `codex resume --last <flags> [prompt] || codex <flags> [prompt]`
+  - gemini: `gemini --resume latest <flags> -i [prompt] || gemini <flags> -i [prompt]`
+- The `freshWorktree=true` path (createFeature, recreateImplementWorktree) is unchanged: just the fresh form, no chain.
 
-Both helpers preserve the exact display-name (`-n`), config flag suffix, and initial-prompt argument across the resume and fresh halves of the chain so the user sees identical behavior either way.
+Both halves of every chain preserve the exact display-name, config flag suffix, and initial-prompt argument so the user sees identical behavior whether the resume succeeds or the fresh fallback runs.
 
 ## Tests
 
@@ -20,6 +24,10 @@ Updated `tests/unit/WorktreeCoreAutoResume.test.ts`:
 
 ## Notes for cleanup
 
-- The function names (`launchClaudeSessionWithFallback`, `launchAISessionWithFallback`) once again match their behavior. No rename needed.
+- One launch helper now (`launchAISessionWithFallback`) instead of two. The old `launchClaudeSessionWithFallback` was deleted; its only Claude-specific bit (`-n displayName`) became an optional parameter on the unified helper.
 - `AIToolService.launchTool` (`src/services/AIToolService.ts:181`) still launches `claude --continue` with no fallback. It is unused in production (`grep` shows no callers in `src/`), so it was left untouched. If a future caller wires it back up, the same fallback shape should be applied there.
 - The fallback is intentionally silent — no extra UI/print line — so the user's pane just shows a working AI prompt whether the resume succeeded or not. Matches the original pre-`ca72a85` behavior and the user's preference confirmed during discovery.
+
+## Stage review
+
+Implementation matched the requirements one-to-one. After review feedback ("why is this separate from the others?"), the Claude-specific helper was folded into the unified `launchAISessionWithFallback` — the only Claude-specific concern (`-n displayName`) is now an optional trailing parameter, and the call site picks it only for `selectedTool === 'claude'`. Full suite (781 tests) and typecheck pass clean.

--- a/tracker/items/claude-launch-fallback/notes.md
+++ b/tracker/items/claude-launch-fallback/notes.md
@@ -1,0 +1,29 @@
+# Discovery — claude-launch-fallback
+
+## Problem
+
+When devteam attaches to an existing worktree, it launches Claude with `claude --continue` so the prior on-disk session resumes. Sometimes `claude --continue` fails (no resumable session, or claude exits nonzero) and the tmux pane is left empty — the user gets no Claude at all and has to restart manually.
+
+The user reports this happens specifically **when switching which agent is used on a worktree** (e.g. previously used codex → now picking claude). In that case there is no prior claude session to continue from, so `claude --continue` exits and there is no fallback.
+
+## Findings
+
+- The launch site is `WorktreeCore.launchClaudeSessionWithFallback` (`src/cores/WorktreeCore.ts:599`). Despite the name, **it no longer has a fallback**. The current command is just `claude --continue …` with no `||` chain.
+- The fallback was deliberately removed on 2026-04-26 in commit `ca72a85` ("fix(sessions): launch fresh AI in just-created worktrees, drop unused fallback"). That commit also threaded a `freshWorktree` flag from the create-feature paths so newly-created worktrees skip `--continue` entirely (no resume to fall back from).
+- Before `ca72a85`, the launch was `claude --continue … || claude …` — exactly the backup the user is now asking to restore. Codex/Gemini had analogous `resume || fresh` chains and lost theirs in the same commit.
+- The `freshWorktree=true` path (createFeature, recreateImplementWorktree) is a non-issue: it already launches plain `claude` and never uses `--continue`. The regression only affects the `freshWorktree=false` path — the **plain attach-to-existing-worktree** flow, which is also the most common one.
+- The stated reason in `ca72a85` for dropping the chain: "trust that a prior session exists and use the resume form without a fallback chain." The user's report is empirical evidence that this trust is misplaced — `--continue` does still fail in some scenarios on existing worktrees. The most concrete trigger: **agent switch on an existing worktree**. `createSessionIfNeeded` (`src/cores/WorktreeCore.ts:384`) accepts an explicit `aiTool` argument, but the `freshWorktree` flag is only set on the create-worktree paths. If the user previously ran codex on this worktree and now picks claude, `selectedTool='claude'` and `freshWorktree=false` — so the launch is `claude --continue` even though no claude session has ever existed in this cwd.
+- Existing test `tests/unit/WorktreeCoreAutoResume.test.ts:56` asserts the exact non-fresh command shape — restoring the fallback will require updating that expectation (and is a good place to add a test for the fallback chain itself).
+
+## Recommendation
+
+Restore the `||` shell-level fallback for the **non-fresh** Claude launch only:
+
+```
+claude --continue … || claude …
+```
+
+Keep the `freshWorktree=true` path as-is (plain `claude`, no `--continue`). This narrowly reverts the regression without re-introducing the noisy first-launch error that motivated `ca72a85`.
+
+Open question for requirements:
+- Should the same fallback be restored for codex (`resume --last || fresh`) and gemini (`--resume latest || fresh`) on the non-fresh path? The user's report only mentions Claude, but the codex/gemini paths have the identical structural risk and lost their fallback in the same commit.

--- a/tracker/items/claude-launch-fallback/requirements.md
+++ b/tracker/items/claude-launch-fallback/requirements.md
@@ -1,0 +1,24 @@
+# claude-launch-fallback
+
+## Problem
+
+When devteam attaches to an existing worktree, it launches Claude with `claude --continue` so the prior on-disk session resumes. Sometimes `claude --continue` fails (no resumable session, or claude exits nonzero) and the tmux pane is left empty — the user gets no Claude at all and has to restart manually.
+
+The user reports this happens specifically **when switching which agent is used on a worktree** (e.g. previously used codex → now picking claude). In that case there is no prior claude session to continue from, so `claude --continue` exits and there is no fallback.
+
+## Why
+
+A failed AI launch in a tmux session is a dead end for the user — the pane sits empty, devteam thinks the session is fine, and the user has to manually kill and restart. The launch helpers in `WorktreeCore` are still named `launchClaudeSessionWithFallback` / `launchAISessionWithFallback`, and the whole point of those helpers — gracefully recovering when the resume form fails — was lost when commit `ca72a85` (2026-04-26) dropped the `||` chain. Restoring the chain on the non-fresh path is a narrow, well-scoped fix that puts the helpers back in line with their names.
+
+## Summary
+
+Restore the shell-level `resume-or-fresh` fallback for all three AI tools (claude, codex, gemini) on the **non-fresh attach** path in `WorktreeCore`. When `freshWorktree=false`, build the launch command as `<resume-form> || <fresh-form>` so that if the resume form exits nonzero, tmux falls through to a clean fresh session in the same pane. Leave the `freshWorktree=true` path (createFeature, recreateImplementWorktree) untouched — it already launches the fresh form directly and never tries to resume. The fallback runs silently; the user just sees a working AI prompt.
+
+## Acceptance criteria
+
+1. On the non-fresh attach path, `launchClaudeSessionWithFallback` produces a tmux command of the form `claude --continue <name+flags+prompt> || claude <name+flags+prompt>`. The fresh form preserves the same display-name (`-n`), flag suffix, and initial-prompt argument as the resume form.
+2. On the non-fresh attach path, `launchAISessionWithFallback` produces a tmux command of the form `<resume-form> || <fresh-form>` for both codex and gemini, where the resume and fresh forms each preserve the existing prompt-argument shape (`codex resume --last [PROMPT]` vs `codex [PROMPT]`; `gemini --resume latest -i [PROMPT]` vs `gemini -i [PROMPT]`).
+3. On the **fresh** path (`freshWorktree=true`), the launch command is unchanged from today: just the fresh form, no `||` chain.
+4. The agent-switch scenario works: with a worktree that previously ran codex and a tmux session not yet open, calling `attachSession(wt, 'claude')` results in a tmux pane that ends up at an interactive Claude prompt (because `claude --continue` exits and `claude` runs).
+5. Existing test `tests/unit/WorktreeCoreAutoResume.test.ts` is updated so the non-fresh assertions match the new `||`-chained command shape, and a new test covers the agent-switch scenario (previously codex, now claude on the same worktree path → final command includes the `claude … || claude …` chain).
+6. The `npm run build` and `npm test` suites pass.


### PR DESCRIPTION
## Summary

- Restore the `<resume> || <fresh>` shell-level fallback that commit `ca72a85` removed. When the user attaches to an existing worktree, devteam launches the selected AI tool with its resume flag (`claude --continue`, `codex resume --last`, `gemini --resume latest`) — but on tool-switch (e.g. picking claude on a worktree that previously ran codex) the resume form exits with no prior session, leaving the tmux pane empty. The chain falls through to a fresh launch in that case.
- Unify the per-tool launch helpers. Previously there was a separate `launchClaudeSessionWithFallback` and `launchAISessionWithFallback`; the only Claude-specific concern (the `-n displayName` tmux pane title flag) is now an optional parameter on a single helper. The helper is one straight-line build instead of per-tool branching.
- The `freshWorktree=true` callers (`createFeature`, `recreateImplementWorktree`) are unchanged: they still launch the fresh form directly with no chain, since the worktree was just created and there is nothing to resume.

## Test plan

- [x] `npm run build` clean
- [x] `npm test` — 781/781 pass across 77 suites
- [x] `npx tsc -p tsconfig.test.json` clean
- [x] Updated existing `WorktreeCoreAutoResume` assertions to match the chained command shape
- [x] Added regression test: switching to claude on a worktree with `lastTool=codex` produces the chained launch (the originally-reported failure case)
- [ ] Manual: open an existing worktree with claude, observe `claude --continue || claude` runs and lands at a working prompt whether the resume succeeds or not

🤖 Generated with [Claude Code](https://claude.com/claude-code)