### PR TITLE
feat: add support for the pi.dev coding agent

### DIFF
--- a/docs/concepts/status-model.md
+++ b/docs/concepts/status-model.md
@@ -32,7 +32,7 @@ Represents tmux session state. Polled by `TmuxService` every ~2 s for visible ro
   session_name: string;
   attached: boolean;           // someone is currently in this tmux session
   ai_status: 'working' | 'waiting' | 'thinking' | 'idle' | 'none';
-  ai_tool: string;             // 'claude', 'gemini', etc.
+  ai_tool: string;             // 'claude', 'codex', 'gemini', 'pi'
   shell_attached: boolean;
   run_attached: boolean;
 }

--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -24,6 +24,6 @@
 
 **Workspace header** — A synthetic list row in `WorktreeListScreen` that represents a workspace group. Not a real worktree on disk; `is_workspace_header === true`.
 
-**AI tool** — The CLI program used as the AI agent: currently `claude` or `gemini`. Stored in `.devteam/config.json` as `aiTool`.
+**AI tool** — The CLI program used as the AI agent: one of `claude`, `codex`, `gemini`, or `pi`. Stored in `.devteam/config.json` as `aiTool`.
 
 **action_priority** — A computed field on `WorktreeInfo` that ranks worktrees by urgency for display ordering.

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -105,6 +105,19 @@ export const AI_TOOLS = {
       working: 'esc to cancel',
       idle_prompt: ['│ >', '']
     }
+  },
+  pi: {
+    name: 'Pi',
+    command: 'pi',
+    resumeArgs: '--continue',
+    // pi runs as the bare `pi` binary in `ps -o args=` (not `node …`).
+    processPatterns: ['pi'],
+    // pi's working/waiting detection lives in AIToolService.isWorking/isWaitingForTool
+    // (PI_WORKING_RE / PI_WAITING_RE) — its spinner is a braille glyph and its waiting
+    // states are select-dialog UIs that a plain substring can't pin down.
+    statusPatterns: {
+      idle_prompt: ['─']
+    }
   }
 } as const;
 
@@ -314,6 +327,17 @@ export const CONFIG_SCHEMA: Record<string, SchemaNode> = {
           flags: {
             type: 'string[]',
             description: 'Additional CLI flags',
+            example: [],
+          },
+        },
+      },
+      pi: {
+        type: 'object',
+        description: 'Flags for pi CLI',
+        children: {
+          flags: {
+            type: 'string[]',
+            description: 'e.g. ["--thinking", "high"] or ["-e", "<extension>"]',
             example: [],
           },
         },

--- a/src/services/AIToolService.ts
+++ b/src/services/AIToolService.ts
@@ -20,6 +20,9 @@ const PI_WORKING_RE = /^[ \t]*[⠁-⣿][ \t]/m;
 // keystroke. `enter select` / `↑↓ navigate` is the select-dialog footer; an `(N/M)` line
 // is the filterable picker's counter (model selector, command palette).
 const PI_WAITING_RE = /enter\s+select|↑↓\s*navigate|^[ \t]*\(\d+\/\d+\)[ \t]*$/m;
+// The pi-permission-system extension's gate phrasing, which survives even when the
+// select-dialog footer PI_WAITING_RE keys on has scrolled out of the captured window.
+const PI_PERMISSION_RE = /permission required|allow this (?:command|call|external directory access)\b/i;
 
 // Iteration order is load-bearing for the word-boundary fallback below: when args contains
 // multiple tool names, the first hit wins. Object.keys preserves insertion order, so
@@ -182,12 +185,9 @@ export class AIToolService {
 
       case 'pi':
         // PI_WAITING_RE matches pi's select/confirm dialog chrome (used by the model
-        // selector, command palette, and the pi-permission-system extension's gate).
-        // The explicit phrases catch that extension's prompt even on a frame where the
-        // navigation footer has scrolled out of view.
-        return PI_WAITING_RE.test(text) ||
-          lower.includes('permission required') ||
-          /allow this (?:command|call|external directory access)\b/i.test(text);
+        // selector, command palette, and the pi-permission-system extension's gate);
+        // PI_PERMISSION_RE catches that extension's prompt by phrasing.
+        return PI_WAITING_RE.test(text) || PI_PERMISSION_RE.test(text);
 
       default:
         return false;

--- a/src/services/AIToolService.ts
+++ b/src/services/AIToolService.ts
@@ -15,10 +15,8 @@ const CLAUDE_WORKING_RE = /…\s*\(\d+s/;
 // Anchoring on a leading braille glyph (excluding the blank U+2800) avoids matching the
 // literal word "Working" if it appears in transcript text.
 const PI_WORKING_RE = /^[ \t]*[⠁-⣿][ \t]/m;
-// pi has no built-in permission gate, but its interactive select/confirm dialogs — and the
-// pi-permission-system extension's gate, which renders as one — all sit waiting on a
-// keystroke. `enter select` / `↑↓ navigate` is the select-dialog footer; an `(N/M)` line
-// is the filterable picker's counter (model selector, command palette).
+// pi's interactive dialogs all sit waiting on a keystroke: `enter select` / `↑↓ navigate`
+// is the select/confirm-dialog footer; an `(N/M)` line is the filterable picker's counter.
 const PI_WAITING_RE = /enter\s+select|↑↓\s*navigate|^[ \t]*\(\d+\/\d+\)[ \t]*$/m;
 // The pi-permission-system extension's gate phrasing, which survives even when the
 // select-dialog footer PI_WAITING_RE keys on has scrolled out of the captured window.

--- a/src/services/AIToolService.ts
+++ b/src/services/AIToolService.ts
@@ -11,14 +11,28 @@ const CLAUDE_WAITING_RE = /❯\s+\d+\.\s+\w+/m;
 // Note: this assumes the spinner always reports seconds. If Claude ever switches to `(2m 30s`
 // for long-running operations, broaden to `/…\s*\(\d+(s|m)/`.
 const CLAUDE_WORKING_RE = /…\s*\(\d+s/;
+// pi's spinner is a braille glyph at the start of its status line (e.g. `⠙ Working...`).
+// Anchoring on a leading braille glyph (excluding the blank U+2800) avoids matching the
+// literal word "Working" if it appears in transcript text.
+const PI_WORKING_RE = /^[ \t]*[⠁-⣿][ \t]/m;
+// pi has no built-in permission gate, but its interactive select/confirm dialogs — and the
+// pi-permission-system extension's gate, which renders as one — all sit waiting on a
+// keystroke. `enter select` / `↑↓ navigate` is the select-dialog footer; an `(N/M)` line
+// is the filterable picker's counter (model selector, command palette).
+const PI_WAITING_RE = /enter\s+select|↑↓\s*navigate|^[ \t]*\(\d+\/\d+\)[ \t]*$/m;
 
-// Iteration order is load-bearing for the loose fallback below: when args contains
-// substrings of multiple tool names, the first hit wins. Object.keys preserves insertion
-// order, so reordering AI_TOOLS in constants.ts changes that priority silently.
+// Iteration order is load-bearing for the word-boundary fallback below: when args contains
+// multiple tool names, the first hit wins. Object.keys preserves insertion order, so
+// reordering AI_TOOLS in constants.ts changes that priority silently.
 const TOOL_NAMES = Object.keys(AI_TOOLS) as Array<keyof typeof AI_TOOLS>;
 const escapeRe = (s: string) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 const TOOL_TOKEN_RES: Record<keyof typeof AI_TOOLS, RegExp> = Object.fromEntries(
   TOOL_NAMES.map(name => [name, new RegExp(`(?:^|[\\s/])${escapeRe(name)}(?=\\s|$)`)])
+) as Record<keyof typeof AI_TOOLS, RegExp>;
+// Whole-word fallback: looser anchoring than TOOL_TOKEN_RES (also matches across `.`/`-`/`=`)
+// but still bounded, so a short name like `pi` can't match inside `pip`, `compile`, etc.
+const TOOL_WORD_RES: Record<keyof typeof AI_TOOLS, RegExp> = Object.fromEntries(
+  TOOL_NAMES.map(name => [name, new RegExp(`\\b${escapeRe(name)}\\b`)])
 ) as Record<keyof typeof AI_TOOLS, RegExp>;
 
 export class AIToolService {
@@ -90,8 +104,9 @@ export class AIToolService {
   }
 
   // Strict pass first: a tool name inside a prompt, slug, or install path must not
-  // outrank the actually-running binary. Falls back to loose `.includes()` for legacy
-  // invocation shapes the strict pass may not recognize.
+  // outrank the actually-running binary. Falls back to whole-word matching for legacy
+  // invocation shapes the strict pass may not recognize — never a loose substring,
+  // since a short name like `pi` would then mis-tag `pip`, `compile`, etc.
   private detectToolFromArgs(args: string): AITool {
     const argsLower = args.toLowerCase();
     // shellQuote uses single quotes for non-safe args; strip those plus double-quoted spans
@@ -102,7 +117,7 @@ export class AIToolService {
       if (TOOL_TOKEN_RES[tool].test(stripped)) return tool;
     }
     for (const tool of TOOL_NAMES) {
-      if (argsLower.includes(tool)) return tool;
+      if (TOOL_WORD_RES[tool].test(stripped)) return tool;
     }
     return 'none';
   }
@@ -128,6 +143,8 @@ export class AIToolService {
     switch (tool) {
       case 'claude':
         return CLAUDE_WORKING_RE.test(text);
+      case 'pi':
+        return PI_WORKING_RE.test(text);
       case 'codex':
       case 'gemini':
         return text.toLowerCase().includes(AI_TOOLS[tool].statusPatterns.working.toLowerCase());
@@ -162,6 +179,15 @@ export class AIToolService {
           lower.includes('needs permission') ||
           lower.includes('yes, allow') ||
           lower.includes('do you want me to');
+
+      case 'pi':
+        // PI_WAITING_RE matches pi's select/confirm dialog chrome (used by the model
+        // selector, command palette, and the pi-permission-system extension's gate).
+        // The explicit phrases catch that extension's prompt even on a frame where the
+        // navigation footer has scrolled out of view.
+        return PI_WAITING_RE.test(text) ||
+          lower.includes('permission required') ||
+          /allow this (?:command|call|external directory access)\b/i.test(text);
 
       default:
         return false;

--- a/tests/fakes/FakeAIToolService.ts
+++ b/tests/fakes/FakeAIToolService.ts
@@ -12,6 +12,7 @@ export class FakeAIToolService extends AIToolService {
   isAIPaneCommand(command: string): boolean {
     const lower = command.toLowerCase();
     if (lower.includes('claude') || lower.includes('codex') || lower.includes('gemini')) return true;
+    if (/\bpi\b/.test(lower)) return true; // pi runs as the bare `pi` binary
     if (lower.includes('node')) return true; // both codex and gemini use node
     return false;
   }

--- a/tests/fakes/FakeAIToolService.ts
+++ b/tests/fakes/FakeAIToolService.ts
@@ -51,6 +51,11 @@ export class FakeAIToolService extends AIToolService {
       case 'claude':
         if (lowerText.includes('❯') && /\d+\./.test(text)) return 'waiting';
         break;
+      case 'pi':
+        // pi's permission gate; its dialog footer ("enter select") is already
+        // caught by the generic 'select' rule above.
+        if (lowerText.includes('permission required')) return 'waiting';
+        break;
     }
     
     return 'idle';

--- a/tests/fixtures/ai-states/pi/README.md
+++ b/tests/fixtures/ai-states/pi/README.md
@@ -1,0 +1,16 @@
+These pi fixtures drive `tests/unit/ai-tool-detection.test.ts`.
+
+`idle.txt` and `working.txt` are live captures from a bare `pi` session and the
+`capture-ai-states` skill regenerates them directly.
+
+`waiting.txt` needs the **`pi-permission-system`** extension. pi has no built-in
+permission gate — by default it auto-runs bash/edits and never blocks on the
+user. Installing that extension (`pi install pi-permission-system`) makes pi
+gate tool calls behind a select dialog ("Permission Required … Allow this
+command?"), which is pi's real "waiting" state.
+
+To regenerate `waiting.txt`:
+1. `pi install pi-permission-system` (it auto-loads on the next `pi` launch).
+2. Run the `capture-ai-states` skill — the pi/waiting cell will then capture
+   live. Without the extension the skill fails that cell fast with a message
+   pointing back here, and the committed snapshot is used as-is.

--- a/tests/fixtures/ai-states/pi/idle.txt
+++ b/tests/fixtures/ai-states/pi/idle.txt
@@ -1,0 +1,17 @@
+pi
+mserv@userv:/tmp/pi-cap/clean$ pi
+
+ pi v0.74.1
+ escape interrupt · ctrl+c/ctrl+d clear/exit · / commands · ! bash · ctrl+o more
+ Press ctrl+o to show full startup help and loaded resources.
+
+ Pi can explain its own features and look up its docs. Ask it how to use or extend Pi.
+
+
+ Warning: tmux extended-keys is off. Modified Enter keys may not work. Add `set -g extended-keys on` to ~/.tmux.conf and restart tmux.
+
+─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+
+─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+/tmp/pi-cap/clean
+0.0%/128k (auto)                                                                                            (local-model) unsloth/Qwen3.6-35B-A3B-UD-MLX-4bit

--- a/tests/fixtures/ai-states/pi/waiting.txt
+++ b/tests/fixtures/ai-states/pi/waiting.txt
@@ -1,0 +1,37 @@
+
+ pi v0.74.1
+ escape interrupt · ctrl+c/ctrl+d clear/exit · / commands · ! bash · ctrl+o more
+ Press ctrl+o to show full startup help and loaded resources.
+
+ Pi can explain its own features and look up its docs. Ask it how to use or extend Pi.
+
+[Extensions]
+  pi-permission-system
+
+
+ Warning: tmux extended-keys is off. Modified Enter keys may not work. Add `set -g extended-keys on` to ~/.tmux.conf and restart tmux.
+
+
+ Run the bash command: echo hello
+
+
+
+ $ echo hello
+
+
+ ⠏ Working...
+
+─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+
+ Permission Required
+ Current agent requested bash command 'echo hello'. Allow this command?
+
+ → Yes
+   No
+   No, provide reason
+
+ ↑↓ navigate  enter select  escape/ctrl+c cancel
+
+─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+/tmp/pi-cap
+↑2.1k ↓27 1.6%/128k (auto)                                                                                  (local-model) unsloth/Qwen3.6-35B-A3B-UD-MLX-4bit

--- a/tests/fixtures/ai-states/pi/working.txt
+++ b/tests/fixtures/ai-states/pi/working.txt
@@ -1,0 +1,77 @@
+pi
+mserv@userv:/tmp/pi-cap/clean$ pi
+
+ pi v0.74.1
+ escape interrupt · ctrl+c/ctrl+d clear/exit · / commands · ! bash · ctrl+o more
+ Press ctrl+o to show full startup help and loaded resources.
+
+ Pi can explain its own features and look up its docs. Ask it how to use or extend Pi.
+
+
+ Warning: tmux extended-keys is off. Modified Enter keys may not work. Add `set -g extended-keys on` to ~/.tmux.conf and restart tmux.
+
+
+ Count from 1 to 80, one number per line.
+
+
+ 1
+ 2
+ 3
+ 4
+ 5
+ 6
+ 7
+ 8
+ 9
+ 10
+ 11
+ 12
+ 13
+ 14
+ 15
+ 16
+ 17
+ 18
+ 19
+ 20
+ 21
+ 22
+ 23
+ 24
+ 25
+ 26
+ 27
+ 28
+ 29
+ 30
+ 31
+ 32
+ 33
+ 34
+ 35
+ 36
+ 37
+ 38
+ 39
+ 40
+ 41
+ 42
+ 43
+ 44
+ 45
+ 46
+ 47
+ 48
+ 49
+ 50
+ 51
+ 52
+ 5
+
+ ⠙ Working...
+
+─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+
+─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+/tmp/pi-cap/clean
+0.0%/128k (auto)                                                                                            (local-model) unsloth/Qwen3.6-35B-A3B-UD-MLX-4bit

--- a/tests/unit/AIToolService.test.ts
+++ b/tests/unit/AIToolService.test.ts
@@ -25,6 +25,7 @@ describe('AIToolService', () => {
       expect(aiToolService.isAIPaneCommand('claude')).toBe(true);
       expect(aiToolService.isAIPaneCommand('/usr/bin/claude')).toBe(true);
       expect(aiToolService.isAIPaneCommand('CLAUDE')).toBe(true);
+      expect(aiToolService.isAIPaneCommand('pi --continue')).toBe(true);
     });
 
     test('returns true for node-based tools', () => {

--- a/tests/unit/AIToolService.test.ts
+++ b/tests/unit/AIToolService.test.ts
@@ -104,9 +104,16 @@ random-session:33333`);
         ['case-insensitive: uppercase path codex', '/USR/BIN/CODEX', 'codex'],
         ['non-tool: bash', 'bash', 'none'],
         ['non-tool: vim', 'vim', 'none'],
-        // Loose fallback path: no token boundary present, but the substring still resolves
-        // the way it did before strict matching was introduced.
-        ['legacy embedded substring', 'someweirdtoolnameclaudethingembedded', 'claude'],
+        // Word-boundary fallback: a tool name embedded mid-word (no boundary) no longer
+        // resolves — substring matching was dropped so short names stay unambiguous.
+        ['embedded substring does not match', 'someweirdtoolnameclaudethingembedded', 'none'],
+        // pi is a 2-char name; it must not match inside longer words/paths.
+        ['pi: bare binary', 'pi', 'pi'],
+        ['pi: with resume flag', 'pi --continue', 'pi'],
+        ['pi: install path', 'node /home/user/.nvm/versions/node/v24.7.0/bin/pi', 'pi'],
+        ['pi: not matched inside pip', 'pip install requests', 'none'],
+        ['pi: not matched inside a path word', 'node /usr/lib/compile-cache/run.js', 'none'],
+        ['pi: claude in quoted prompt stays pi', `bash -c pi --continue 'fix the claude bug' || pi 'fix the claude bug'`, 'pi'],
       ];
 
       for (const [name, argsLine, expected] of cases) {
@@ -199,6 +206,33 @@ random-session:33333`);
       });
     });
 
+    describe('Pi status detection', () => {
+      test('detects working state (braille spinner)', () => {
+        const workingText = ' 1\n 2\n\n ⠙ Working...';
+        expect(aiToolService.getStatusForTool(workingText, 'pi')).toBe('working');
+      });
+
+      test('detects waiting state (select-dialog footer)', () => {
+        const waitingText = ' → Yes\n   No\n\n ↑↓ navigate  enter select  escape/ctrl+c cancel';
+        expect(aiToolService.getStatusForTool(waitingText, 'pi')).toBe('waiting');
+      });
+
+      test('detects waiting state (permission-system extension prompt)', () => {
+        const waitingText = " Permission Required\n Current agent requested bash command 'echo hi'. Allow this command?";
+        expect(aiToolService.getStatusForTool(waitingText, 'pi')).toBe('waiting');
+      });
+
+      test('permission picker on screen wins over the working spinner', () => {
+        const mixed = ' ⠏ Working...\n\n Permission Required\n Allow this call?\n\n ↑↓ navigate  enter select';
+        expect(aiToolService.getStatusForTool(mixed, 'pi')).toBe('waiting');
+      });
+
+      test('detects idle state as default', () => {
+        const idleText = ' pi v0.74.1\n escape interrupt · / commands\n\n 0.0%/128k (auto)';
+        expect(aiToolService.getStatusForTool(idleText, 'pi')).toBe('idle');
+      });
+    });
+
     test('returns not_running for none tool', () => {
       expect(aiToolService.getStatusForTool('any text', 'none')).toBe('not_running');
     });
@@ -210,6 +244,7 @@ random-session:33333`);
       expect(tools).toContain('claude');
       expect(tools).toContain('codex');
       expect(tools).toContain('gemini');
+      expect(tools).toContain('pi');
       expect(tools.length).toBe(Object.keys(AI_TOOLS).length);
     });
 
@@ -217,6 +252,7 @@ random-session:33333`);
       expect(aiToolService.getToolName('claude')).toBe('Claude');
       expect(aiToolService.getToolName('codex')).toBe('OpenAI Codex');
       expect(aiToolService.getToolName('gemini')).toBe('Gemini');
+      expect(aiToolService.getToolName('pi')).toBe('Pi');
       expect(aiToolService.getToolName('none')).toBe('None');
     });
 

--- a/tests/unit/ai-tool-detection.test.ts
+++ b/tests/unit/ai-tool-detection.test.ts
@@ -4,7 +4,7 @@ import {AIToolService} from '../../src/services/AIToolService.js';
 import {AITool, AIStatus} from '../../src/models.js';
 
 const FIXTURES_ROOT = join(process.cwd(), 'tests/fixtures/ai-states');
-const TOOLS: AITool[] = ['claude', 'codex', 'gemini'];
+const TOOLS: AITool[] = ['claude', 'codex', 'gemini', 'pi'];
 const STATES: AIStatus[] = ['idle', 'working', 'waiting'];
 
 function loadFixture(tool: AITool, state: AIStatus): string | null {

--- a/tracker/items/pi-dev-agent-support/implementation.md
+++ b/tracker/items/pi-dev-agent-support/implementation.md
@@ -85,3 +85,12 @@ token pass is unchanged; the fallback is now bounded.
   `.claude/`); nothing to review there in the diff.
 - `pi`'s waiting fixture depends on the `pi-permission-system` extension being
   installed to regenerate — documented in the fixtures README.
+
+## Stage review
+
+Added pi as a fully data-driven fourth AI tool — the only non-mechanical work
+was capturing real pi terminal output for detection patterns and replacing the
+unsafe substring fallback in `detectToolFromArgs` with whole-word matching.
+Discovered pi has no built-in permission gate, so the "waiting" state is
+detected from pi's select dialogs plus the optional `pi-permission-system`
+extension. typecheck/test (815)/build all green; verified end-to-end.

--- a/tracker/items/pi-dev-agent-support/implementation.md
+++ b/tracker/items/pi-dev-agent-support/implementation.md
@@ -1,0 +1,87 @@
+# Implementation — add support for pi.dev agent
+
+## What was built
+
+Registered the `pi` coding agent (pi.dev, binary `pi`, npm
+`@earendil-works/pi-coding-agent`) as a fourth first-class AI tool in devteam.
+
+### Tool registration (`src/constants.ts`)
+
+- New `AI_TOOLS.pi` entry: `name: 'Pi'`, `command: 'pi'`,
+  `resumeArgs: '--continue'`, `processPatterns: ['pi']`, `statusPatterns`
+  (vestigial `idle_prompt` only — pi's real detection is regex-based, like
+  claude). The `AITool` type, `getAvailableTools`, `detectAvailableAITools`,
+  and the `AIToolDialog` picker are all data-driven off `AI_TOOLS` keys, so pi
+  appears in the picker and is launchable with no further wiring.
+- New `CONFIG_SCHEMA.aiToolSettings.pi` block with a `flags` field, so
+  per-project launch flags work for pi like the other tools.
+
+### Status detection (`src/services/AIToolService.ts`)
+
+- `PI_WORKING_RE` — matches pi's spinner: a braille glyph at the start of its
+  status line (`⠙ Working...`). Excludes U+2800 (blank) so the literal word
+  "Working" in transcript text can't false-match.
+- `PI_WAITING_RE` — matches pi's select/confirm dialog chrome (`enter select`,
+  `↑↓ navigate`, and the standalone `(N/M)` counter line of the filterable
+  picker). `isWaitingForTool` also checks the `pi-permission-system` extension's
+  phrases (`Permission Required`, `Allow this command/call?`).
+- Explicit `case 'pi'` added to both `isWorking` and `isWaitingForTool` — they
+  switch on tool and the `default` branch reports permanent-idle / never-waiting.
+
+### Detection hardening (`detectToolFromArgs`)
+
+The loose `argsLower.includes(tool)` fallback was replaced with whole-word
+matching (`TOOL_WORD_RES`, `\bname\b`). A 2-char name like `pi` would otherwise
+mis-tag `pip`, `compile`, or any path/word merely containing `pi`. The strict
+token pass is unchanged; the fallback is now bounded.
+
+### Key decisions
+
+- **pi has no built-in permission gate** — by default it auto-runs bash/edits
+  and never blocks on the user. Its only agent-blocked "waiting" state comes
+  from the third-party `pi-permission-system` extension, which renders as a
+  standard pi `select` dialog. Per the user's call, detection covers both pi's
+  native interactive dialogs (model selector, command palette, confirm) **and**
+  that extension's permission prompt.
+- **`resumeArgs: '--continue'`** — verified `pi --continue` starts fresh and
+  exits 0 when there's no prior session, so the `pi --continue || pi` chain in
+  `launchAISessionWithFallback` works (the `|| pi` simply never needs to fire).
+- pi launches as the bare `pi` binary in `ps -o args=` (not `node …`), so
+  `processPatterns` is `['pi']`.
+
+### Fixtures, tests, capture tooling
+
+- `tests/fixtures/ai-states/pi/{idle,working,waiting}.txt` — real captures from
+  pi v0.74.1 (idle/working from a bare `pi`; waiting via the
+  `pi-permission-system` extension). `README.md` explains regeneration.
+- `tests/unit/ai-tool-detection.test.ts` — `pi` added to the fixture-driven
+  matrix.
+- `tests/unit/AIToolService.test.ts` — new "Pi status detection" block; the
+  detect-from-args cases updated for whole-word matching (an embedded substring
+  no longer resolves) plus pi-specific cases (`pip`, `compile` → `none`).
+- `tests/fakes/FakeAIToolService.ts` — `isAIPaneCommand` recognises `pi`.
+- The `capture-ai-states` skill (`.claude/skills/capture-ai-states/`) gained a
+  `pi` entry in `capture.mjs` and SKILL.md. **Note:** this skill is local-only
+  tooling — `.claude/` is gitignored, so that change is not in the commit; it
+  lives on disk where the skill runs.
+
+### Docs
+
+- `docs/reference/glossary.md` and `docs/concepts/status-model.md` now list
+  `pi` alongside the other AI tools.
+
+## Verification
+
+- `npm run typecheck` — passes.
+- `npm test` — 815/815 pass.
+- `npm run build` — passes.
+- End-to-end: launched pi via the real `createSessionWithCommand` path
+  (`bash -c pi --continue || pi`); `detectAllSessionAITools` tagged the session
+  `pi` and `getStatusForTool` returned `idle`.
+
+## Notes for cleanup
+
+- The `capture-ai-states` skill edits are not version-controlled (gitignored
+  `.claude/`); nothing to review there in the diff.
+- `pi`'s waiting fixture depends on the `pi-permission-system` extension being
+  installed to regenerate — documented in the fixtures README.

--- a/tracker/items/pi-dev-agent-support/notes.md
+++ b/tracker/items/pi-dev-agent-support/notes.md
@@ -1,0 +1,80 @@
+# Discovery — add support for pi.dev agent
+
+## Problem
+
+devteam supports three AI coding agent CLIs (`claude`, `codex`, `gemini`). The
+"pi" coding agent from pi.dev is a fourth terminal coding agent users want to run
+inside devteam worktrees. It is not currently selectable, launchable, or
+status-detected.
+
+## Why
+
+pi is a minimal, token-efficient terminal coding harness (AGENTS.md + skills
+support). Users who prefer it currently can't drive it through devteam's
+worktree/session/kanban workflow at all — they'd have to launch it manually
+outside the tool, losing AI-status detection on the board.
+
+## Findings
+
+### What pi is
+
+- CLI binary: **`pi`**. npm package `@earendil-works/pi-coding-agent`
+  (also installable via curl/bun). Repo: `github.com/badlogic/pi-mono`,
+  `packages/coding-agent`.
+- Interactive launch: bare `pi`.
+- Resume: **`-c` / `--continue`** = "continue most recent session"
+  (`-r`/`--resume` opens an interactive picker). `--continue` mirrors Claude's
+  resume flag exactly and fits devteam's `resumeArgs` + fresh-fallback model.
+- TUI: startup header, message log, an editor input box, and a footer line
+  (cwd, session name, token/cost/context, model). Editor border colour signals
+  thinking level.
+
+### Integration surface in this repo
+
+Adding a tool means touching, at minimum:
+
+- `src/constants.ts` — new `AI_TOOLS.pi` entry (`command`, `resumeArgs`,
+  `processPatterns`, `statusPatterns`) and a `CONFIG_SCHEMA.aiToolSettings.pi`
+  block so per-project launch flags work.
+- `src/services/AIToolService.ts` — `isWorking` and `isWaitingForTool` both
+  `switch` on tool and need an explicit `case 'pi'` (the `default` branches
+  silently report permanent-idle / never-waiting).
+- `tests/fixtures/ai-states/pi/{idle,working,waiting}.txt` + the
+  `capture-ai-states` skill (currently claude/codex/gemini only).
+- Fakes (`FakeAIToolService` etc.) and the AI-tool test suite.
+- Docs: `docs/reference/glossary.md` ("currently `claude` or `gemini`") and
+  `docs/concepts/status-model.md`.
+
+`AITool` type, `getAvailableTools`, and the `AIToolDialog` picker are all
+data-driven off `AI_TOOLS` keys — no change needed there.
+
+### Notable risk 1 — detection patterns are unknown
+
+pi's docs do **not** specify the on-screen text for idle / working / waiting
+states. Detection relies on literal pane-text patterns (`statusPatterns`,
+`isWorking`, `isWaitingForTool`). These cannot be written reliably from docs —
+they need a real `pi` session captured via the `capture-ai-states` skill. If pi
+isn't installed locally, fixtures/patterns will be guesses and status on the
+kanban will be wrong.
+
+### Notable risk 2 — `pi` is a 2-char substring
+
+`detectToolFromArgs` runs a strict anchored token regex (`(?:^|[\s/])pi(?=\s|$)`,
+safe) **then** a loose `argsLower.includes(tool)` fallback. With `tool === 'pi'`
+the loose pass false-matches common process args (`pip`, `compile`, install
+paths containing `pi`, etc.), and `TOOL_NAMES` iteration order is explicitly
+"first hit wins". The loose fallback must be dropped or guarded for `pi`, or
+detection will mis-tag unrelated panes.
+
+## Recommendation
+
+Proceed. The change follows the established codex/gemini pattern and is mostly
+mechanical. Two things must be resolved during implementation:
+
+1. **Capture real pi terminal states** (idle/working/waiting) with the
+   `capture-ai-states` skill before writing `statusPatterns` — do not guess.
+2. **Harden `detectToolFromArgs`** so the loose `.includes` fallback can't
+   mis-tag panes as `pi`; prefer strict token matching only for short names.
+
+`resumeArgs` = `--continue`; `processPatterns` likely `['node']` (npm install)
+or `['pi']` — confirm against the captured process args.

--- a/tracker/items/pi-dev-agent-support/requirements.md
+++ b/tracker/items/pi-dev-agent-support/requirements.md
@@ -1,0 +1,87 @@
+# Requirements — add support for pi.dev agent
+
+## Problem
+
+devteam supports three AI coding agent CLIs (`claude`, `codex`, `gemini`). The
+"pi" coding agent from pi.dev is a fourth terminal coding agent users want to run
+inside devteam worktrees. It is not currently selectable, launchable, or
+status-detected.
+
+## Why
+
+pi is a minimal, token-efficient terminal coding harness (AGENTS.md + skills
+support). Users who prefer it currently can't drive it through devteam's
+worktree/session/kanban workflow at all — they'd have to launch it manually
+outside the tool, losing AI-status detection on the board.
+
+## Summary
+
+Register the `pi` coding agent (binary `pi`, npm `@earendil-works/pi-coding-agent`)
+as a first-class AI tool in devteam, following the existing codex/gemini pattern:
+add it to `AI_TOOLS` and the project config schema, give it status-detection rules
+for idle/working/waiting, and cover it with fixtures and tests. As part of this,
+harden `AIToolService.detectToolFromArgs` so the short two-character name `pi`
+cannot false-match unrelated process arguments — replace the loose substring
+fallback with whole-word/token matching.
+
+## Acceptance criteria
+
+### Tool registration & launch
+
+1. `AI_TOOLS` in `src/constants.ts` gains a `pi` entry with `name` (`"Pi"`),
+   `command` (`"pi"`), `resumeArgs` (`"--continue"`), `processPatterns`, and
+   `statusPatterns`. The `AITool` type, `getAvailableTools`, and the
+   `AIToolDialog` picker pick `pi` up automatically with no further change.
+2. `pi` is launchable from the AI-tool picker and via the `[T]` "different tool"
+   flow; launching resumes the most recent session (`pi --continue`) and falls
+   back to a fresh `pi` session when there is nothing to resume, matching the
+   existing `launchAISessionWithFallback` behaviour.
+3. `CONFIG_SCHEMA.aiToolSettings` in `src/constants.ts` gains a `pi` block with a
+   `flags` `string[]` field, so per-project launch flags work for `pi` the same
+   way they do for `claude`/`codex`/`gemini`.
+
+### Status detection
+
+4. `AIToolService.isWorking` has an explicit `case 'pi'` that detects pi's
+   working/busy state from real pane text — it must not fall through to the
+   `default` branch (which reports permanent idle).
+5. `AIToolService.isWaitingForTool` has an explicit `case 'pi'` that detects
+   pi's user-actionable prompts (permission/consent/picker), consistent with the
+   project rule that any prompt needing a user keystroke counts as "waiting".
+6. The idle/working/waiting `statusPatterns` and detection rules for `pi` are
+   derived from a real captured `pi` session, not guessed from documentation.
+   `processPatterns` is set to whatever the captured process args actually show.
+
+### Detection hardening (short-name safety)
+
+7. `AIToolService.detectToolFromArgs` no longer mis-tags panes as `pi`: the loose
+   `argsLower.includes(tool)` fallback is replaced with whole-word/token matching
+   so common args (`pip`, `compile`, paths or words merely containing `pi`) do
+   not match the `pi` tool. Detection of `claude`/`codex`/`gemini` is unchanged.
+8. A unit test asserts that process args containing `pi` as a substring but not
+   as a whole word (e.g. `pip install`, a path with `compile`) resolve to `none`
+   (or the correct tool), while a genuine `pi`/`pi --continue` invocation
+   resolves to `pi`.
+
+### Fixtures, tests & capture tooling
+
+9. `tests/fixtures/ai-states/pi/{idle,working,waiting}.txt` exist and reflect
+   real `pi` terminal output. If `pi` cannot be captured live, the fixtures are
+   curated realistic snapshots with a `README.md` explaining this, matching the
+   existing `gemini` fixtures convention.
+10. `tests/unit/ai-tool-detection.test.ts` covers `pi` for idle, working, and
+    waiting states, and `FakeAIToolService` (and any other fakes enumerating
+    tools) handle `pi` without error.
+11. The `capture-ai-states` skill is extended to include `pi` in its tool matrix
+    (skill description, `argument-hint`, and `capture.mjs`), so detector fixtures
+    for `pi` can be regenerated like the other tools.
+
+### Documentation
+
+12. `docs/reference/glossary.md` and `docs/concepts/status-model.md` are updated
+    to list `pi` alongside the other supported AI tools.
+
+### Verification
+
+13. `npm run typecheck`, `npm test`, and `npm run build` all pass with the new
+    tool wired in.


### PR DESCRIPTION
## Summary

Registers `pi` (the [pi.dev](https://pi.dev) coding agent, binary `pi`, npm `@earendil-works/pi-coding-agent`) as a fourth first-class AI tool alongside claude/codex/gemini.

- **Tool registration** — new `AI_TOOLS.pi` entry (`--continue` resume, `processPatterns: ['pi']`) and a `CONFIG_SCHEMA.aiToolSettings.pi` flags block. The `AITool` type, availability detection, picker, and launch path are all data-driven off `AI_TOOLS`, so pi is selectable and launchable with no further wiring.
- **Status detection** — `PI_WORKING_RE` (braille spinner) and `PI_WAITING_RE` / `PI_PERMISSION_RE` (pi's select/confirm dialog chrome plus the `pi-permission-system` extension's gate), with explicit `case 'pi'` in `isWorking`/`isWaitingForTool`. Patterns derived from real captured pi v0.74.1 output, not docs.
- **Detection hardening** — `detectToolFromArgs`'s loose `.includes()` fallback is replaced with whole-word matching, so the 2-char name `pi` can't mis-tag `pip`, `compile`, or paths merely containing `pi`.
- **Fixtures / tests / docs** — real captured `tests/fixtures/ai-states/pi/*` fixtures, detection-test coverage, the `capture-ai-states` skill extended for pi, and glossary/status-model docs updated.

## Notes

- pi has no built-in permission gate (it auto-runs bash/edits by default); its only agent-blocked "waiting" state comes from the optional `pi-permission-system` extension, which renders as a standard pi select dialog. Detection covers both pi's native interactive dialogs and that extension's prompt.

## Verification

`npm run typecheck`, `npm test` (815/815), `npm run build` all pass. Verified end-to-end: launched pi via the real `bash -c pi --continue || pi` path and confirmed `detectAllSessionAITools` tags the session `pi`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)